### PR TITLE
Adding Multiple-host HTTP(s) Benchmarking tool (mb) to WLG.

### DIFF
--- a/openshift_scalability/config/stress-mb.yaml
+++ b/openshift_scalability/config/stress-mb.yaml
@@ -1,0 +1,28 @@
+projects:
+  - num: 1
+    basename: centos-stress
+    ifexists: delete
+    tuning: default
+    templates:
+      - num: 1
+        file: ./content/quickstarts/stress/stress-pod.json
+        parameters:
+         - RUN: "mb"                    # which app to execute inside WLG pod
+         - RUN_TIME: "120"              # benchmark run-time in seconds
+         - PLACEMENT: "test"            # Placement of the WLG pods based on a node's label
+         - MB_DELAY: "100"              # maximum delay between client requests in ms
+         - MB_TARGETS: "^cakephp-"      # extended RE (egrep) to filter target routes
+         - MB_CONNS_PER_TARGET: "1"     # how many connections per target route
+         - MB_KA_REQUESTS: "100"        # how many HTTP keep-alive requests to send before sending "Connection: close".
+         - MB_TLS_SESSION_REUSE: "y"    # use TLS session reuse [yn]
+         - MB_RAMP_UP: "60"             # thread ramp-up time in seconds
+         - URL_PATH: "/"                # target path for HTTP(S) requests
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 5
+        pause: 0 min
+      rate_limit:
+        delay: 0 ms

--- a/openshift_scalability/content/centos-stress/Dockerfile
+++ b/openshift_scalability/content/centos-stress/Dockerfile
@@ -17,6 +17,8 @@ RUN yum install -y bc gcc git gnuplot go java-1.8.0-openjdk lua-devel make \
     git clone https://github.com/wg/wrk.git && \
       cd wrk && git reset --hard 50305ed1d89408c26067a970dcd5d9dbea19de9d && \
       patch -p1 < ../svt/utils/wrk/patches/wrk-4.0.2.diff && make && cp ./wrk /usr/local/bin && cd .. && \
+    git clone -b stable https://github.com/jmencak/mb.git && \
+      cd mb && make && cp ./mb /usr/local/bin && cd .. && \
     cd && rm -rf build && \
     yum remove gcc go lua-devel make patch -y && \
     yum clean all

--- a/openshift_scalability/content/centos-stress/README.md
+++ b/openshift_scalability/content/centos-stress/README.md
@@ -33,6 +33,44 @@ Add description.
 
 Add description.
 
+### mb
+
+This test harness makes use of Multiple-host HTTP(s) Benchmarking tool [mb](https://github.com/jmencak/mb).  [stress-mb.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/stress-mb.yaml) is an example of the cluster-loader configuration file.
+
+#### Sample run
+
+Allow access to cluster-loader autogen synchronisation primitive on port 9090
+and label OCP nodes for WLG pods.
+
+```
+# firewall-cmd --zone=public --add-port=9090/tcp --permanent && systemctl reload firewalld
+$ oc label node ip-172-31-20-98.us-west-2.compute.internal placement=test
+```
+
+Build centos-stress docker image.  Note that the step to push the image to a
+docker registry is omitted here.
+
+```
+$ docker build -t svt/centos-stress ~/svt/openshift_scalability/content/centos-stress
+```
+
+Deploy sample (quickstart) applications across OCP cluster nodes.
+```
+$ cd ~/svt/openshift_scalability
+$ ./cluster-loader.py -vf config/master-vert.yaml
+```
+
+Choose `RUN_TIME`, `MB_TARGETS` and optionally `WLG_IMAGE` and other
+[stress-pod.json](https://github.com/openshift/svt/blob/master/openshift_scalability/content/quickstarts/stress/stress-pod.json) variables as needed.  Start cluster-loader in autogen mode.
+
+```
+$ vi config/stress-mb.yaml # edit RUN_TIME, MB_TARGETS, WLG_IMAGE and/or other variables as needed
+$ ./cluster-loader.py -vaf config/stress-mb.yaml
+```
+
+The results from the WLG pods will be uploaded to the host running cluster-loader to directory defined by an environment variable `benchmark_run_dir`.  If this variable is unset it defaults to `/tmp`.
+
+
 ### wrk
 
 This test harness makes use of a modern HTTP benchmarking tool [wrk](https://github.com/wg/wrk) with support for scripting in LUA. [stress-wrk.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/stress-wrk.yaml) is an example of the cluster-loader configuration file.

--- a/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
+++ b/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
@@ -210,6 +210,53 @@ main() {
       have_server "${GUN}" && scp -o StrictHostKeyChecking=false -p *.jtl *.log *.png ${GUN}:${PBENCH_DIR}
       ;; 
 
+    mb)
+      local mb_log=/tmp/${HOSTNAME}-${gateway}.log
+      local requests_awk=requests-mb.awk
+      local dir_out=${RUN}-${HOSTNAME:-${IDENTIFIER:-0}}
+      local targets_lst=/opt/wlg/targets.txt
+      local requests_json=$dir_out/requests.json
+      local mb=/usr/local/bin/mb
+      local env_out=$dir_out/environment	# for debugging
+      local results_csv=$dir_out/results.csv
+      local graph_dir=gnuplot/${RUN}
+      local graph_sh=gnuplot/$RUN/graph.sh
+      local interval=10				# sample interval for d3js graphs [s]
+      local tls_session_reuse=""
+
+      rm -rf ${dir_out} && mkdir -p ${dir_out}
+      ulimit -n 1048576				# use the same limits as HAProxy pod
+      #sysctl -w net.ipv4.tcp_tw_reuse=1	# safe to use on client side
+      env > $env_out				# dump out the environment for debugging
+
+      local tls_session_reuse=$(use_option "true" MB_TLS_SESSION_REUSE n n)		# TLS session reuse is disabled by default
+
+      cat ${targets_lst} | grep -E "${MB_TARGETS:-.}" | awk \
+        -vtls_session_reuse=${tls_session_reuse:-false} \
+        -vka_requests=${MB_KA_REQUESTS:-100} -vclients=${MB_CLIENTS:-10} \
+        -vpath=${URL_PATH:-/} -vdelay_min=0 -vdelay_max=${MB_DELAY:-1000} \
+        -f ${requests_awk} > ${requests_json} || \
+        die $? "${RUN} failed: $?: unable to retrieve wrk targets list \`targets'"
+
+      $timeout \
+        $mb \
+          -d${RUN_TIME:-600} \
+          -r${MB_RAMP_UP:-0} \
+          -i ${requests_json} \
+          -o ${results_csv}.$$
+      $(timeout_exit_status) || die $? "${RUN} failed: $?"
+      LC_ALL=C sort -t, -n -k1 ${results_csv}.$$ > ${results_csv}
+      rm -f ${results_csv}.$$
+      $graph_sh ${graph_dir} ${results_csv} $dir_out/graphs $interval
+      xz -0 -T0 ${results_csv}
+
+      have_server "${GUN}" && \
+        scp -rp ${dir_out} ${GUN}:${PBENCH_DIR}
+      $(timeout_exit_status) || die $? "${RUN} failed: scp: $?"
+
+      announce_finish
+      ;;
+
     wrk)
       local wrk_log=/tmp/${HOSTNAME}-${gateway}.log
       local requests_awk=requests.awk

--- a/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
+++ b/openshift_scalability/content/centos-stress/root/docker-entrypoint.sh
@@ -251,7 +251,7 @@ main() {
       xz -0 -T0 ${results_csv}
 
       have_server "${GUN}" && \
-        scp -rp ${dir_out} ${GUN}:${PBENCH_DIR}
+        scp -o StrictHostKeyChecking=false -rp ${dir_out} ${GUN}:${PBENCH_DIR}
       $(timeout_exit_status) || die $? "${RUN} failed: scp: $?"
 
       announce_finish
@@ -308,7 +308,7 @@ main() {
       xz -0 -T0 < ${results_csv} > ${results_csv}.xz && rm -f ${results_csv}
 
       have_server "${GUN}" && \
-        scp -rp ${dir_out} ${GUN}:${PBENCH_DIR}
+        scp -o StrictHostKeyChecking=false -rp ${dir_out} ${GUN}:${PBENCH_DIR}
       $(timeout_exit_status) || die $? "${RUN} failed: scp: $?"
 
       announce_finish

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/graph.sh
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/graph.sh
@@ -1,0 +1,445 @@
+#!/bin/sh
+
+#################################################################################
+### WARNING: the code for generating time-based graphs below assumes the data ###
+###          has been sorted by something like: "LC_ALL=C sort -t, -n -k1"    ###
+#################################################################################
+
+### binaries ####################################################################
+pctl_bin=pctl
+pctls="90 95 99"
+
+### functions ###################################################################
+graph_d3js_time() {
+  local graph_title="$1"
+  local graph_data_html="$2"
+  local graph_data_in="$3"
+  local dir_out="$4"
+
+  mkdir -p $dir_out
+
+  cat >$dir_out/$graph_data_html<<EOF
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link href="/static/css/v0.3/jschart.css" rel="stylesheet" type="text/css" media="all">
+  </head>
+  <body>
+    <script src="/static/js/v0.3/d3.min.js"></script>
+    <script src="/static/js/v0.3/d3-queue.min.js"></script>
+    <script src="/static/js/v0.3/saveSvgAsPng.js"></script>
+    <script src="/static/js/v0.3/jschart.js"></script>
+    <center><h2>$graph_title</h2></center>
+    <div id="chart_1">
+      <script>
+        create_jschart("lineChart", "timeseries", "chart_1", "$graph_title", null, null, { csvfiles: [ "$graph_data_in" ], threshold: 0 });
+      </script>
+    </div>
+  </body>
+</html>
+EOF
+}
+
+graph_d3js_xy() {
+  local graph_title="$1"
+  local graph_data_html="$2"
+  local graph_data_in="$3"
+  local dir_out="$4"
+
+  mkdir -p $dir_out
+
+  cat >$dir_out/$graph_data_html<<EOF
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link href="/static/css/v0.3/jschart.css" rel="stylesheet" type="text/css" media="all">
+  </head>
+  <body>
+    <script src="/static/js/v0.3/d3.min.js"></script>
+    <script src="/static/js/v0.3/d3-queue.min.js"></script>
+    <script src="/static/js/v0.3/saveSvgAsPng.js"></script>
+    <script src="/static/js/v0.3/jschart.js"></script>
+    <center><h2>$graph_title</h2></center>
+    <div id="jschart_xy">
+      <script>
+        create_jschart(0, "xy", "jschart_xy", "$graph_title", null, null, { csvfiles: [ "$graph_data_in" ] });
+      </script>
+    </div>
+  </body>
+</html>
+EOF
+}
+graph_total_latency_pctl() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local graph_conf=$(realpath ${graph_dir}/total_latency_pctl.conf)
+  local graph_data_in=$dir_out/total_latency_pctl.txt
+  local graph_image_out=$dir_out/total_latency_pctl.png
+ 
+  mkdir -p $dir_out
+  rm -f $graph_data_in
+  printf "# http_status	90%%	95%%	99%%\n" > $graph_data_in
+  for err in $(awk -F, '{print $3}' $results | sort -u)
+  do
+    printf "%s\t" $err >> $graph_data_in
+    awk -F, "{if(\$3 == $err) {print (\$2/1000)}}" < $results  | \
+      $pctl_bin -l $pctls >> $graph_data_in
+  done
+  
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out'" \
+    $graph_conf
+}
+
+graph_time_bytes_hits_latency() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local graph_data_in=$dir_out/time_bhl.txt
+
+  local graph_bytes_conf_out=$(realpath ${graph_dir}/time_bytes_out.conf)
+  local graph_image_out_bytes_out=$dir_out/time_bytes_out.png
+
+  local graph_bytes_conf_in=$(realpath ${graph_dir}/time_bytes_in.conf)
+  local graph_image_out_bytes_in=$dir_out/time_bytes_in.png
+
+  local graph_hits_conf=$(realpath ${graph_dir}/time_hits.conf)
+  local graph_image_out_hits=$dir_out/time_hits.png
+
+  local graph_latency_conf=$(realpath ${graph_dir}/time_latency.conf)
+  local graph_image_out_latency=$dir_out/time_latency.png
+
+  mkdir -p $dir_out
+  printf "# time	bytes_out	bytes_in	hits	latency\n" > $graph_data_in
+  awk '
+{
+  time=int($1/1000000)	# get seconds [original value in us]
+  latency += ($2/1000)	# get miliseconds [original value in us]
+  bytes_out += $4
+  bytes_in += $5
+  hits += 1
+  if(time_prev == 0) {
+    time_prev=time		# we just started
+  }
+  if(time_prev != time) {
+    printf "%ld\t%ld\t%ld\t%ld\t%lf\n", time_prev, bytes_out, bytes_in, hits, (latency/hits)
+    time_prev=time
+    bytes_out=0
+    bytes_in=0
+    hits=0
+    latency=0
+  }
+} 
+BEGIN {
+  FS=","
+  time_prev=0
+  bytes_out=0
+  bytes_in=0
+  hits=0
+  latency=0
+}
+' $results >> $graph_data_in
+
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out_bytes_out'" \
+    $graph_bytes_conf_out
+
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out_bytes_in'" \
+    $graph_bytes_conf_in
+
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out_hits'" \
+    $graph_hits_conf
+
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out_latency'" \
+    $graph_latency_conf
+}
+
+graph_total_hits() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local graph_conf=$(realpath ${graph_dir}/total_hits.conf)
+  local graph_data_in=$dir_out/total_hits.txt
+  local graph_image_out_hits=$dir_out/total_hits.png
+
+  mkdir -p $dir_out
+  rm -f $graph_data_in
+
+  printf "# http_status	count\n" > $graph_data_in
+  for err in $(awk -F, '{print $3}' $results | sort -n -u)
+  do
+    printf "%s\t" $err >> $graph_data_in
+    awk -F, "
+{
+  if(\$3 == $err) {i++}
+}"'
+BEGIN {
+  i=0
+}
+END {
+  printf "%d\n", i
+}' < $results  >> $graph_data_in
+  done
+
+  gnuplot \
+    -e "data_in='$graph_data_in'" \
+    -e "graph_out='$graph_image_out_hits'" \
+    $graph_conf
+}
+
+graph_time_bytes_in_per_endpoint() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local interval="$4"	# sample interval for d3js graphs [s]
+  local graph_data_base=time_bytes_in_per_endpoint
+  local graph_data_in=$dir_out/${graph_data_base}.csv
+  local unique_endpoints=unique_endpoints.txt
+
+  mkdir -p $dir_out
+  rm -f $graph_data_in
+  graph_d3js_time "Bytes received by client per second" ${graph_data_base}.html ${graph_data_in##*/} $dir_out
+
+  awk -F, '{a[$6]}END{for (v in a) {print v}}' $results | LC_ALL=C sort > $unique_endpoints
+  awk -F, -v "intvl=${interval:-1}" '
+function print_header(name) {
+  printf "timestamp_ms" 
+  for (v in a) {
+    printf ",%s",v
+  }
+  printf "\n"
+}
+
+function print_stats(time) {
+  printf "%d",time
+  for (v in a) {
+    if(a[v]["hits"]) {
+      printf ",%lf",a[v]["bytes"]/intvl
+    } else {
+      printf ",0"
+    }
+  }
+  printf "\n"
+}
+
+function clear_stats() {
+  for (v in a) {
+    a[v]["bytes"]=0
+    a[v]["hits"]=0
+  }
+}
+
+function main(name) {
+  time=int($1/1000000/intvl)*intvl	# get seconds [original value in us]
+  a[name]["bytes"]+=$5			# get bytes in
+  a[name]["hits"]++
+
+  if(time_prev == 0) {
+    time_prev=time			# we just started
+  }
+  if(time_prev != time) {
+    print_stats(time*1000)		# we have a time in seconds, d3js needs ms
+    time_prev=time
+    clear_stats()
+  }
+}
+
+NR==FNR{ # fill a[] with keys from the first file
+  a[$1]["bytes"]
+  a[$1]["hits"]
+  next
+}
+FNR==1{print_header()}			# just started processing the second file ($results)
+
+main($6)				# processing of the second file
+
+BEGIN {
+  time_prev=0
+}
+
+END {
+}
+' $unique_endpoints $results >> $graph_data_in
+
+  rm -f $unique_endpoints 
+}
+
+graph_time_hits_per_endpoint() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local interval="$4"	# sample interval for d3js graphs [s]
+  local graph_data_base=time_hits_per_endpoint
+  local graph_data_in=$dir_out/${graph_data_base}.csv
+  local unique_endpoints=unique_endpoints.txt
+
+  mkdir -p $dir_out
+  rm -f $graph_data_in
+  graph_d3js_time "Client requests per second" ${graph_data_base}.html ${graph_data_in##*/} $dir_out
+
+  awk -F, '{a[$6]}END{for (v in a) {print v}}' $results | LC_ALL=C sort > $unique_endpoints
+  awk -F, -v "intvl=${interval:-1}" '
+function print_header(name) {
+  printf "timestamp_ms" 
+  for (v in a) {
+    printf ",%s",v
+  }
+  printf "\n"
+}
+
+function print_stats(time) {
+  printf "%d",time
+  for (v in a) {
+    if(a[v]["hits"]) {
+      printf ",%d",a[v]["hits"]/intvl
+    } else {
+      printf ",0"
+    }
+  }
+  printf "\n"
+}
+
+function clear_stats() {
+  for (v in a) {
+    a[v]["hits"]=0
+  }
+}
+
+function main(name) {
+  time=int($1/1000000/intvl)*intvl	# get seconds [original value in us]
+  a[name]["hits"]++
+
+  if(time_prev == 0) {
+    time_prev=time			# we just started
+  }
+  if(time_prev != time) {
+    print_stats(time*1000)		# we have a time in seconds, d3js needs ms
+    time_prev=time
+    clear_stats()
+  }
+}
+
+NR==FNR{ # fill a[] with keys from the first file
+  a[$1]["hits"]
+  next
+}
+FNR==1{print_header()}			# just started processing the second file ($results)
+
+main($6)				# processing of the second file
+
+BEGIN {
+  time_prev=0
+}
+
+END {
+}
+' $unique_endpoints $results >> $graph_data_in
+
+  rm -f $unique_endpoints 
+}
+
+graph_time_latency_per_endpoint() {
+  local graph_dir="$1"
+  local results="$2"
+  local dir_out="$3"
+  local interval="$4"	# sample interval for d3js graphs [s]
+  local graph_data_base=time_latency_per_endpoint
+  local graph_data_in=$dir_out/${graph_data_base}.csv
+  local unique_endpoints=unique_endpoints.txt
+
+  mkdir -p $dir_out
+  rm -f $graph_data_in
+  graph_d3js_time "Latency [ms]" ${graph_data_base}.html ${graph_data_in##*/} $dir_out
+
+  awk -F, '{a[$6]}END{for (v in a) {print v}}' $results | LC_ALL=C sort > $unique_endpoints
+  awk -F, -v "intvl=${interval:-1}" '
+function print_header(name) {
+  printf "timestamp_ms" 
+  for (v in a) {
+    printf ",%s",v
+  }
+  printf "\n"
+}
+
+function print_stats(time) {
+  printf "%d",time
+  for (v in a) {
+    if(a[v]["hits"]) {
+      printf ",%lf",a[v]["latency"]/a[v]["hits"]
+    } else {
+      printf ",0"
+    }
+  }
+  printf "\n"
+}
+
+function clear_stats() {
+  for (v in a) {
+    a[v]["latency"]=0
+    a[v]["hits"]=0
+  }
+}
+
+function main(name) {
+  time=int($1/1000000/intvl)*intvl	# get seconds [original value in us]
+  a[name]["latency"]+=$2/1000		# get miliseconds [original value in us]
+  a[name]["hits"]++
+
+  if(time_prev == 0) {
+    time_prev=time			# we just started
+  }
+  if(time_prev != time) {
+    print_stats(time*1000)		# we have a time in seconds, d3js needs ms
+    time_prev=time
+    clear_stats()
+  }
+}
+
+NR==FNR{ # fill a[] with keys from the first file
+  a[$1]["latency"]
+  a[$1]["hits"]
+  next
+}
+FNR==1{print_header()}			# just started processing the second file ($results)
+
+main($6)				# processing of the second file
+
+BEGIN {
+  time_prev=0
+}
+
+END {
+}
+' $unique_endpoints $results >> $graph_data_in
+
+  rm -f $unique_endpoints 
+}
+
+main() {
+  local graph_dir="${1:-.}"
+  local results_csv="${2:-results_sample.csv}"
+  local dir_out="${3:-$(dirname $results_csv)/client-${IDENTIFIER:-0}}"
+  local interval=${4:-1}
+
+  mkdir -p $dir_out
+  graph_total_latency_pctl $graph_dir $results_csv $dir_out
+  graph_time_bytes_hits_latency $graph_dir $results_csv $dir_out
+  graph_total_hits $graph_dir $results_csv $dir_out
+
+  graph_time_bytes_in_per_endpoint $graph_dir $results_csv $dir_out $interval
+  graph_time_hits_per_endpoint $graph_dir $results_csv $dir_out $interval
+  graph_time_latency_per_endpoint $graph_dir $results_csv $dir_out $interval
+}
+
+main "$@"

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_bytes_in.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_bytes_in.conf
@@ -1,0 +1,15 @@
+set terminal png truecolor
+set output graph_out
+set autoscale
+set xdata time
+set title "Bytes received by client per second"
+set style data fsteps
+set xlabel "Time"
+set timefmt "%s"
+#set format x "%H:%M:%S"
+set format x "%H:%M"
+set ylabel "Bytes"
+set grid
+set key off
+set xtics 120
+plot data_in using 1:3 title "bytes in"

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_bytes_out.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_bytes_out.conf
@@ -1,0 +1,15 @@
+set terminal png truecolor
+set output graph_out
+set autoscale
+set xdata time
+set title "Bytes sent by client per second"
+set style data fsteps
+set xlabel "Time"
+set timefmt "%s"
+#set format x "%H:%M:%S"
+set format x "%H:%M"
+set ylabel "Bytes"
+set grid
+set key off
+set xtics 120
+plot data_in using 1:2 title "bytes out"

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_hits.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_hits.conf
@@ -1,0 +1,15 @@
+set terminal png truecolor
+set output graph_out
+set autoscale
+set xdata time
+set title "Client requests per second"
+set style data fsteps
+set xlabel "Time"
+set timefmt "%s"
+#set format x "%H:%M:%S"
+set format x "%H:%M"
+set ylabel "Requests"
+set grid
+set key off
+set xtics 120
+plot data_in using 1:4 title "requests"

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_latency.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/time_latency.conf
@@ -1,0 +1,15 @@
+set terminal png truecolor
+set output graph_out
+set autoscale
+set xdata time
+set title "Server latency [ms]"
+set style data fsteps
+set xlabel "Time"
+set timefmt "%s"
+#set format x "%H:%M:%S"
+set format x "%H:%M"
+set ylabel "Latency [ms]"
+set grid
+set key off
+set xtics 120
+plot data_in using 1:5 title "latency"

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/total_hits.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/total_hits.conf
@@ -1,0 +1,10 @@
+set terminal png truecolor
+set output graph_out
+set grid
+set title "Server response distribution"
+set style data histograms
+set style fill solid 1.00 border -1
+set xlabel "HTTP status code"
+set ylabel "Number of responses"
+set key off
+plot data_in using 2:xtic(1)

--- a/openshift_scalability/content/centos-stress/root/gnuplot/mb/total_latency_pctl.conf
+++ b/openshift_scalability/content/centos-stress/root/gnuplot/mb/total_latency_pctl.conf
@@ -1,0 +1,10 @@
+set terminal png truecolor
+set output graph_out
+set grid
+set title "Server latency percentiles [ms]"
+set style data histograms
+set style fill solid 1.00 border -1
+set xlabel "HTTP status code"
+set ylabel "Latency [ms]"
+set key left
+plot data_in using 2:xtic(1) title "90%", '' using 3 title "95%", '' using 4 title "99%"

--- a/openshift_scalability/content/centos-stress/root/requests-mb.awk
+++ b/openshift_scalability/content/centos-stress/root/requests-mb.awk
@@ -142,7 +142,7 @@
   printf "    }"
   i++
 }
-/^jws-app-tomcat8-/ {
+/^jws-app-/ {
   if (i) {printf "\n  },\n" }
   printf "  {\n"
   printf "    \"scheme\": \"http\",\n"
@@ -162,7 +162,7 @@
   printf "    }"
   i++
 }
-/^secure-jws-app-tomcat8-/ {
+/^secure-jws-app-/ {
   if (i) {printf "\n  },\n" }
   printf "  {\n"
   printf "    \"scheme\": \"https\",\n"

--- a/openshift_scalability/content/centos-stress/root/requests-mb.awk
+++ b/openshift_scalability/content/centos-stress/root/requests-mb.awk
@@ -1,0 +1,207 @@
+/^nginx-route-/ { # insecure routes
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+#  printf "    \"host_from": \"192.168.0.102\",
+  printf "    \"scheme\": \"http\",\n"
+#  printf "    \"tls-session-reuse\": %s,\n", tls_session_reuse
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+#  printf "    \"headers\": {\n"
+#  printf "      \"Content-Type\": \"application/x-www-form-urlencoded\",\n"
+#  printf "      \"X-Custom-Header-2\": \"test 2\"\n"
+#  printf "    },\n"
+#  printf "    \"body\": \"name=user&email=user@example.com\",\n"
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^secure-nginx-route-/ { # secure routes
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"https\",\n"
+  printf "    \"tls-session-reuse\": %s,\n", tls_session_reuse
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 443,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^cakephp-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^dancer-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"POST\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"headers\": {\n"
+  printf "      \"Content-Type\": \"application/x-www-form-urlencoded\"\n"
+  printf "    },\n"
+  printf "    \"body\": \"name=user&email=user@example.com\",\n"
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^django-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"/\",\n"
+  printf "    \"keep-alive-requests\": 100,\n"
+  printf "    \"clients\": 10,\n"
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^eap-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"POST\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"headers\": {\n"
+  printf "      \"Content-Type\": \"application/x-www-form-urlencoded\"\n"
+  printf "    },\n"
+  printf "    \"body\": \"summary=eap:+get+stuff+done&description=eap:+omg+so+many+things\",\n"
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^nodejs-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^rails-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^jws-app-tomcat8-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"http\",\n"
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 80,\n"
+  printf "    \"method\": \"POST\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"headers\": {\n"
+  printf "      \"Content-Type\": \"application/x-www-form-urlencoded\"\n"
+  printf "    },\n"
+  printf "    \"body\": \"summary=jws-app-tomcat8:+get+stuff+done&description=jws-app-tomcat8:+omg+so+many+things\",\n"
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^secure-jws-app-tomcat8-/ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"https\",\n"
+  printf "    \"tls-session-reuse\": %s,\n", tls_session_reuse
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 443,\n"
+  printf "    \"method\": \"POST\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"headers\": {\n"
+  printf "      \"Content-Type\": \"application/x-www-form-urlencoded\"\n"
+  printf "    },\n"
+  printf "    \"body\": \"summary=secure-jws-app-tomcat8:+get+stuff+done&description=secure-jws-app-tomcat8:+omg+so+many+things\",\n"
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+/^127./ {
+  if (i) {printf "\n  },\n" }
+  printf "  {\n"
+  printf "    \"scheme\": \"https\",\n"
+  printf "    \"tls-session-reuse\": %s,\n", tls_session_reuse
+  printf "    \"host\": \"%s\",\n", $1
+  printf "    \"port\": 8443,\n"
+  printf "    \"method\": \"GET\",\n"
+  printf "    \"path\": \"%s\",\n", path
+  printf "    \"keep-alive-requests\": %s,\n", ka_requests
+  printf "    \"clients\": %s,\n", clients
+  printf "    \"delay\": {\n"
+  printf "      \"min\": %s,\n", delay_min
+  printf "      \"max\": %s\n", delay_max
+  printf "    }"
+  i++
+}
+BEGIN { i=0; printf "[\n" }
+END {
+  if (i) { printf "\n  }" }
+  printf "\n]\n"
+}

--- a/openshift_scalability/content/centos-stress/root/requests.awk
+++ b/openshift_scalability/content/centos-stress/root/requests.awk
@@ -136,7 +136,7 @@
   printf "    }"
   i++
 }
-/^jws-app-tomcat8-/ {
+/^jws-app-/ {
   if (i) {printf "\n  },\n" }
   printf "  {\n"
 #  printf "    \"host_from": \"192.168.0.102\",
@@ -155,7 +155,7 @@
   printf "    }"
   i++
 }
-/^secure-jws-app-tomcat8-/ {
+/^secure-jws-app-/ {
   if (i) {printf "\n  },\n" }
   printf "  {\n"
 #  printf "    \"host_from": \"192.168.0.102\",

--- a/openshift_scalability/content/quickstarts/stress/stress-pod.json
+++ b/openshift_scalability/content/quickstarts/stress/stress-pod.json
@@ -59,6 +59,30 @@
                                 "value": "${JMETER_TPS}"
                             },
                             {
+                                "name": "MB_DELAY",
+                                "value": "${MB_DELAY}"
+                            },
+                            {
+                                "name": "MB_TARGETS",
+                                "value": "${MB_TARGETS}"
+                            },
+                            {
+                                "name": "MB_CONNS_PER_TARGET",
+                                "value": "${MB_CONNS_PER_TARGET}"
+                            },
+                            {
+                                "name": "MB_KA_REQUESTS",
+                                "value": "${MB_KA_REQUESTS}"
+                            },
+                            {
+                                "name": "MB_TLS_SESSION_REUSE",
+                                "value": "${MB_TLS_SESSION_REUSE}"
+                            },
+                            {
+                                "name": "MB_RAMP_UP",
+                                "value": "${MB_RAMP_UP}"
+                            },
+                            {
                                 "name": "WRK_DELAY",
                                 "value": "${WRK_DELAY}"
                             },
@@ -208,6 +232,42 @@
             "displayName": "JMeter throughput",
             "description": "Thread throuput rate for JMeter",
             "value": "60"
+        },
+        {
+            "name": "MB_DELAY",
+            "displayName": "Delay between requests for mb",
+            "description": "Delay between requests for the mb client in ms.",
+            "value": "1000"
+        },
+        {
+            "name": "MB_TARGETS",
+            "displayName": "Regex to select target routes",
+            "description": "Regex to select target routes for mb.",
+            "value": "."
+        },
+        {
+            "name": "MB_CONNS_PER_TARGET",
+            "displayName": "Connections per target route for mb",
+            "description": "Connections per target route for mb.",
+            "value": "y"
+        },
+        {
+            "name": "MB_KA_REQUESTS",
+            "displayName": "How many HTTP keep-alive requests to send per connection",
+            "description": "How many HTTP keep-alive requests to send per connection before sending Connection: close header.",
+            "value": "y"
+        },
+        {
+            "name": "MB_TLS_SESSION_REUSE",
+            "displayName": "Enable TLS session reuse for mb",
+            "description": "Enable TLS session reuse for mb.",
+            "value": "n"
+        },
+        {
+            "name": "MB_RAMP_UP",
+            "displayName": "Thread ramp-up time in seconds",
+            "description": "Thread ramp-up time in seconds.",
+            "value": "n"
         },
         {
             "name": "WRK_DELAY",


### PR DESCRIPTION
While we already have an existing HTTP test harness (wrk-based), it has its limitations, and I'd like to eventually replace it.

With mb, I was trying to address the following:
- no 2k host limit
- much lower memory footprint (it can still be quite high, especially with higher number of threads)
- faster (especially with no keep-alive mode)
- no keep-alive mode fixed
- ramp-up (both all thread and hit delay ramp-up)
- possibility to specify the number of keep-alive requests to send
- improved *.csv output (added plain and TLS connection establishment delays,
  thread id, connection id, sent_bytes, ...)
- tracking the number of bytes sent in addition to received
- ability to select TLS session reuse and keep-alive modes per target
- select the number of worker threads automatically (can be overriden)
