### PR TITLE
Add support to image provisioner to generate atomic image

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -47,3 +47,5 @@ image_version=v3.3.0.30
 # image naming
 # set openshift_version to the rpm version, sometimes with a trailing -N
 openshift_version=3.3.0.30-1
+# set atomic to True for atomic image
+atomic=False

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -45,3 +45,5 @@ network_interface=bond0.7
 dns_domain=cluster.local
 kube_svc_ip=10.192.0.1
 existing_dns_ip=10.1.16.4
+# set atomic to True for atomic image
+atomic=False

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -48,3 +48,5 @@ image_version=v3.3.0.30
 # image naming
 # set openshift_version to the rpm version, sometimes with a trailing -N
 openshift_version=3.3.0.30-1
+# set atomic to True for atomic image
+atomic=False

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -22,9 +22,9 @@
       vpc_subnet_id: "{{ vpc_subnet_id }}"
       image: "{{ base_image }}"
       volumes:
-        - device_name: /dev/sdb
+        - device_name: "{{ '/dev/sda1' if atomic | default(False) else '/dev/sdb' }}"
           volume_type: gp2
-          volume_size: 30
+          volume_size: 50
           delete_on_termination: true
       wait: yes
       user_data: "{{ lookup('file', '../cloud-init/user-data-aws') }}"
@@ -42,21 +42,31 @@
   - name: add host to group
     add_host: name={{ ami_instance.tagged_instances.0.public_dns_name }} groups=just_created
 
+- hosts: localhost
+  user: root
+  vars:
+    internal_image: false
+  roles:
+    - { role: repo-install, when: atomic | default(False) | bool }
+    - { role: clone-repos, when: atomic | default(False) | bool }
+
 - hosts: just_created
   remote_user: root
   vars:
     internal_image: false
   roles:
-    - repo-install
-    - os-kickstart
-    - collectd-install
-    - clone-repos
-    - pbench-config
-    - docker-config
-    - aos-ansible
-    - ansible-update
-    - openshift-package-install
-    - seal-image
+    - { role: repo-install, when: not atomic | default(False) | bool }
+    - { role: os-kickstart }
+    - { role: clone-repos, when: not atomic | default(False) | bool }
+    - { role: docker-config }
+    - { role: pbench-config, when: not atomic | default(False) | bool }
+    - { role: aos-ansible }
+    - { role: ansible-update, when: not atomic | default(False) | bool }
+    - { role: openshift-package-install, when: not atomic | default(False) | bool }
+    - { role: pbench-kickstart, when: atomic | default(False) | bool }
+    - { role: collectd-install }
+    - { role: seal-image, when: not atomic | default(False) | bool }
+    - { role: clean-env, when: atomic | default(False) | bool }
 
 - hosts: localhost
   connection: local
@@ -76,7 +86,7 @@
       region: "{{ region }}"
       state: present
       description: This was provisioned {{ ansible_date_time.iso8601 }}
-      name: ocp-{{ openshift_version }}-{{ ami_type }}-gold-auto
+      name: ocp-{{ openshift_version }}-{{ ami_type }}-gold
       wait: yes
     register: amioutput
 

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -1,19 +1,26 @@
 ---
-- name: provision gold images
+- hosts: localhost
   user: root
-  hosts: all
   vars:
     internal_image: false
-
   roles:
-    - repo-install
-    - os-kickstart
-    - collectd-install
-    - clone-repos
-    - pbench-config
-    - docker-config
-    - aos-ansible
-    - svt-setup
-    - openshift-package-install
-    - seal-image
+    - { role: repo-install, when: atomic | default(False) | bool }
+    - { role: clone-repos, when: atomic | default(False) | bool }
 
+- hosts: all
+  user: root
+  vars:
+    internal_image: false
+  roles:
+    - { role: repo-install, when: not atomic | default(False) | bool }
+    - { role: os-kickstart }
+    - { role: clone-repos, when: not atomic | default(False) | bool }
+    - { role: docker-config }
+    - { role: pbench-config, when: not atomic | default(False) | bool}
+    - { role: aos-ansible }
+    - { role: pbench-kickstart, when: atomic | default(False) | bool }
+    - { role: collectd-install }
+    - { role: ansible-update, when: not atomic | default(False) | bool }
+    - { role: openshift-package-install, when: not atomic | default(False) | bool }
+    - { role: seal-image, when: not atomic | default(False) | bool }
+    - { role: clean-env, when: atomic | default(False) | bool }

--- a/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
@@ -1,15 +1,39 @@
 ---
-- name: customize aos-ansible inventory file
-  template: src=hosts.j2 dest={{ aos_ansible_inventory }}
+- block:
+   - name: customize aos-ansible inventory file
+     template: 
+       src: hosts.j2 
+       dest: "{{ aos_ansible_inventory }}"
+ 
+   - name: run aos-ansible
+     shell: ansible-playbook -i {{ aos_ansible_inventory }} {{ aos_ansible_path }}/playbooks/aws_install_prep.yml --connection=local
+  when: not atomic | default(False) | bool  
 
-- name: run aos-ansible
-  shell: ansible-playbook -i {{ aos_ansible_inventory }} {{ aos_ansible_path }}/playbooks/aws_install_prep.yml --connection=local
+- block:
+   - name: customize aos-ansible inventory file
+     template: 
+       src: hosts.j2 
+       dest: "{{ aos_ansible_inventory }}"
+
+   - name: run aos-ansible
+     shell: ansible-playbook -i {{ aos_ansible_inventory }} {{ aos_ansible_path }}/playbooks/aws_install_prep.yml
+  when: atomic | default(False) | bool
+  delegate_to: localhost 
 
 - name: add iptables rule for cluster-loader
-  iptables: chain=INPUT protocol=tcp match=tcp ctstate=NEW destination_port=9090 jump=ACCEPT
+  iptables: 
+    chain: INPUT 
+    protocol: tcp 
+    match: tcp 
+    ctstate: NEW 
+    destination_port: 9090 
+    jump: ACCEPT
 
 - name: save iptables rules
   shell: iptables-save > /etc/sysconfig/iptables
 
 - name: enable iptables service
-  service: name=iptables state=started enabled=yes
+  service: 
+    name: iptables 
+    state: started 
+    enabled: yes

--- a/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
+++ b/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
@@ -19,4 +19,8 @@ qe_repo_image_versions={{ image_version }}
 docker_login=no
 
 [masters]
+{% if not atomic %}
 localhost
+{% else %}
+{{ inventory_hostname }}
+{% endif %}

--- a/image_provisioner/playbooks/roles/clean-env/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/clean-env/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: delete repos
+  file:
+    path: '/root/{{ item }}'
+    state: absent
+  with_items:
+    - svt-private
+    - openshift-ansible
+    - kubernetes/contrib
+  delegate_to: localhost

--- a/image_provisioner/playbooks/roles/clone-repos/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/clone-repos/tasks/main.yaml
@@ -1,15 +1,52 @@
 ---
+- name: stat svt repo
+  stat:
+    path: /root/svt
+  register: svt
+
 - name: clone svt repo
-  git: repo=https://github.com/openshift/svt dest=/root/svt update=yes
+  git: 
+    repo: https://github.com/openshift/svt 
+    dest: /root/svt 
+    update: yes
+  when: svt.stat.exists == False
+
+- name: stat svt-private repo
+  stat:
+    path: /root/svt-private
+  register: svt_private
 
 - name: clone svt-private repo
-  git: repo=https://{{ github_token }}@github.com/openshift/svt-private dest=/root/svt-private update=yes force=yes
+  git: 
+    repo: https://{{ github_token }}@github.com/openshift/svt-private 
+    dest: /root/svt-private 
+    update: yes 
+    force: yes
+  when: svt_private.stat.exists == False
+
+- name: stat openshift-ansible repo
+  stat:
+    path: /root/openshift-ansible 
+  register: openshift_ansible
 
 - name: clone openshift-ansible repo
-  git: repo=https://@github.com/openshift/openshift-ansible dest=/root/openshift-ansible update=yes
-
+  git: 
+    repo: https://@github.com/openshift/openshift-ansible 
+    dest: /root/openshift-ansible 
+    update: yes
+  when: openshift_ansible.stat.exists == False
+  
 #- name: clone kubernetes repo
 #  git: repo=https://github.com/kubernetes/kubernetes dest=/root/kubernetes/kubernetes update=yes
 
+- name: stat kubernetes contrib repo
+  stat:
+    path: /root/kubernetes/contrib
+  register: kube_contrib
+
 - name: clone kubernetes contrib repo
-  git: repo=https://github.com/kubernetes/contrib dest=/root/kubernetes/contrib update=yes
+  git: 
+    repo: https://github.com/kubernetes/contrib 
+    dest: /root/kubernetes/contrib 
+    update: yes
+  when: kube_contrib.stat.exists == False

--- a/image_provisioner/playbooks/roles/collectd-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/collectd-install/tasks/main.yaml
@@ -1,20 +1,31 @@
 ---
-- name: install collectd
-  yum: name={{ item }} state=latest
-  with_items:
-    - collectd
+- block:
+   - name: install collectd
+     yum: name={{ item }} state=latest
+     with_items:
+       - collectd
 
-- name: Configure collectd.conf
-  template:
-    src={{config_type}}.collectd.conf.j2
-    dest=/etc/collectd.conf
-    owner=root
-    group=root
-    mode=0644
-  become: true
+   - name: Configure collectd.conf
+     template:
+       src={{config_type}}.collectd.conf.j2
+       dest=/etc/collectd.conf
+       owner=root
+       group=root
+       mode=0644
+     become: true
 
-- name: allow collectd to use the network
-  shell: setsebool -P collectd_tcp_network_connect on
+   - name: allow collectd to use the network
+     shell: setsebool -P collectd_tcp_network_connect on
 
-- name: set collectd service
-  service: name=collectd state={{ collectd_status }}
+   - name: set collectd service
+     service: name=collectd state={{ collectd_status }}
+  when: not atomic | default(False) | bool
+
+- block:
+   # not using docker_image module of ansible since that requires docker-py package to be installed on the atomic host
+   - name: pull collectd image from dockerhub
+     command: docker pull ravielluri/image:collectd
+
+   - name: tag the image as collectd:latest
+     command: docker tag ravielluri/image:collectd collectd:latest
+  when: atomic | default(False) | bool

--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -22,15 +22,23 @@
       state: latest
   when: not atomic | default(False) | bool
 
+
 - name: stop docker service
   systemd:
     name: docker
     state: stopped
 
-- name: reset docker storage
-  command: atomic storage reset
-  when: atomic | default(False) | bool
+- block:
+   - name: extend root volume
+     command: lvextend -l +60%FREE /dev/atomicos/root
 
+   - name: resize the filesystem
+     command: xfs_growfs /dev/atomicos/root
+
+   - name: reset docker storage
+     command: atomic storage reset
+  when: atomic | default(False) | bool
+  
 - name: check that docker-storage has been deleted
   stat:
     path: /etc/sysconfig/docker-storage

--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -1,69 +1,92 @@
 ---
-- name: yum update
-  yum: name=* state=latest
+- block:
+  - name: yum update
+    yum: 
+      name: '*' 
+      state: latest
 
-- name: install packages
-  yum: name={{ item }} state=latest
-  with_items:
-    - ansible
-    - bind-utils
-    - blktrace
-    - ethtool
-    - findutils
-    - git
-    - gnuplot
-    - golang
-    - httpd-tools
-    - hwloc
-    - iotop
-    - iptables-services
-    - kernel
-    - ltrace
-    - mailx
-    - maven
-    - netsniff-ng
-    - net-tools
-    - ntp
-    - ntpdate
-    - numactl
-    - pciutils
-    - perf
-    - pbench-agent
-    - pbench-sysstat
-    - python-docker-py
-    - python-flask
-    - python-pip
-    - python-rbd
-    - python2-boto3
-    - powertop
-    - psmisc
-    - rpm-build
-    - screen
-    - sos
-    - strace
-    - tar
-    - tcpdump
-    - tmux
-    - vim-enhanced
-    - xauth
-    - wget
-    - yum-utils
-    - rpmdevtools
-    - iperf3
+  - name: install packages
+    yum: 
+      name: "{{ item }}"
+      state: latest
+    with_items:
+      - ansible
+      - bind-utils
+      - blktrace
+      - ethtool
+      - findutils
+      - git
+      - gnuplot
+      - golang
+      - httpd-tools
+      - hwloc
+      - iotop
+      - iptables-services
+      - kernel
+      - ltrace
+      - mailx
+      - maven
+      - netsniff-ng
+      - net-tools
+      - ntp
+      - ntpdate
+      - numactl
+      - pciutils
+      - perf
+      - pbench-agent
+      - pbench-sysstat
+      - python-docker-py
+      - python-flask
+      - python-pip
+      - python-rbd
+      - python2-boto3
+      - powertop
+      - psmisc
+      - rpm-build
+      - screen
+      - sos
+      - strace
+      - tar
+      - tcpdump
+      - tmux
+      - vim-enhanced
+      - xauth
+      - wget
+      - yum-utils
+      - rpmdevtools
+      - iperf3
+      - docker
+      - ceph-common
+      - glusterfs-fuse
+      - iscsi-initiator-utils
 
-- name: install pbench internal
-  yum: name=pbench-agent-internal state=latest
-  when: internal_image | bool
+  - name: install pbench internal
+    yum: 
+      name: pbench-agent-internal 
+      state: latest
+    when: internal_image | bool
 
-- name: install persistent storage clients
-  yum: name={{ item }} state=latest
-  with_items:
-    - ceph-common
-    - glusterfs-fuse
-    - iscsi-initiator-utils
+  # yum module doesn't support clean
+  - name: clean yum cache
+    command: yum --enablerepo=ndokos-pbench-interim clean all 
+
+  - name: update pbench-agent to get the latest changes
+    yum: 
+      name: pbench-agent 
+      enablerepo: ndokos-pbench-interim
+      state: latest
+
+  - name: never expire yum metadata
+    lineinfile: 
+      dest: /etc/yum.conf 
+      line: "metadata_expire=never"
+  when: not atomic | default(False) | bool
 
 - name: install bashrc file
-  copy: src=bashrc dest=/root/.bashrc force=yes
+  template: 
+    src: bashrc 
+    dest: /root/.bashrc 
+    force: yes
 
 - name: download ssh keys
   get_url:
@@ -73,8 +96,12 @@
     headers: 'Authorization:token {{ github_token }},Accept:application/vnd.github.v3.raw'
 
 - name: disable strict host checking
-  lineinfile: dest=/etc/ssh/ssh_config line="StrictHostKeyChecking no"
+  lineinfile: 
+    dest: /etc/ssh/ssh_config 
+    line: "StrictHostKeyChecking no"
 
-- name: never expire yum metadata
-  lineinfile: dest=/etc/yum.conf line="metadata_expire=never"
-
+- name: copy svt repo to atomic host
+  synchronize:
+    src: /root/svt
+    dest: /var/home/
+  when: atomic | default(False) | bool

--- a/image_provisioner/playbooks/roles/os-kickstart/templates/bashrc
+++ b/image_provisioner/playbooks/roles/os-kickstart/templates/bashrc
@@ -31,7 +31,9 @@ alias cl='clear ; ls -al'
 alias ur='uname -r'
 alias rehash='source ~/.bashrc'
 alias rs='rsync -avz --progress --stats'
+{% if not atomic | bool %}
 alias vi='vim'
+{% endif %}
 alias iftop='sudo iftop'
 export SVN_EDITOR=vim
 alias less='less -FiX'

--- a/image_provisioner/playbooks/roles/pbench-kickstart/files/pbench-agent-daemonset.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/files/pbench-agent-daemonset.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: pbench-agent
+  labels:
+    name: pbench-agent
+spec:
+  template:
+    metadata:
+      labels:
+        name: pbench-agent
+    spec:
+      hostNetwork: true
+      containers:
+      - image: pbench-agent
+        name: pbench-agent
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: kube-config
+            mountPath: /root/.kube
+          - name: proc-mount
+            mountPath: /proc_host
+          - name: ssh-keys
+            mountPath: /root/.ssh
+        ports:
+          - containerPort: 2022
+      volumes:
+        - name: kube-config
+          hostPath:
+            path: /root/.kube
+        - name: proc-mount
+          hostPath:
+            path: /proc
+        - name: ssh-keys
+          hostPath:
+            path: /root/.ssh
+      nodeSelector: 
+        type: pbench

--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: create directory to store pbench results, store openshift templates for pbench
+  file: 
+    path: "{{ item }}"
+    state: directory
+  with_items:
+     - /var/lib/pbench-agent
+     - /var/home/openshift-templates/pbench
+
+- name: copy openshift template for pbench
+  copy: 
+    src: pbench-agent-daemonset.yml  
+    dest: /var/home/openshift-templates/pbench 
+    owner: root 
+    group: root 
+    mode: 0644
+     
+# not using docker_image module of ansible since that requires docker-py package to be installed on the atomic host
+- name: pull pbench-agent from dockerhub
+  command: docker pull ravielluri/image:agent
+
+- name: tag pbench-agent image
+  command: docker tag ravielluri/image:agent pbench-agent:latest
+
+- name: pull pbench-controller image from dockerhub
+  command: docker pull ravielluri/image:controller
+
+- name: tag pbench-controller image
+  command: docker tag ravielluri/image:controller pbench-controller:latest

--- a/image_provisioner/playbooks/roles/repo-install/files/ndokos-pbench-interim.repo
+++ b/image_provisioner/playbooks/roles/repo-install/files/ndokos-pbench-interim.repo
@@ -1,0 +1,10 @@
+[ndokos-pbench-interim]
+name=Copr repo for pbench-interim owned by ndokos
+baseurl=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench-interim/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench-interim/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -2,105 +2,115 @@
 - name: clean yum cache
   shell:  yum clean all
   ignore_errors: true
+  when: not atomic | default(False) | bool 
 
 - block:
   - name: download aos-ansible tarball
     get_url:
-      url: https://api.github.com/repos/openshift/aos-ansible/tarball/master 
+      url: https://api.github.com/repos/openshift/aos-ansible/tarball/master
       dest: /root/aos-ansible.tar.gz
       headers: 'Authorization:token {{ github_token }},Accept:application/vnd.github.v3.raw'
-  
+
   - name: create aos-ansible directory
     file:
       path: "{{ aos_ansible_path }}"
       state: directory
-  
+
   - name: extract aos-ansible tarball
     command: /usr/bin/tar xzf /root/aos-ansible.tar.gz --strip=1 -C {{ aos_ansible_path }}
-  
-  - name: install internal rhel7-cdn repo
-    template:
-      src: etc/yum.repos.d/rhel7-internal-cdn.repo.j2
-      dest: /etc/yum.repos.d/rhel7-internal-cdn.repo
-      owner: root
-      group: root
-      mode: 0644
-    when: internal_image | bool
-  
-  - name: install external rhel-cdn repo
-    copy:
-      src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/rhel7next.repo"
-      dest: /etc/yum.repos.d/
-      remote_src: true
-    when: not (internal_image | bool)
-  
-  - name: install external dockernext repo
-    copy:
-      src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/dockernext.repo"
-      dest: /etc/yum.repos.d/
-      remote_src: true
-    when: not (internal_image | bool)
-  
-  - name: install oso-rhui-rhel-server-releases
-    copy:
-      src: oso-rhui-rhel-server-releases.repo
-      dest: /etc/yum.repos.d
-  
-  - name: install oso-rhui-rhel-server-extras
-    copy:
-      src: oso-rhui-rhel-server-extras.repo
-      dest: /etc/yum.repos.d
 
-  - name: install rhel-7-update-kernel-repo
-    template:
-      src: etc/yum.repos.d/rhel7-update-kernel.repo.j2
-      dest: /etc/yum.repos.d/rhel7-update-kernel.repo
-    when: docker_storage_driver == "overlay" or update_kernel == "true"
-
-  - name: install rhel-7-gluster-3.1-latest mirror.openshift.com repo
-    copy:
-      src: rhel7-gluster.repo
-      dest: /etc/yum.repos.d
-
-  - name: install rhel-7-ceph-2-latest mirror.openshift.com repo
-    copy:
-      src: rhel7-ceph.repo
-      dest: /etc/yum.repos.d
+  - block:  
+      - name: install internal rhel7-cdn repo
+        template:
+          src: etc/yum.repos.d/rhel7-internal-cdn.repo.j2
+          dest: /etc/yum.repos.d/rhel7-internal-cdn.repo
+          owner: root
+          group: root
+          mode: 0644
+        when: internal_image | bool
   
-  #- name: install pbench-internal repo
-  #  template:
-  #    src: etc/yum.repos.d/pbench.repo.j2
-  #    dest: /etc/yum.repos.d/pbench.repo
-  #    owner: root
-  #    group: root
-  #    mode: 0644
-  #  when: internal_image | bool
+      - name: install external rhel-cdn repo
+        copy:
+          src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/rhel7next.repo"
+          dest: /etc/yum.repos.d/
+          remote_src: true
+        when: not (internal_image | bool)
   
-  - name: copy aos yum repository certificate
-    copy:
-      src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/client-cert.pem"
-      dest: /var/lib/yum/
-      remote_src: true
+      - name: install external dockernext repo
+        copy:
+          src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/dockernext.repo"
+          dest: /etc/yum.repos.d/
+          remote_src: true
+        when: not (internal_image | bool)
+  
+      - name: install oso-rhui-rhel-server-releases
+        copy:
+          src: oso-rhui-rhel-server-releases.repo
+          dest: /etc/yum.repos.d
+  
+      - name: install oso-rhui-rhel-server-extras
+        copy:
+          src: oso-rhui-rhel-server-extras.repo
+          dest: /etc/yum.repos.d
 
-  - name: copy aos yum repository key
-    copy:
-      src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/client-key.pem"
-      dest: /var/lib/yum/
-      remote_src: true
+      - name: install rhel-7-update-kernel-repo
+        template:
+          src: etc/yum.repos.d/rhel7-update-kernel.repo.j2
+          dest: /etc/yum.repos.d/rhel7-update-kernel.repo
+        when: docker_storage_driver == "overlay2" or update_kernel == "true"
+
+      - name: install rhel-7-gluster-3.1-latest mirror.openshift.com repo
+        copy:
+          src: rhel7-gluster.repo
+          dest: /etc/yum.repos.d
+
+      - name: install rhel-7-ceph-2-latest mirror.openshift.com repo
+        copy:
+          src: rhel7-ceph.repo
+          dest: /etc/yum.repos.d
+
+      #- name: install pbench-internal repo
+      #  template:
+      #    src: etc/yum.repos.d/pbench.repo.j2
+      #    dest: /etc/yum.repos.d/pbench.repo
+      #    owner: root
+      #    group: root
+      #    mode: 0644
+      #  when: internal_image | bool
+
+      - name: copy aos yum repository certificate
+        copy:
+          src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/client-cert.pem"
+          dest: /var/lib/yum/
+          remote_src: true
+
+      - name: copy aos yum repository key
+        copy:
+          src: "{{ aos_ansible_path }}/playbooks/roles/ops_mirror_bootstrap/files/client-key.pem"
+          dest: /var/lib/yum/
+          remote_src: true
+
+      - name: copy pbench-interim repo to get latest pbench
+        copy:
+          src: ndokos-pbench-interim.repo
+          dest: /etc/yum.repos.d
+    when: not atomic | default(False) | bool 
   when: vm_install | default(True) | bool
 
-- name: install EPEL repo
-  copy:
-    src: epel.repo
-    dest: /etc/yum.repos.d/
+- block:
+    - name: install EPEL repo
+      copy:
+        src: epel.repo
+        dest: /etc/yum.repos.d/
 
-- name: install pbench-external repo
-  copy:
-    src: ndokos-pbench-epel-7.repo
-    dest: /etc/yum.repos.d/
+    - name: install pbench-external repo
+      copy:
+        src: ndokos-pbench-epel-7.repo
+        dest: /etc/yum.repos.d/
 
-- name: create local yum repository configuration
-  template:
-    src: etc/yum.repos.d/all.repo.j2
-    dest: /etc/yum.repos.d/all.repo
-  when: not vm_install | default(True) | bool
+    - name: create local yum repository configuration
+      template:
+        src: etc/yum.repos.d/all.repo.j2
+        dest: /etc/yum.repos.d/all.repo
+      when: not vm_install | default(True) | bool
+  when: not atomic |  default(False) | bool 

--- a/image_provisioner/playbooks/roles/setup-image/files/meta-data
+++ b/image_provisioner/playbooks/roles/setup-image/files/meta-data
@@ -1,0 +1,1 @@
+local-hostname: localhost

--- a/image_provisioner/playbooks/roles/setup-image/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/setup-image/tasks/main.yaml
@@ -23,6 +23,30 @@
   
   - name: resize second partition to use all free space
     command: virt-resize --quiet --expand {{ docker_storage_device }} {{ base_image_location }} {{ qemu_img_location }}
+
+  - name: check if the cloud-init configuration drive already exists
+    stat:
+      path: /tmp/config.iso
+    register: config_drive
+
+  - name: delete the configuration drive if it already exists
+    file:
+      path: /tmp/config.iso
+      state: absent
+    when: config_drive.stat.exists == True
+
+  - name: copy cloud-init user-data to tmp directory
+    template:
+      src: user-data.j2
+      dest: /tmp/user-data
+
+  - name: copy cloud-init meta-data to tmp directory
+    copy:
+      src: meta-data
+      dest: /tmp/meta-data
+
+  - name: create the configuration drive
+    shell: genisoimage -o /tmp/config.iso -V cidata -r -J /tmp/meta-data /tmp/user-data
   when: atomic | default(False) | bool
 
 - block:

--- a/image_provisioner/playbooks/roles/setup-image/templates/user-data.j2
+++ b/image_provisioner/playbooks/roles/setup-image/templates/user-data.j2
@@ -1,0 +1,12 @@
+#cloud-config for setting up root passwd and ssh-keys
+chpasswd: {expire: False}
+ssh_pwauth: 1
+disable_root: 0
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA57NxnEo8KnrBYRrWjgS8eSZBKiUFBbP4GGbC1M1Kxo+494T2+y3uuihK0Ey5n824ch2OafK7m/TnByIC9pQ3VuAi/ggiOfja2gvZ/GtTedE3ct0jVbGbM/98MS0GV1NoIZRqX6e44JMDqID+ngwQutPyTgxbJ/PL2jVUrjP6sOMEJqgSEbQ9a3s+oM3O0vMTLp7E0PtgKQo0bKRoKFEn5mUxiQ2gmwg/dPqOb2/VpBAKCozsE2illszzyP/KC1gq0VkgMqIZspUsXRqvDDbnaSkCc8/AwA0yBAPBMAjtuk5UZvpioHSh2X0ShcgHtYocZiQIxiSvDzvxdYkFBztu6w== perf-team-shared-key
+user: root
+password: {{ root_password }}
+growpart:
+  mode: off
+runcmd:
+- [ sed, -i, "'s/requiretty/!requiretty/'", /etc/sudoers ]


### PR DESCRIPTION
This commit:
- generates atomic ami and qcow images when atomic variable is set
  to true.
- bakes in pbench-agent, controller and collectd images in to the
  image.
- Includes openshift templates to launch pbench-agent and collectd
  pods as daemonset
- Installs latest pbench using the rpm generated by Jenkins on a
  daily basis.
- Resizes volumes.