### PR TITLE
pvc template to create desired number of PVCs

### DIFF
--- a/openshift_scalability/content/pvc-templates/pvc-parameters.yaml
+++ b/openshift_scalability/content/pvc-templates/pvc-parameters.yaml
@@ -1,0 +1,19 @@
+projects:
+  - num: 1
+    basename: pvcproject
+    tuning: default
+    templates:
+      - num: 1
+        file: ./content/fio/pvc-template.json
+        parameters:
+          - STORAGE_CLASS: "cnsclass" # this is name of storage class to use
+          - STORAGE_SIZE: "1Gi" # this is size of PVC mounted inside pod
+
+tuningsets:
+  - name: default
+    templates:
+      stepping:
+        stepsize: 5
+        pause: 1 min
+      rate_limit:
+        delay: 1000 ms

--- a/openshift_scalability/content/pvc-templates/pvc-template.json
+++ b/openshift_scalability/content/pvc-templates/pvc-template.json
@@ -1,0 +1,68 @@
+{
+    "apiVersion": "v1",
+    "kind": "Template",
+    "metadata": {
+        "name": "pvc-template",
+        "labels": {
+            "name": "pvc-template"
+        },
+        "annotations": {
+            "descriptions": "Template to create PVC and bound it to PV in desired namespace",
+            "tags": "pvc, pvc-template"
+        }
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "${PVC_NAME}",
+                "annotations": {
+                    "volume.beta.kubernetes.io/storage-class": "${STORAGE_CLASS}"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "${ACCESS_MODES}"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${STORAGE_SIZE}"
+                    }
+                }
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "PVC_NAME",
+            "description": "PVC name",
+            "required": true,
+            "from": "pvc[a-z0-9]{10}",
+            "generate": "expression"
+        },
+        {
+            "name" : "STORAGE_CLASS",
+            "description": "Storagecclass to use - here we expect storageclass name",
+            "required": true,
+            "value": "storageclassname"
+        },
+        {
+            "name": "STORAGE_SIZE",
+            "description": "The PVC size - default is 1Gi",
+            "required": true,
+            "value": "1Gi"
+        },
+        {
+            "name": "ACCESS_MODES",
+            "description": "PVC access mode - this will have different values for different storage backends",
+            "required": true,
+            "value": "ReadWriteOnce"
+        },
+        {
+            "name": "IDENTIFIER",
+            "description": "Number to append to the name of resources",
+            "value": "1"
+        }
+    ]
+}


### PR DESCRIPTION
Example of : 

- pvc template to create desired number of PVCs and bound them to PVs

- it uses storageclass and dynamic provisioning when creating PVC

- This will help when we want *only* to check how fast PV/PVC are created/allocated when different storageclasses ( originating from different storage backends ) are used 


Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>