### PR TITLE
cakephp-mysql-example in deploy template not built in openshift namespace

### DIFF
--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-deploy.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-deploy.json
@@ -84,7 +84,8 @@
 			    ],
 			    "from": {
 				"kind": "ImageStreamTag",
-				"name": "cakephp-mysql-example:latest"
+				"name": "cakephp-mysql-example:latest",
+				"namespace": "openshift"
 			    }
 			}
 		    },


### PR DESCRIPTION
Tested and works on 3.5.0.12.