### PR TITLE
Remove extraneous securityContext

### DIFF
--- a/openshift_scalability/content/quickstarts/stress/stress-pod.json
+++ b/openshift_scalability/content/quickstarts/stress/stress-pod.json
@@ -113,21 +113,6 @@
                                 "mountPath": "/opt/wlg"
                             }
                         ],
-                        "securityContext": {
-                            "capabilities": {
-                                "drop": [
-                                    "KILL",
-                                    "MKNOD",
-                                    "SETGID",
-                                    "SETUID",
-                                    "SYS_CHROOT"
-                                ]
-                            },
-                            "privileged": false,
-                            "seLinuxOptions": {
-                                "level": "s0:c9,c4"
-                            }
-                        },
                         "terminationMessagePath": "/dev/termination-log"
                     }
                 ],


### PR DESCRIPTION
The stress pod template was created from a pod export which, for some reason, contains seLinuxOptions and some other security context information that is not needed.   This PR removes the securityContext from the template.