### PR TITLE
os_kickstart must be first role

### DIFF
--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -4,10 +4,10 @@
   hosts: all
 
   roles:
+    - os-kickstart
     - clone-repos
     - aos-ansible
     - repo-install
-    - os-kickstart
     - collectd-install
     - clone-repos
     - pbench-config


### PR DESCRIPTION
If os_kickstart is not first, nobody will be happy.