### PR TITLE
Update image stream and template versions for eap quickstarts.

### DIFF
--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-build.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-build.json
@@ -6,13 +6,13 @@
 	    "description": "An example DayTrader application with a PostgreSQL database",
             "iconClass": "icon-jboss",
             "tags": "daytrader,postgresql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
 	"name": "daytrader-postgresql"
     },
     "labels": {
         "template": "daytrader-postgresql",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
         {
@@ -141,7 +141,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-deploy.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-deploy.json
@@ -6,13 +6,13 @@
 	    "description": "An example DayTrader application with a PostgreSQL database",
             "iconClass": "icon-jboss",
             "tags": "daytrader,postgresql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
 	"name": "daytrader-postgresql"
     },
     "labels": {
         "template": "daytrader-postgresql",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
         {

--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv-deploy.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv-deploy.json
@@ -6,13 +6,13 @@
 	    "description": "An example DayTrader application with a PostgreSQL database with persistent storage",
             "iconClass": "icon-jboss",
             "tags": "daytrader,postgresql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
 	"name": "daytrader-postgresql-pv"
     },
     "labels": {
         "template": "daytrader-postgresql-pv",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
         {

--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv.json
@@ -6,13 +6,13 @@
 	    "description": "An example DayTrader application with a PostgreSQL database with persistent storage",
             "iconClass": "icon-jboss",
             "tags": "daytrader,postgresql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
 	"name": "daytrader-postgresql-pv"
     },
     "labels": {
         "template": "daytrader-postgresql-pv",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
         {
@@ -387,7 +387,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql.json
@@ -6,13 +6,13 @@
 	    "description": "An example DayTrader application with a PostgreSQL database",
             "iconClass": "icon-jboss",
             "tags": "daytrader,postgresql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
 	"name": "daytrader-postgresql"
     },
     "labels": {
         "template": "daytrader-postgresql",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
         {
@@ -381,7 +381,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/eap/eap64-build.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-build.json
@@ -7,13 +7,13 @@
             "iconClass": "icon-jboss",
 	    "source": "https://github.com/openshift/online/blob/master/templates/examples/eap64-mysql-persistent-s2i.json",
             "tags": "eap,mysql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
         "name": "eap64-mysql-persistent-s2i"
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "objects": [
 {
@@ -51,7 +51,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-deploy.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-deploy.json
@@ -7,13 +7,13 @@
             "iconClass": "icon-jboss",
 	    "source": "https://github.com/openshift/online/blob/master/templates/examples/eap64-mysql-persistent-s2i.json",
             "tags": "eap,mysql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
         "name": "eap64-mysql-persistent-s2i"
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
 	{

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv-deploy.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv-deploy.json
@@ -7,13 +7,13 @@
             "iconClass": "icon-jboss",
 	    "source": "https://github.com/openshift/online/blob/master/templates/examples/eap64-mysql-persistent-s2i.json",
             "tags": "eap,mysql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
         "name": "eap64-mysql-persistent-s2i"
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
 	{

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
@@ -7,13 +7,13 @@
             "iconClass": "icon-jboss",
 	    "source": "https://github.com/openshift/online/blob/master/templates/examples/eap64-mysql-persistent-s2i.json",
             "tags": "eap,mysql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
         "name": "eap64-mysql-persistent-s2i"
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
 	{
@@ -437,7 +437,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql.json
@@ -7,13 +7,13 @@
             "iconClass": "icon-jboss",
 	    "source": "https://github.com/openshift/online/blob/master/templates/examples/eap64-mysql-persistent-s2i.json",
             "tags": "eap,mysql,javaee,java,database,jboss,xpaas",
-            "version": "1.2.0"
+            "version": "1.3.2"
         },
         "name": "eap64-mysql-persistent-s2i"
     },
     "labels": {
         "template": "eap64-mysql-persistent-s2i",
-        "xpaas": "1.2.0"
+        "xpaas": "1.3.2"
     },
     "parameters": [
 	{
@@ -430,7 +430,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap64-openshift:1.2"
+                            "name": "jboss-eap64-openshift:latest"
                         }
                     }
                 },


### PR DESCRIPTION
Without this change daytrader and eap quickstarts fail to start correctly on OCP 3.5.0.5.  PR tested and worked on OCP 3.3.1.1, 3.4.0.39 and 3.5.0.5.