### PR TITLE
Fix deprecated usage of -v param for oc process command in 3.5 version.

### DIFF
--- a/networking/synthetic/pod-ip-test-setup.yaml
+++ b/networking/synthetic/pod-ip-test-setup.yaml
@@ -62,8 +62,8 @@
   - name: Create sender pods
     shell: >
       oc process
-      -v REGION={{ sender_region }}
-      -v ROLE=sender
+      -p REGION={{ sender_region }}
+      -p ROLE=sender
       -f /tmp/origin/uperf-rc-template.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}
@@ -74,8 +74,8 @@
   - name: Create receiver pods
     shell: >
       oc process
-      -v REGION={{ receiver_region }}
-      -v ROLE=receiver
+      -p REGION={{ receiver_region }}
+      -p ROLE=receiver
       -f /tmp/origin/uperf-rc-template.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}

--- a/networking/synthetic/svc-ip-test-setup.yaml
+++ b/networking/synthetic/svc-ip-test-setup.yaml
@@ -72,8 +72,8 @@
   - name: Create sender pods
     shell: >
       oc process
-      -v REGION={{ sender_region }}
-      -v ROLE=sender
+      -p REGION={{ sender_region }}
+      -p ROLE=sender
       -f /tmp/origin/uperf-rc-template.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}
@@ -81,7 +81,7 @@
   - name: Create sender services
     shell: >
       oc process
-      -v ROLE=sender
+      -p ROLE=sender
       -f /tmp/origin/uperf-svc-template-{{ item }}.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}
@@ -92,8 +92,8 @@
   - name: Create receiver pods
     shell: >
       oc process
-      -v REGION={{ receiver_region }}
-      -v ROLE=receiver
+      -p REGION={{ receiver_region }}
+      -p ROLE=receiver
       -f /tmp/origin/uperf-rc-template.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}
@@ -101,7 +101,7 @@
   - name: Create receiver services
     shell: >
       oc process
-      -v ROLE=receiver
+      -p ROLE=receiver
       -f /tmp/origin/uperf-svc-template-{{ item }}.json |
       oc create --namespace=uperf-{{ item }} -f -
     with_sequence: start=1 end={{ uperf_pod_number }}


### PR DESCRIPTION
(cherry picked from commit 91c9fca70e1774445f14501e0a3c72971a4da4ec)

fix for #135 

