### PR TITLE
Add templates to trigger the ARP table overflow issue on OCP when usi…

### DIFF
--- a/openshift_scalability/config/router-arp_stress.yaml
+++ b/openshift_scalability/config/router-arp_stress.yaml
@@ -1,0 +1,24 @@
+# This template aims to trigger the ARP table overflow issue when using the default
+# Linux kernel's neigh/default/gc_thresh[1-3] settings.  Tested on a 6 node EC2 instance. 
+
+projects:
+  - num: 10
+    basename: arp
+    tuning: default
+    ifexists: delete
+    templates:
+      - num: 100
+        file: content/router/router-arp_stress.json
+
+quotas:
+  - name: default
+    file: default
+
+tuningsets:
+  - name: default
+    templates:
+      stepping:
+        stepsize: 5
+        pause: 10 s
+      rate_limit:
+        delay: 3 s

--- a/openshift_scalability/content/router/router-arp_stress.json
+++ b/openshift_scalability/content/router/router-arp_stress.json
@@ -1,0 +1,144 @@
+{
+    "apiVersion": "v1",
+    "kind": "Template",
+    "metadata": {
+        "name": "hello-openshift"
+    },
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "hello-service-${IDENTIFIER}",
+                "labels": {
+                    "name": "hello-openshift"
+                }
+            },
+            "spec": {
+                "selector": {
+                    "name": "hello-openshift-${IDENTIFIER}"
+                },
+                "ports": [
+                    {
+                        "name": "first",
+                        "protocol": "TCP",
+                        "port": 8080,
+                        "targetPort": 8080
+                    },
+                    {
+                        "name": "second",
+                        "protocol": "TCP",
+                        "port": 8888,
+                        "targetPort": 8888
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "hello-route-${IDENTIFIER}"
+            },
+            "spec": {
+                "host": "${APPLICATION_DOMAIN}",
+                "to": {
+                    "kind": "Service",
+                    "name": "hello-service-${IDENTIFIER}"
+                }
+            }
+        },
+        {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "generateName": "hello-pod-",
+                "labels": {
+                    "name": "hello-openshift-${IDENTIFIER}",
+                    "test": "hello-openshift"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "PORT",
+                                "value": "${PORT}"
+                            },
+                            {
+                                "name": "SECOND_PORT",
+                                "value": "${SECOND_PORT}"
+                            }
+                        ],
+                        "image": "openshift/hello-openshift",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "hello-openshift",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 8888,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                           "limits": {
+                                "cpu": "800m",
+                                "memory": "20Mi"
+                            },
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "KILL",
+                                    "MKNOD",
+                                    "SETGID",
+                                    "SETUID",
+                                    "SYS_CHROOT"
+                                ]
+                            },
+                            "privileged": false,
+                            "seLinuxOptions": {
+                                "level": "s0:c9,c4"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log"
+                    }
+                ],
+                "restartPolicy": "Never"
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "PORT",
+            "displayName": "Listen on PORT",
+            "description": "Tells the container to start httpd server on port PORT",
+            "value": "8080"
+        },
+        {
+            "name": "SECOND_PORT",
+            "displayName": "Listen also on SECOND_PORT",
+            "description": "Tells the container to start httpd server also on port SECOND_PORT",
+            "value": "8888"
+        },
+        {
+            "name": "APPLICATION_DOMAIN",
+            "displayName": "Application Hostname",
+            "description": "The exposed hostname that will route to the hello-openshift-* service, if left blank a value will be defaulted.",
+            "value": ""
+        },
+        {
+            "name": "IDENTIFIER",
+            "description": "Number to append to the name of resources",
+            "value": "1"
+        }
+    ]
+}

--- a/openshift_scalability/content/router/router-arp_stress.json
+++ b/openshift_scalability/content/router/router-arp_stress.json
@@ -55,7 +55,6 @@
                 "generateName": "hello-pod-",
                 "labels": {
                     "name": "hello-openshift-${IDENTIFIER}",
-                    "test": "hello-openshift"
                 }
             },
             "spec": {

--- a/openshift_scalability/content/router/router-arp_stress.json
+++ b/openshift_scalability/content/router/router-arp_stress.json
@@ -54,7 +54,7 @@
             "metadata": {
                 "generateName": "hello-pod-",
                 "labels": {
-                    "name": "hello-openshift-${IDENTIFIER}",
+                    "name": "hello-openshift-${IDENTIFIER}"
                 }
             },
             "spec": {


### PR DESCRIPTION
…ng the default Linux kernel's values gc_thresh[1-3].

Signed-off-by: Jiri Mencak jmencak@redhat.com
