### PR TITLE
Check oc client version and use correct parameter flag for oc process

### DIFF
--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -22,6 +22,6 @@ export KUBE_REPO_ROOT=/root/origin/vendor/k8s.io/kubernetes
 export EXTENDED_TEST_PATH=/root/origin/test/extended
 
 
-TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
+TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo --noColor -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
 #TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-serial ginkgo --noColor -v "-focus=$SERIAL_TESTS" "-skip=$SERIAL_SKIP" /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
  

--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -22,6 +22,6 @@ export KUBE_REPO_ROOT=/root/origin/vendor/k8s.io/kubernetes
 export EXTENDED_TEST_PATH=/root/origin/test/extended
 
 
-TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo --noColor -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
-TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-serial ginkgo --noColor -v "-focus=$SERIAL_TESTS" "-skip=$SERIAL_SKIP" /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
+TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
+#TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-serial ginkgo --noColor -v "-focus=$SERIAL_TESTS" "-skip=$SERIAL_SKIP" /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
  

--- a/openshift_scalability/cluster-loader.py
+++ b/openshift_scalability/cluster-loader.py
@@ -74,6 +74,8 @@ if "tuningsets" in testconfig:
 if user and passwd and master:
     login = login(user, passwd, master)
 
+globalvars["version_info"] = check_oc_version(globalvars)
+
 for config in testconfig["projects"]:
     if "tuning" in config:
         globalvars["tuningset"] = find_tuning(testconfig["tuningsets"],\

--- a/openshift_scalability/content/quickstarts/stress/stress-pod.json
+++ b/openshift_scalability/content/quickstarts/stress/stress-pod.json
@@ -43,6 +43,10 @@
 				"value": "${TARGET_PORT}"
                             },
                             {
+                                "name": "JVM_ARGS",
+				"value": "${JVM_ARGS}"
+                            },
+                            {
                                 "name": "JMETER_SIZE",
 				"value": "${JMETER_SIZE}"
                             },
@@ -52,7 +56,27 @@
                             },
                             {
                                 "name": "JMETER_TPS",
-				"value": "${JMETER_TPS}"
+                                "value": "${JMETER_TPS}"
+                            },
+                            {
+                                "name": "VEGETA_RPS",
+                                "value": "${VEGETA_RPS}"
+                            },
+                            {
+                                "name": "WRK_DELAY",
+                                "value": "${WRK_DELAY}"
+                            },
+                            {
+                                "name": "WRK_TARGETS",
+                                "value": "${WRK_TARGETS}"
+                            },
+                            {
+                                "name": "WRK_KEEPALIVE",
+                                "value": "${WRK_KEEPALIVE}"
+                            },
+                            {
+                                "name": "WRK_TLS_SESSION_REUSE",
+                                "value": "${WRK_TLS_SESSION_REUSE}"
                             },
                             {
                                 "name": "PBENCH_DIR",
@@ -65,12 +89,22 @@
                             {
                                 "name": "GUN",
 				"value": "${GUN}"
+                            },
+                            {
+                                "name": "IDENTIFIER",
+				"value": "${IDENTIFIER}"
                             }
                         ],
-                        "image": "sjug/centos-stress:latest",
+                        "image": "jmencak/centos-stress:latest",
                         "imagePullPolicy": "Always",
                         "name": "centos-stress",
                         "resources": {},
+                        "volumeMounts": [
+                            {   
+                                "name": "targets",
+                                "mountPath": "/opt/wlg"
+                            }
+                        ],  
                         "securityContext": {
                             "capabilities": {
                                 "drop": [
@@ -87,6 +121,14 @@
                             }
                         },
                         "terminationMessagePath": "/dev/termination-log"
+                    }
+                ],
+                "volumes": [
+                    {   
+                        "name": "targets",
+                        "configMap": {
+                            "name": "wlg-targets"
+                        }
                     }
                 ],
                 "imagePullSecrets": [
@@ -130,6 +172,12 @@
 	    "value": "80"
 	},
 	{
+	    "name": "JVM_ARGS",
+	    "displayName": "Optional JVM arguments",
+	    "description": "Optional JVM arguments",
+	    "value": ""
+	},
+	{
 	    "name": "JMETER_SIZE",
 	    "displayName": "JMeter instance size",
 	    "description": "Number of hosts to stress per JMeter instance",
@@ -146,6 +194,36 @@
 	    "displayName": "JMeter throughput",
 	    "description": "Thread throuput rate for JMeter",
 	    "value": "60"
+	},
+	{
+	    "name": "VEGETA_RPS",
+	    "displayName": "Vegeta requests/second",
+	    "description": "Vegeta HTTP load testing tool requests per second (per all targets combined).",
+	    "value": "100"
+	},
+	{
+	    "name": "WRK_DELAY",
+	    "displayName": "Delay between requests for wrk",
+	    "description": "Delay between requests for the wrk client in ms.",
+	    "value": "1000"
+	},
+	{
+	    "name": "WRK_TARGETS",
+	    "displayName": "Regex to select target routes",
+	    "description": "Regex to select target routes for wrk.",
+	    "value": "."
+	},
+	{
+	    "name": "WRK_KEEPALIVE",
+	    "displayName": "Enable http-keepalive for wrk",
+	    "description": "Enable http-keepalive for wrk.",
+	    "value": "y"
+	},
+	{
+	    "name": "WRK_TLS_SESSION_REUSE",
+	    "displayName": "Enable TLS session reuse for wrk",
+	    "description": "Enable TLS session reuse for wrk.",
+	    "value": "n"
 	},
 	{
 	    "name": "ROUTER_IP",

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -44,7 +44,6 @@ def get_route():
     routes_list = [y for y in (x.strip() for x in routes_output.splitlines()) if y]
     return localhost, router_ip, routes_list
 
-
 def create_template(templatefile, num, parameters, globalvars):
     if globalvars["debugoption"]:
         print "create_template function called"
@@ -68,6 +67,7 @@ def create_template(templatefile, num, parameters, globalvars):
                         size = int(value)
             num = math.ceil(float(len(jmeter_ips))/size)
         globalvars["podnum"] += num
+        create_wlg_targets("wlg-targets", globalvars)
 
     data = {}
     timings = {}
@@ -115,6 +115,17 @@ def create_template(templatefile, num, parameters, globalvars):
 
         i = i + 1
         tmpfile.close()
+
+
+def create_wlg_targets(cm_targets, globalvars):
+    namespace = globalvars["namespace"]
+    try:
+        oc_command("oc delete configmap %s -n %s" % (cm_targets, namespace), globalvars)
+    except subprocess.CalledProcessError:
+        pass
+    ret = oc_command("oc get routes --all-namespaces --no-headers | awk '{print $3}' | oc create configmap %s --from-file=targets.txt=/dev/stdin -n %s" %
+          (cm_targets, namespace), globalvars)
+    return ret
 
 
 def create_service(servconfig, num, globalvars):


### PR DESCRIPTION
- OpenShift 3.4 and earlier - use -v flag for oc process
- OpenShift 3.5 and later - use -p flag

Added benefit of storing major/minor version of OpenShift or Kubernetes