### PR TITLE
Few new examples

### DIFF
--- a/openshift_scalability/content/e2ejob.yaml
+++ b/openshift_scalability/content/e2ejob.yaml
@@ -1,0 +1,53 @@
+apiVersion: extensions/v1beta1
+kind: Job
+metadata:
+  name: foo
+spec:
+  activeDeadlineSeconds: 40
+  completions: 4
+  parallelism: 2
+  template:
+    metadata:
+      labels:
+        somekey: somevalue
+    spec:
+      containers:
+      - command:
+        - sleep
+        - "1000000"
+        image: gcr.io/google_containers/busybox:1.24
+        imagePullPolicy: IfNotPresent
+        name: c
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      restartPolicy: Never
+      volumes:
+      - emptyDir: {}
+        name: data
+
+$ cat fakeis.json
+{
+    "kind": "ImageStream",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "pyfake",
+      "creationTimestamp": null
+    },
+    "spec": {
+       "dockerImageRepository": "wsun/non-existen-image",
+           "tags":[
+                      { "name": "3.3",
+                         "annotations":
+                              { "description": "wsun tests" },
+                          "from":
+                           {
+                               "kind": "DockerImage",
+                                "name": "wsun/pythonlol-33-centos"
+                           }
+
+                        }
+             ]
+       }
+
+}

--- a/openshift_scalability/content/job.yaml
+++ b/openshift_scalability/content/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hello
+spec:
+  template:
+    metadata:
+      name: hello
+    spec:
+      containers:
+      - name: hello
+        image: python:3.5.1
+        command: ["python", "-c", "print('Hello world!')"]
+      restartPolicy: Never

--- a/openshift_scalability/content/limitrange.yaml
+++ b/openshift_scalability/content/limitrange.yaml
@@ -1,0 +1,13 @@
+apiVersion: "v1"
+kind: "LimitRange"
+metadata:
+  name: "two"
+spec:
+  limits:
+    - type: openshift.io/Image
+      max:
+        storage: 200Mi
+    - type: openshift.io/ImageStream
+      max:
+        openshift.io/image-tags: 1
+        openshift.io/images: 1

--- a/openshift_scalability/content/node-problem-detector.yaml
+++ b/openshift_scalability/content/node-problem-detector.yaml
@@ -1,0 +1,19 @@
+# https://github.com/kubernetes/node-problem-detector
+# below slightly differs from example in doc above.
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+    spec:
+      containers:
+      - name: node-problem-detector
+        image: gcr.io/google_containers/node-problem-detector:v0.2
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true

--- a/openshift_scalability/content/scheduledjob.yaml
+++ b/openshift_scalability/content/scheduledjob.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v2alpha1
+kind: ScheduledJob
+metadata:
+  name: pi
+spec:
+  schedule: "*/1 * * * ?"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: pi
+        spec:
+          containers:
+          - name: pi
+            image: perl
+            command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+          restartPolicy: Never

--- a/openshift_scalability/content/tuned-daemonset.yaml
+++ b/openshift_scalability/content/tuned-daemonset.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: tuned-daemonset
+spec:
+  template:
+    metadata:
+      labels:
+        app: tuned
+    spec:
+      containers:
+      - name: node-problem-detector
+        image: gcr.io/google_containers/node-problem-detector:v0.2
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true


### PR DESCRIPTION
Spoke with Maciej Szulik this morning about some busted daemonset examples (fixed node-problem-detector.yaml is part of this PR) and he offered some other examples of experimental yaml to test features he's working on.  I've added them here so we don't lose them and they're here when we get to testing his new work out.
