### PR TITLE
Remove bad --profile option for pprof tool.

### DIFF
--- a/openshift_scalability/pbench-register.sh
+++ b/openshift_scalability/pbench-register.sh
@@ -10,13 +10,13 @@ NODES=$*
 
 pbench-register-tool-set --interval=10
 pbench-register-tool --name=oc
-pbench-register-tool --name=pprof -- --profile=cpu --osecomponent=master
+pbench-register-tool --name=pprof -- --osecomponent=master
 
 # setup pbench on nodes
 for NODE in $NODES
   do
     pbench-register-tool-set --remote=$NODE --interval=10
-    pbench-register-tool --name=pprof --remote=$NODE -- --profile=cpu --osecomponent=node
+    pbench-register-tool --name=pprof --remote=$NODE -- --osecomponent=node
 done
 
 pbench-list-tools


### PR DESCRIPTION
The pbench-register script uses a --profile option for the pprof tool which is not recognized by the tool.   The latest version of the pprof tool for pbench always collects both cpu and heap profile data. 