### PR TITLE
Extend tests to enable running tests between hostip-to-hostip

### DIFF
--- a/networking/synthetic/README.md
+++ b/networking/synthetic/README.md
@@ -47,6 +47,9 @@ $ python network-test.py podIP --master <master-hostname/ansible_pod-hostname> -
 
 # svcIP-to-svcIP, node-to-node, 6 pod pairs
 $ python network-test.py svcIP --master <master-hostname/ansible_pod-hostname> --node <node1-hostname> <node2-hostname> --pods 6
+
+# nodeIP-to-nodeIP, To run the tests between any two machines(vms or baremetals) 
+$ python network-test.py nodeIP --master <machine1-ip> --node <machine2-ip>
 ```
 
 ### Running all the combinations

--- a/networking/synthetic/network-test.py
+++ b/networking/synthetic/network-test.py
@@ -2,64 +2,59 @@ import ansible.runner
 import json
 import argparse
 
-from ansible                 import playbook
-from ansible.inventory.host  import Host
+from ansible import playbook
+from ansible.inventory.host import Host
 from ansible.inventory.group import Group
-from ansible.inventory       import Inventory
-from ansible.callbacks       import AggregateStats
-from ansible.callbacks       import PlaybookCallbacks
-from ansible.callbacks       import PlaybookRunnerCallbacks
-from ansible                 import utils
-from decimal                 import Decimal   
-from email.policy import default
+from ansible.inventory import Inventory
+from ansible.callbacks import AggregateStats
+from ansible.callbacks import PlaybookCallbacks
+from ansible.callbacks import PlaybookRunnerCallbacks
+from ansible import utils
+from decimal import Decimal
+
 
 class NetworkTest(object):
     def __init__(self, playbook):
         self.inventory = Inventory(host_list=[])
         self.playbook = playbook
-        
-        self.sender_group = Group(name = 'sender')
+
+        self.sender_group = Group(name='sender')
         self.inventory.add_group(self.sender_group)
-        
-        self.receiver_group = Group(name = 'receiver')
+
+        self.receiver_group = Group(name='receiver')
         self.inventory.add_group(self.receiver_group)
-        
-        self.master_group = Group(name = 'master')
+
+        self.master_group = Group(name='master')
         self.inventory.add_group(self.master_group)
-        
+
         self.inv_vars = dict()
 
-        
     def set_inventory_vars(self, inv_vars):
         self.inv_vars.update(inv_vars)
 
-
     def add_sender(self, sender):
-        sender_host = Host(name = sender)
+        sender_host = Host(name=sender)
         self.sender_group.add_host(sender_host)
 
-
     def add_receiver(self, receiver):
-        receiver_host = Host(name = receiver)
+        receiver_host = Host(name=receiver)
         self.receiver_group.add_host(receiver_host)
 
-        
     def add_master(self, master):
-        master_host = Host(name = master)
+        master_host = Host(name=master)
         self.master_group.add_host(master_host)
-
 
     def run(self):
         stats = AggregateStats()
         playbook_cb = PlaybookCallbacks(verbose=utils.VERBOSITY)
         runner_cb = PlaybookRunnerCallbacks(stats, verbose=utils.VERBOSITY)
 
-        pb = playbook.PlayBook(playbook = self.playbook,
-                               stats = stats,
-                               callbacks = playbook_cb,
-                               runner_callbacks = runner_cb,
-                               inventory = self.inventory,
-                               extra_vars = self.inv_vars,
+        pb = playbook.PlayBook(playbook=self.playbook,
+                               stats=stats,
+                               callbacks=playbook_cb,
+                               runner_callbacks=runner_cb,
+                               inventory=self.inventory,
+                               extra_vars=self.inv_vars,
                                check=False)
 
         pr = pb.run()
@@ -71,36 +66,36 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('test_type',
-                        choices = ['podIP', 'svcIP'])
-    
+                        choices=['podIP', 'svcIP', 'nodeIP'])
+
     parser.add_argument('-v',
                         '--version',
                         required = False,
                         dest = 'os_version',
                         default = '3.5',
                         help = 'OpenShift version')
-    
+
     parser.add_argument('-m',
                         '--master',
-                        required = True,
-                        dest = 'test_master',
-                        help = 'OpenShift master node')
-    
+                        required=True,
+                        dest='test_master',
+                        help='OpenShift master node')
+
     parser.add_argument('-n',
                         '--node',
-                        required = False,
-                        nargs = '*',
-                        dest = 'test_nodes',
-                        help = 'OpenShift node')
+                        required=False,
+                        nargs='*',
+                        dest='test_nodes',
+                        help='OpenShift node')
 
     parser.add_argument('-p',
                         '--pods',
-                        required = True,
-                        nargs = '*',
-                        dest = 'pod_numbers',
-                        type = int,
-                        help = 'Sequence of pod numbers to test')
-    
+                        required=False,
+                        nargs='*',
+                        dest='pod_numbers',
+                        type=int,
+                        help='Sequence of pod numbers to test')
+
     return parser.parse_args()
 
 
@@ -109,7 +104,7 @@ def set_sender(master, nodes):
         return master
     else:
         return nodes[0]
-    
+
 
 def set_receiver(master, nodes):
     if nodes is None:
@@ -118,7 +113,7 @@ def set_receiver(master, nodes):
         return nodes[0]
     elif len(nodes) == 2:
         return nodes[1]
-    
+
 
 def set_pbench_remote(master, nodes):
     if nodes is None:
@@ -127,7 +122,7 @@ def set_pbench_remote(master, nodes):
         return nodes[0]
     elif len(nodes) == 2:
         return nodes[1]
-    
+
 
 def set_sender_region(master, nodes):
     if nodes is None:
@@ -136,7 +131,7 @@ def set_sender_region(master, nodes):
         if len(nodes) == 2 and nodes[0] == nodes[1]:
             return 'both'
         return 'sender'
-    
+
 
 def set_receiver_region(master, nodes):
     if nodes is None:
@@ -146,10 +141,12 @@ def set_receiver_region(master, nodes):
             return 'both'
         return 'receiver'
 
-    
+
 def set_playbook(test_type):
     if test_type == 'podIP':
         return 'pod-ip-test-setup.yaml'
+    elif test_type == 'nodeIP':
+        return 'node-ip-test-setup.yaml'
     else:
         return 'svc-ip-test-setup.yaml'
 
@@ -164,6 +161,8 @@ def set_pbench_label(test_type, nodes):
             return 'pod-to-pod-LB'
         elif len(nodes) == 2 and nodes[0] != nodes[1]:
             return 'pod-to-pod-NN'
+    elif test_type == 'nodeIP':
+            return 'node-to-node'
     else:
         if nodes is None:
             return 'svc-to-svc-LB'
@@ -173,50 +172,55 @@ def set_pbench_label(test_type, nodes):
             return 'svc-to-svc-LB'
         elif len(nodes) == 2 and nodes[0] != nodes[1]:
             return 'svc-to-svc-NN'
-        
+
 def get_option(version):
     if Decimal(version) >= 3.5 :
         return '-p'
     else:
-        return '-v'                    
+        return '-v'
+
+
+def run_tests(args, inventory_vars, sender_host, receiver_host):
+    test_playbook = set_playbook(args.test_type)
+    master_host = args.test_master
+    nettest = NetworkTest(test_playbook)
+    nettest.add_sender(sender_host)
+    nettest.add_receiver(receiver_host)
+    nettest.add_master(master_host)
+    nettest.set_inventory_vars(inventory_vars)
+    nettest.run()
+
 
 def main():
     args = parse_args()
-    
-    sender_host = set_sender(args.test_master, args.test_nodes)
-    receiver_host = set_receiver(args.test_master, args.test_nodes)
-    master_host = args.test_master
-    
+
     pbench_remote = set_pbench_remote(args.test_master, args.test_nodes)
     pbench_base_label = set_pbench_label(args.test_type, args.test_nodes)
-    
+
     sender_region = set_sender_region(args.test_master, args.test_nodes)
     receiver_region = set_receiver_region(args.test_master, args.test_nodes)
-    
-    oc_process_option = get_option(args.os_version);
+    sender_host = set_sender(args.test_master, args.test_nodes)
+    receiver_host = set_receiver(args.test_master, args.test_nodes)
 
-    test_playbook = set_playbook(args.test_type)
+    if args.test_type != 'nodeIP':
+        oc_process_option = get_option(args.os_version);
+        for pod_number in args.pod_numbers:
+            pbench_label = '{0}_PODS_{1}'.format(pbench_base_label, pod_number)
 
-    for pod_number in args.pod_numbers:
-        pbench_label = '{0}_PODS_{1}'.format(pbench_base_label, pod_number)
-        
-        inventory_vars = { 'sender_region': sender_region,
-                           'receiver_region': receiver_region,
-                           'uperf_pod_number': pod_number,
-                           'oc_process_option': oc_process_option,
-                           'pbench_label': pbench_label,
-                           'pbench_remote': pbench_remote }
-    
-        nettest = NetworkTest(test_playbook)
+            inventory_vars = {'sender_region': sender_region,
+                              'receiver_region': receiver_region,
+                              'uperf_pod_number': pod_number,
+                              'oc_process_option': oc_process_option,
+                              'pbench_label': pbench_label,
+                              'pbench_remote': pbench_remote}
+            run_tests(args, inventory_vars, sender_host, receiver_host)
+    else:
+            inventory_vars = {'sender_host': sender_host,
+                              'receiver_host': receiver_host,
+                              'pbench_label': pbench_base_label,
+                              'pbench_remote': pbench_remote}
+            run_tests(args, inventory_vars, sender_host, receiver_host)
 
-        nettest.add_sender(sender_host)
-        nettest.add_receiver(receiver_host)
-        nettest.add_master(master_host)
-    
-        nettest.set_inventory_vars(inventory_vars)
-
-        nettest.run()
-    
 
 if __name__ == '__main__':
     main()

--- a/networking/synthetic/node-ip-test-setup.yaml
+++ b/networking/synthetic/node-ip-test-setup.yaml
@@ -1,0 +1,85 @@
+---
+- hosts: master:sender:receiver
+  sudo: yes
+  user: root
+  tasks:
+    - name: Copy ssh public key to local systems
+      copy: src=id_rsa.pub dest=/root/.ssh/.
+
+- hosts: sender:receiver
+  remote_user: root
+  tasks:
+  - name: Install openssh client and servers
+    shell: yum install --assumeyes openssh-clients openssh-server
+
+  - name: Yum clean-up
+    shell: yum clean all
+
+  - name: Enable epel
+    shell: curl -o /etc/yum.repos.d/pbench.repo https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo
+
+  - name: Install configtools, pbench-agent, pbench-uperf
+    shell: yum install --assumeyes configtools pbench-agent pbench-uperf
+
+  - name: Source pbench profile.
+    shell: source /etc/profile.d/pbench-agent.sh
+
+- hosts: master
+  remote_user: root
+  tasks:
+  - name: Create SSH directory /root/.ssh if it does not exist
+    file: path=/root/.ssh state=directory
+
+  - stat: path=/root/.ssh/id_rsa
+    register: id_rsa
+
+  - name: Create /root/.ssh/id_rsa if it does not exist
+    shell: ssh-keygen -f /root/.ssh/id_rsa -N ''
+    when: id_rsa.stat.islnk is not defined
+
+  - name: Register pbench tools on master
+    shell: pbench-register-tool-set --label={{ pbench_label }}
+
+  - name: Register pbench tools on remote
+    shell: pbench-register-tool-set --label={{ pbench_label }} --remote={{ pbench_remote }}
+    when: pbench_remote != "None"
+
+  - name: Run pbench-uperf for TCP benchmarks
+    shell: >
+      pbench-uperf
+      --test-types=stream,rr
+      --runtime=30
+      --message-sizes=64,1024,16384
+      --protocols=tcp
+      --instances=2
+      --samples=3
+      --max-stddev=10
+      --clients={{ sender_host }}
+      --servers={{ receiver_host }}
+      --config={{ pbench_label }}_TCP
+
+  - name: Run pbench-uperf for UDP benchmarks
+    shell: >
+      pbench-uperf
+      --test-types=stream,rr
+      --runtime=30
+      --message-sizes=64,1024,16384
+      --protocols=udp
+      --instances=2
+      --samples=3
+      --max-stddev=10
+      --clients={{ sender_host }}
+      --servers={{ receiver_host }}
+      --config={{ pbench_label }}_UDP
+
+  - name: Copy pbench results
+    shell: pbench-copy-results
+
+  - name: Kill pbench tools
+    shell: pbench-kill-tools
+
+  - name: Clear pbench tools
+    shell: pbench-clear-tools
+
+  - name: Clear pbench results
+    shell: pbench-clear-results


### PR DESCRIPTION
Add support to enable running test harness between any two hosts.
These hosts can be baremetal servers or VMs.

Also some improvements are being made as per pep8 guidelines,
for example removing extra white spaces, extra blank lines,
undesires spaces around '='.
