### PR TITLE
Create PVCs in target namespace for EBS volume claims

### DIFF
--- a/openshift_scalability/content/pvc-default.json
+++ b/openshift_scalability/content/pvc-default.json
@@ -2,7 +2,8 @@
     "apiVersion": "v1",
     "kind": "PersistentVolumeClaim",
     "metadata": {
-        "name": "pvclaimname"
+        "name": "pvclaimname",
+        "namespace" : ""
     },
     "spec": {
         "accessModes": [ "ReadWriteOnce" ],

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -577,6 +577,7 @@ def ebs_create(globalvars):
     with open("content/pvc-default.json", "r") as pvcstream:
         pvcjson = json.load(pvcstream)
     pvcjson["metadata"]["name"] = ebsvolumeid 
+    pvcjson["metadata"]["namespace"] = namespace 
     pvcjson["spec"]["resources"]["requests"]["storage"] = str(ebsvolumesize) + "Gi"
     pvcjson["spec"]["accessModes"] = [pvcpermissions]
     pvctmpfile = tempfile.NamedTemporaryFile(delete=True)


### PR DESCRIPTION
Fixes issue #108 

Add namespace to instantiated template prior to PVC creation for EBS.

@ekuric please take a look