### PR TITLE
Update stress pod seLinux security context

### DIFF
--- a/openshift_scalability/content/quickstarts/stress/stress-pod.json
+++ b/openshift_scalability/content/quickstarts/stress/stress-pod.json
@@ -125,7 +125,7 @@
                             },
                             "privileged": false,
                             "seLinuxOptions": {
-                                "level": "s0:c9,c4"
+                                "level": "s0:c21,c5"
                             }
                         },
                         "terminationMessagePath": "/dev/termination-log"


### PR DESCRIPTION
Running on latest OCP, starting the stress pod gives:

Error from server (Forbidden): pods "centos-stress-" is forbidden: unable to validate against any security context constraint: [seLinuxOptions.level: Invalid value: "s0:c9,c4": seLinuxOptions.level on centos-str
ess does not match required level.  Found s0:c9,c4, wanted s0:c21,c0]

Updating it to s0:c21,s0 results in a message that it wanted s0:c21,c5.  Need to investigate that

Updated the stress pod definition to match the second message.  Stress pod starts OK.   
