### PR TITLE
Issue #8: Update default pod definition to specify resources

### DIFF
--- a/openshift_scalability/content/pod-default.json
+++ b/openshift_scalability/content/pod-default.json
@@ -20,6 +20,14 @@
           }
         ],
         "resources": {
+				"requests": {
+					"cpu" : "50m",
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu" : "400m",
+					"memory": "400Mi"
+				}
         },
         "terminationMessagePath": "/dev/termination-log",
         "imagePullPolicy": "IfNotPresent",

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -32,7 +32,7 @@ def oc_command(args, globalvars):
     return ret
 
 def login(user,passwd,master):
-    return subprocess.check_output("oc login -u " + user + " -p " + passwd + " " + master,shell=True)
+    return subprocess.check_output("oc login --insecure-skip-tls-verify=true -u " + user + " -p " + passwd + " " + master,shell=True)
 
 
 def create_template(templatefile, num, parameters, globalvars):


### PR DESCRIPTION
1. Add requests to the default pod definition - this will allow the sample pyconfig.yaml to work properly for pod creation since it specifies a quota.  

2. small change to login to tolerate self-signed certs