### PR TITLE
dynamic persistent storage update for applications templates

### DIFF
--- a/openshift_scalability/content/quickstarts/appdeploy.yaml
+++ b/openshift_scalability/content/quickstarts/appdeploy.yaml
@@ -1,0 +1,64 @@
+projects:
+  - num: 1
+    basename: apptest
+    tuning: default
+    templates:
+      - num: 1
+        file: ./content/quickstarts/cakephp/cakephp-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/django/django-postgresql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/nodejs/nodejs-mongodb-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/dancer/dancer-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/daytrader/daytrader-postgresql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/rails/rails-postgresql-pv.json
+        parametrs:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/tomcat/tomcat8-mongodb-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/eap/eap64-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+
+
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 1
+        pause: 0 min
+      rate_limit:
+        delay: 1000 ms

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
@@ -116,12 +116,12 @@
 	    "metadata": {
 		"name": "${DATABASE_SERVICE_NAME}",
 		"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		}
 	    },
 	    "spec": {
 		"accessModes": [
-		    "ReadWriteOnce"
+            "${ACCESS_MODES}"
 		],
 		"resources": {
 		    "requests": {
@@ -494,6 +494,18 @@
       "name": "IDENTIFIER",
       "description": "Number to append to the name of resources",
       "value": "1"
-    }
+    },
+      {
+        "name": "STORAGE_CLASS",
+        "description": "Name of storage class used for dynamic storage allocation",
+        "required": true,
+        "value": "foo"
+      },
+      {
+        "name": "ACCESS_MODES",
+        "description": "What access modes will be imposed on PVC inside pod",
+        "required": true,
+        "value": "ReadWriteOnce"
+      }
     ]
 }

--- a/openshift_scalability/content/quickstarts/dancer/dancer-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/dancer/dancer-mysql-pv.json
@@ -218,12 +218,12 @@
 	    "metadata": {
 		"name": "${DATABASE_SERVICE_NAME}",
 	  	"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		}
 	    },
 	    "spec": {
 		"accessModes": [
-		    "ReadWriteOnce"
+		    "${ACCESS_MODES}"
 		],
 		"resources": {
 		    "requests": {
@@ -461,6 +461,18 @@
       "name": "IDENTIFIER",
       "description": "Number to append to the name of resources",
       "value": "1"
+    },
+    {
+      "name": "STORAGE_CLASS",
+      "description": "Name of storage class used for dynamic storage allocation",
+      "required": true,
+      "value": "foo"
+    },
+    {
+      "name": "ACCESS_MODES",
+      "description": "What access modes will be imposed on PVC inside pod",
+      "required": true,
+      "value": "ReadWriteOnce"
     }
     ]
 }

--- a/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv.json
+++ b/openshift_scalability/content/quickstarts/daytrader/daytrader-postgresql-pv.json
@@ -206,6 +206,18 @@
            "name": "IDENTIFIER",
            "description": "Number to append to the name of resources",
            "value": "1"
+        },
+        {
+          "name": "STORAGE_CLASS",
+          "description": "Name of storage class used for dynamic storage allocation",
+          "required": true,
+          "value": "foo"
+        },
+        {
+          "name": "ACCESS_MODES",
+          "description": "What access modes will be imposed on PVC inside pod",
+          "required": true,
+          "value": "ReadWriteOnce"
         }
     ],
     "objects": [
@@ -750,12 +762,12 @@
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "annotations": {
-                    "volume.alpha.kubernetes.io/storage-class": "foo"
+                    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
                 }
             },
             "spec": {
                 "accessModes": [
-                    "ReadWriteOnce"
+                    "${ACCESS_MODES}"
                 ],
                 "resources": {
                     "requests": {

--- a/openshift_scalability/content/quickstarts/django/django-postgresql-pv.json
+++ b/openshift_scalability/content/quickstarts/django/django-postgresql-pv.json
@@ -228,12 +228,12 @@
 	    "metadata": {
 		"name": "${DATABASE_SERVICE_NAME}",
 	  	"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		}
 	    },
 	    "spec": {
 		"accessModes": [
-		    "ReadWriteOnce"
+		    "${ACCESS_MODES}"
 		],
 		"resources": {
 		    "requests": {
@@ -463,6 +463,18 @@
       "name": "IDENTIFIER",
       "description": "Number to append to the name of resources",
       "value": "1"
+    },
+    {
+      "name": "STORAGE_CLASS",
+      "description": "Name of storage class used for dynamic storage allocation",
+      "required": true,
+      "value": "foo"
+    },
+    {
+      "name": "ACCESS_MODES",
+      "description": "What access modes will be imposed on PVC inside pod",
+      "required": true,
+      "value": "ReadWriteOnce"
     }
     ]
 }

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
@@ -258,7 +258,20 @@
          "name": "IDENTIFIER",
          "description": "Number to append to the name of resources",
          "value": "1"
-        }
+       },
+       {
+         "name": "STORAGE_CLASS",
+         "description": "Name of storage class used for dynamic storage allocation",
+         "required": true,
+         "value": "foo"
+       },
+       {
+         "name": "ACCESS_MODES",
+         "description": "What access modes will be imposed on PVC inside pod",
+         "required": true,
+         "value": "ReadWriteOnce"
+       }
+
     ],
     "objects": [
 	{
@@ -822,7 +835,7 @@
             "metadata": {
                 "name": "${APPLICATION_NAME}-mysql-claim",
 		"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		},
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -830,7 +843,7 @@
             },
             "spec": {
                 "accessModes": [
-                    "ReadWriteOnce"
+                    "${ACCESS_MODES}"
                 ],
                 "resources": {
                     "requests": {

--- a/openshift_scalability/content/quickstarts/help.md
+++ b/openshift_scalability/content/quickstarts/help.md
@@ -1,0 +1,106 @@
+### Usage
+
+Templates in this directory can be used with cluster loader with
+
+```
+# python cluster-loader.py -f appdeloy.yaml
+```
+where in `appdeloy.yaml` we can specify `storageclass` which will be used by
+application pods to allocate storage
+
+Beside `STORAGE_CLASS` parameter, we can specify also other parameters related storage
+as `ACCESS_MODES` where access mode is one from https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+
+`VOLUME_CAPACITY` parameter allows to specify size of volume which will be mounted
+inside pod
+An example of appdeploy.yaml is showed below.
+
+Below template will
+
+- create one project
+- use templates specified by `file` line. Currently these templates are tested, it is possible to add more templates, but not tested more at this time.
+-  applications starting based on specific template, will use storage class
+specified with variable `STORAGE_CLASS` to allocated persistent volume claims(PVC) for applications. The storageclass must exist prior trying to use it. For instructions how to configure storage class, check OCP documentation
+- `ACCESS_MODES` set to be `ReadWriteOnce`
+- VOLUME_CAPACITY set to 5Gi
+
+Mount point where PVC is mounted inside application pods is managed by applications
+and we cannot add it at time as parameter.
+
+In below template, it is possible to use different storage classes for different
+applications, that means some applications can use one storage type to run while
+some others different storage type. In all cases, storage class must exist before it is tried to use.
+
+Currently it is not supported/possible to create multiple instances of same application in single project
+If it is necessary to run multiple applications, then this is possible by
+increasing number of projects. Future updates of these templates
+will support multiple applications running in single project/namespace.
+
+Each application template support additional parameters, if there is need to use them then check template specific parameters and specify them in section related to particular application. 
+
+```
+projects:
+  - num: 1
+    basename: apptest
+    tuning: default
+    templates:
+      - num: 1
+        file: ./content/quickstarts/cakephp/cakephp-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/django/django-postgresql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/nodejs/nodejs-mongodb-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/dancer/dancer-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/daytrader/daytrader-postgresql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/rails/rails-postgresql-pv.json
+        parametrs:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/tomcat/tomcat8-mongodb-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+      - num: 1
+        file: ./content/quickstarts/eap/eap64-mysql-pv.json
+        parameters:
+          - STORAGE_CLASS: "elclass"
+          - ACCESS_MODES: "ReadWriteOnce"
+          - VOLUME_CAPACITY: "5Gi"
+
+
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 1
+        pause: 0 min
+      rate_limit:
+        delay: 1000 ms
+````

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv.json
@@ -223,12 +223,12 @@
 	    "metadata": {
 		"name": "${DATABASE_SERVICE_NAME}",
 	  	"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		}
 	    },
 	    "spec": {
 		"accessModes": [
-		    "ReadWriteOnce"
+		    "${ACCESS_MODES}"
 		],
 		"resources": {
 		    "requests": {
@@ -461,6 +461,18 @@
       "name": "IDENTIFIER",
       "description": "Number to append to the name of resources",
       "value": "1"
+    },
+    {
+      "name": "STORAGE_CLASS",
+      "description": "Name of storage class used for dynamic storage allocation",
+      "required": true,
+      "value": "foo"
+    },
+    {
+      "name": "ACCESS_MODES",
+      "description": "What access modes will be imposed on PVC inside pod",
+      "required": true,
+      "value": "ReadWriteOnce"
     }
     ]
 }

--- a/openshift_scalability/content/quickstarts/rails/rails-postgresql-pv.json
+++ b/openshift_scalability/content/quickstarts/rails/rails-postgresql-pv.json
@@ -253,7 +253,7 @@
 	    "kind": "Service",
 	    "apiVersion": "v1",
 	    "metadata": {
-		"name": "${DATABASE_SERVICE_NAME}",
+		"name": "${DATABASE_SERVICE_NAME}-${SERVICE_NAME_SUFFIX}",
 		"annotations": {
 		    "description": "Exposes the database server"
 		}
@@ -267,7 +267,7 @@
 		    }
 		],
 		"selector": {
-		    "name": "${DATABASE_SERVICE_NAME}"
+		    "name": "${DATABASE_SERVICE_NAME}-${SERVICE_NAME_SUFFIX}"
 		}
 	    }
 	},
@@ -275,14 +275,14 @@
 	    "kind": "PersistentVolumeClaim",
 	    "apiVersion": "v1",
 	    "metadata": {
-		"name": "${DATABASE_SERVICE_NAME}",
+		"name": "${DATABASE_SERVICE_NAME}-${PVC_NAME_SUFFIX}",
 	  	"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		}
 	    },
 	    "spec": {
 		"accessModes": [
-		    "ReadWriteOnce"
+		    "${ACCESS_MODES}"
 		],
 		"resources": {
 		    "requests": {
@@ -295,7 +295,7 @@
 	    "kind": "DeploymentConfig",
 	    "apiVersion": "v1",
 	    "metadata": {
-		"name": "${DATABASE_SERVICE_NAME}",
+		"name": "${DATABASE_SERVICE_NAME}-${DEPLOYMENT_CONFIG_SUFIX}",
 		"annotations": {
 		    "description": "Defines how to deploy the database"
 		}
@@ -325,13 +325,13 @@
 		],
 		"replicas": 1,
 		"selector": {
-		    "name": "${DATABASE_SERVICE_NAME}"
+		    "name": "${DATABASE_SERVICE_NAME}-${DEPLOYMENT_CONFIG_SUFIX}"
 		},
 		"template": {
 		    "metadata": {
-			"name": "${DATABASE_SERVICE_NAME}",
+			"name": "${DATABASE_SERVICE_NAME}-${DEPLOYMENT_CONFIG_SUFIX}",
 			"labels": {
-			    "name": "${DATABASE_SERVICE_NAME}"
+			    "name": "${DATABASE_SERVICE_NAME}-${DEPLOYMENT_CONFIG_SUFIX}"
 			}
 		    },
 		    "spec": {
@@ -397,7 +397,7 @@
 			    {
 				"name": "${DATABASE_SERVICE_NAME}-data",
 				"persistentVolumeClaim": {
-				    "claimName": "${DATABASE_SERVICE_NAME}"
+				    "claimName": "${DATABASE_SERVICE_NAME}-${PVC_NAME_SUFFIX}"
 				}
 			    }
 			]
@@ -516,6 +516,36 @@
       "name": "IDENTIFIER",
       "description": "Number to append to the name of resources",
       "value": "1"
+    },
+    {
+      "name": "STORAGE_CLASS",
+      "description": "Name of storage class used for dynamic storage allocation",
+      "required": true,
+      "value": "foo"
+    },
+    {
+      "name": "ACCESS_MODES",
+      "description": "What access modes will be imposed on PVC inside pod",
+      "required": true,
+      "value": "ReadWriteOnce"
+    },
+    {
+      "name": "SERVICE_NAME_SUFFIX",
+      "description": "database suffix, to make it different",
+      "required": true,
+      "value": "postgre"
+    },
+    {
+      "name": "PVC_NAME_SUFFIX",
+      "description": "pvc name suffix",
+      "required": true,
+      "value": "postgre"
+    },
+    {
+      "name": "DEPLOYMENT_CONFIG_SUFIX",
+      "description": "deployment config suffix",
+      "required": true,
+      "value": "postgre"
     }
     ]
 }

--- a/openshift_scalability/content/quickstarts/tomcat/tomcat8-mongodb-pv.json
+++ b/openshift_scalability/content/quickstarts/tomcat/tomcat8-mongodb-pv.json
@@ -211,6 +211,18 @@
           "name": "IDENTIFIER",
           "description": "Number to append to the name of resources",
           "value": "1"
+        },
+        {
+          "name": "STORAGE_CLASS",
+          "description": "Name of storage class used for dynamic storage allocation",
+          "required": true,
+          "value": "foo"
+        },
+        {
+          "name": "ACCESS_MODES",
+          "description": "What access modes will be imposed on PVC inside pod",
+          "required": true,
+          "value": "ReadWriteOnce"
         }
     ],
     "objects": [
@@ -706,7 +718,7 @@
             "metadata": {
                 "name": "${APPLICATION_NAME}-mongodb-claim",
 		"annotations": {
-		    "volume.alpha.kubernetes.io/storage-class": "foo"
+		    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
 		},
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -714,7 +726,7 @@
             },
             "spec": {
                 "accessModes": [
-                    "ReadWriteOnce"
+                    "${ACCESS_MODES}"
                 ],
                 "resources": {
                     "requests": {


### PR DESCRIPTION
dynamic persistant storage support for applications templates 
check help.md for short guidance how to use them.
these templates does not create storageclasses but only use them to allocate storage, that means, prior using these templates ensure that Openshift is properly configured from storage and storageclasses point of view. 
 
