### PR TITLE
Trigger ARP issues in OCP template and cluster-loader config cleanup.

### DIFF
--- a/openshift_scalability/config/router-arp_stress.yaml
+++ b/openshift_scalability/config/router-arp_stress.yaml
@@ -2,7 +2,7 @@
 # Linux kernel's neigh/default/gc_thresh[1-3] settings.  Tested on a 6 node EC2 instance. 
 
 projects:
-  - num: 10
+  - num: 11
     basename: arp
     tuning: default
     ifexists: delete

--- a/openshift_scalability/content/router/router-arp_stress.json
+++ b/openshift_scalability/content/router/router-arp_stress.json
@@ -24,12 +24,6 @@
                         "protocol": "TCP",
                         "port": 8080,
                         "targetPort": 8080
-                    },
-                    {
-                        "name": "second",
-                        "protocol": "TCP",
-                        "port": 8888,
-                        "targetPort": 8888
                     }
                 ]
             }
@@ -64,10 +58,6 @@
                             {
                                 "name": "PORT",
                                 "value": "${PORT}"
-                            },
-                            {
-                                "name": "SECOND_PORT",
-                                "value": "${SECOND_PORT}"
                             }
                         ],
                         "image": "openshift/hello-openshift",
@@ -76,10 +66,6 @@
                         "ports": [
                             {
                                 "containerPort": 8080,
-                                "protocol": "TCP"
-                            },
-                            {
-                                "containerPort": 8888,
                                 "protocol": "TCP"
                             }
                         ],
@@ -121,12 +107,6 @@
             "displayName": "Listen on PORT",
             "description": "Tells the container to start httpd server on port PORT",
             "value": "8080"
-        },
-        {
-            "name": "SECOND_PORT",
-            "displayName": "Listen also on SECOND_PORT",
-            "description": "Tells the container to start httpd server also on port SECOND_PORT",
-            "value": "8888"
         },
         {
             "name": "APPLICATION_DOMAIN",


### PR DESCRIPTION
- 1000 routes not enough to trigger the ARP issue in some cases, increasing to 1100.
- Removing second port from router-arp_stress.json.