### PR TITLE
docker-py is required by ansible to use docker module

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -22,6 +22,7 @@
     - numactl
     - pciutils
     - perf
+    - python-docker-py
     - python-pip
     - python-rbd
     - python2-boto3


### PR DESCRIPTION
For some reason ansible doesn't try to pull down docker-py.  It's required in order to use ansible's docker module.