### PR TITLE
Update node vertical test to use pause pods

### DIFF
--- a/openshift_scalability/config/nodeVertical.yaml
+++ b/openshift_scalability/config/nodeVertical.yaml
@@ -2,18 +2,12 @@ projects:
   - num: 1
     basename: clusterproject
     tuning: default
-    users:
-      - num: 1
-        role: admin
-        basename: demo
-        password: demo
-        userpassfile: /etc/origin/openshift-passwd
     pods:
-      - total: 240
+      - total: 500
       - num: 100
-        image: openshift/hello-openshift
-        basename: hellopods
-        file: default
+        image: gcr.io/google_containers/pause-amd64:3.0
+        basename: pausepods
+        file: content/pod-pause.json
         storage:
           - type: none
           

--- a/openshift_scalability/content/pod-pause.json
+++ b/openshift_scalability/content/pod-pause.json
@@ -1,0 +1,37 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "pause-amd64",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "pause-amd64"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "pause-amd64",
+        "image": "gcr.io/google_containers/pause-amd64:3.0",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}
+


### PR DESCRIPTION
The node vertical test currently uses the hello-openshift pod.   While smaller than some pods, it is still too large for a test which has a goal of solely measuring pod overhead.   The gcr.io/google_containers/pause-amd64:3.0  pd is pretty much the smallest possible shim pod available.  Update the nodeVertical test case to use this pod.

Also, for 3.3, update the number of pods created across 2 nodes to 500.