### PR TITLE
only specify openshift version in one place

### DIFF
--- a/image_provisioner/inventory/inventory
+++ b/image_provisioner/inventory/inventory
@@ -9,7 +9,8 @@ graphite_host=
 graphite_prefix=ose
 collectd_interval=10
 collectd_status=started
-openshift_version=3.3.0.8
+# set openshift_version to the rpm version, sometimes with a trailing -N
+openshift_version=3.3.0.11-1
 # vda1 for openstack. Only necessary for image resize for RHEL cloud image.
 #root_partition=/dev/vda1
 ## vda2 for openstack sdb for ec2
@@ -20,8 +21,9 @@ github_token=
 config_repo=svt-private
 aos_ansible_path=/root/aos-ansible
 aos_ansible_inventory=/root/aos-ansible/inventory/hosts   
-aos_repo=
-version=v3.3.0.8
+puddle_url=
+# this is the version of the images.  never has the trailing -N like the RPMs might
+image_version=v3.3.0.11
 qe_repo_image_type=ose
 rhel_repo_hostname=
 pbench_internal_hostname=

--- a/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
+++ b/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
@@ -4,7 +4,7 @@ masters
 [OSEv3:vars]
 qe_openshift_kerberos_user=user@domain.com
 ansible_ssh_user=root
-aos_repo=https://mirror.openshift.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os
+aos_repo={{ puddle_url }}
 #prerelease_rhel7_repo_enable=False (Optional, True by default)
 
 # You can specify the docker images versions to pull. To skip image pull,
@@ -15,7 +15,7 @@ aos_repo=https://mirror.openshift.com/enterprise/enterprise-3.3/latest/RH7-RHAOS
 #qe_repo_aep_image_prepull=False (Optional, False by default)
 #qe_repo_image_versions=v3.1.1.6
 #qe_repo_image_versions=v3.1.1.900
-#qe_repo_image_versions=v3.3.0.5
+qe_repo_image_versions={{ image_version }}
 docker_login=no
 
 [masters]

--- a/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
@@ -1,6 +1,15 @@
 ---
 - name: install openshift packages
   yum: name={{ item }} state=latest
-# master package drags in everything else
   with_items:
     - atomic-openshift-master
+    - atomic-openshift-sdn-ovs
+    - atomic-openshift-tests
+    - atomic-openshift-node
+    - atomic-openshift-pod
+    - atomic-openshift-utils
+    - atomic-openshift-clients
+    - atomic-openshift-clients-redistributable
+    - atomic-openshift-dockerregistry
+    - tuned-profiles-atomic
+    - tuned-profiles-atomic-openshift-node


### PR DESCRIPTION
Feed openshift_version variable into the aos-ansible inventory template via the image_provisioner inventory.  Also add a few new packages.