### PR TITLE
Fix kernel upgrade repo and ansible 2.3.0.0 compatibility

### DIFF
--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -48,6 +48,7 @@
      ignore_errors: true
  
    - name: waiting for server to come back
+     become: false
      local_action: wait_for
      args:
        host: "{{ inventory_hostname }}"

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -52,9 +52,9 @@
       dest: /etc/yum.repos.d
 
   - name: install rhel-7-update-kernel-repo
-    copy:
-      src: rhel-7-update-kernel.repo
-      dest: /etc/yum.repos.d/rhel-7-update-kernel.repo
+    template:
+      src: etc/yum.repos.d/rhel7-update-kernel.repo.j2
+      dest: /etc/yum.repos.d/rhel7-update-kernel.repo
     when: docker_storage_driver == "overlay" or update_kernel == "true"
   
   #- name: install pbench-internal repo
@@ -77,7 +77,7 @@
       src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/client-key.pem"
       dest: /var/lib/yum/
       remote_src: true
-  when: "{{ vm_install | default(True) | bool }}"
+  when: vm_install | default(True) | bool
 
 - name: install EPEL repo
   copy:
@@ -93,4 +93,4 @@
   template:
     src: etc/yum.repos.d/all.repo.j2
     dest: /etc/yum.repos.d/all.repo
-  when: not vm_install
+  when: not vm_install | default(True) | bool

--- a/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/rhel7-update-kernel.repo.j2
+++ b/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/rhel7-update-kernel.repo.j2
@@ -4,3 +4,5 @@ baseurl={{ kernel_url }}
 enabled=1
 gpgcheck=0
 skip_if_unavailable=1
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem


### PR DESCRIPTION
New kernel repo is actually a template not just a file to be copied over given the parameter.

The final repo-install step errors out if (vm_install) is not set in the inventory (which it's not by default). 

Finally in Ansible 2.3.0.0 using jinja templates in when statements has been deprecated so that has been resolved.