### PR TITLE
disable StrictHostKeyChecking on scp

### DIFF
--- a/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
+++ b/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
@@ -207,7 +207,7 @@ main() {
         -Jresults_file="${results_filename}".jtl -l "${results_filename}".jtl \
         -j "${results_filename}".log -Jgun="${GUN}" || die $? "${RUN} failed: $?"
 
-      have_server "${GUN}" && scp -p *.jtl *.log *.png ${GUN}:${PBENCH_DIR}
+      have_server "${GUN}" && scp -o StrictHostKeyChecking=false -p *.jtl *.log *.png ${GUN}:${PBENCH_DIR}
       ;; 
 
     wrk)


### PR DESCRIPTION
I've had recent failures with host key issues on the scp of results back to the cluster-loader host.   Disabling StrictHostKeyChecking takes care of it.