### PR TITLE
Updated image_provisioner playbooks/build_ami.yaml and roles/repo-ins…

### DIFF
--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -65,7 +65,7 @@
       region: "{{ region }}"
       state: present
       description: This was provisioned {{ ansible_date_time.iso8601 }}
-      name: ocp-{{ openshift_version }}-gold
+      name: ocp-{{ openshift_version }}-gold-auto
       wait: yes
     register: amioutput
 

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+- name: clean yum cache
+  shell:  yum clean all
+  ignore_errors: true
+
 - name: download aos-ansible tarball
   get_url:
     url: https://api.github.com/repos/openshift/aos-ansible/tarball/master 


### PR DESCRIPTION
Updated:
-  image_provisioner playbooks/build_ami.yaml file to add "-auto" suffix to AMI name
-  roles/repo-install/tasks/main.yaml files to insert a "yum clean all step" before repos are installed