### PR TITLE
verify-registry.sh and verify-router.sh script fixes.

### DIFF
--- a/openshift_scalability/scripts/verify-registry.sh
+++ b/openshift_scalability/scripts/verify-registry.sh
@@ -9,7 +9,7 @@ set -o nounset
 set -o pipefail
 
 # checks that docker-registry service exists in the 'default' namespace
-if ! $(oc adm registry --dry-run --namespace default); then
+if ! oc adm registry --dry-run --namespace default; then
     echo "docker-registry service doesn't exit"
     exit 1
 fi
@@ -18,7 +18,7 @@ fi
 REGISTRY_IP=$(oc get services --template '{{range .items}}{{if eq .metadata.name "docker-registry"}}{{printf "%s\n" .spec.clusterIP}}{{end}}{{end}}' --namespace default)
 
 # curl $REGISTRY_IP:5000 to verify docker-registry pod is running
-if ! $(curl --head --fail ${REGISTRY_IP}:5000); then
+if ! curl --head --fail ${REGISTRY_IP}:5000; then
     echo "docker-registry pod is not running"
     exit 1
 fi

--- a/openshift_scalability/scripts/verify-router.sh
+++ b/openshift_scalability/scripts/verify-router.sh
@@ -11,13 +11,13 @@ set -o pipefail
 MASTER_IP=${1:-127.0.0.1}
 
 # checks that router service exists in the 'default' namespace
-if ! $(oc adm router --dry-run --namespace default); then
+if ! oc adm router --dry-run --namespace default; then
     echo "router service doesn't exit"
     exit 1
 fi
 
 # curl healthz endpoint for router
-if ! $(curl --head --fail ${MASTER_IP}:1936/healthz); then
+if ! curl --head --fail ${MASTER_IP}:1936/healthz; then
     echo "router pod is not running"
     exit 1
 fi


### PR DESCRIPTION
Removed command substitution from verify-registry.sh and verify-router.sh for the scripts to make them work.

Signed-off-by: Jiri Mencak <jmencak@redhat.com>