### PR TITLE
[networking/synthetic] Fix set region name

### DIFF
--- a/networking/synthetic/network-test.py
+++ b/networking/synthetic/network-test.py
@@ -124,6 +124,8 @@ def set_sender_region(master, nodes):
     if nodes is None:
         return 'both'
     else:
+        if len(nodes) == 2 and nodes[0] == nodes[1]:
+            return 'both'
         return 'sender'
     
 
@@ -131,6 +133,8 @@ def set_receiver_region(master, nodes):
     if nodes is None:
         return 'both'
     else:
+        if len(nodes) == 2 and nodes[0] == nodes[1]:
+            return 'both'
         return 'receiver'
 
     


### PR DESCRIPTION
This fix is for the scenario where there is only one node and uperf
sender and receiver pods are intended to be run only on this single
node. Example command:
$ python network-test.py podIP --master <master_hostname> --node <node1_hostname> <node1_hostname> --pods 1

In current code, sender pod will never be able to schedule because the node region
will get overwritten as "receiver". It should be set as "both" in this case.

Signed-off-by: vikaschoudhary16 <vichoudh@redhat.com>