### PR TITLE
Fix parameter flag

### DIFF
--- a/openshift_scalability/cluster-loader.py
+++ b/openshift_scalability/cluster-loader.py
@@ -74,6 +74,8 @@ if "tuningsets" in testconfig:
 if user and passwd and master:
     login = login(user, passwd, master)
 
+globalvars["version_info"] = check_oc_version(globalvars)
+
 for config in testconfig["projects"]:
     if "tuning" in config:
         globalvars["tuningset"] = find_tuning(testconfig["tuningsets"],\


### PR DESCRIPTION
For OCP 3.4/Kube 1.4 and earlier, use -v for oc process.

For OCP 3.5/Kube 1.5 and earlier, use -p for oc process