### PR TITLE
Modified setup-image for atomic

### DIFF
--- a/image_provisioner/playbooks/roles/setup-image/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/setup-image/tasks/main.yaml
@@ -17,22 +17,33 @@
 - name: add empty space to disk image as specified in the inventory
   command: qemu-img resize {{ base_image_location }}  +{{ extend_disk_gb }}G
 
-- name: create tmp disk for first resize pass
-  command: qemu-img create -f {{ qemu_img_format }} -o preallocation=full {{ tmp_img_location }} {{ (extend_disk_gb+10)|int|abs }}G
+- block:
+  - name: create tmp disk for second partition resize
+    command: qemu-img create -f {{ qemu_img_format }} -o preallocation=full {{ qemu_img_location }} {{ (extend_disk_gb+10)|int|abs }}G
+  
+  - name: resize second partition to use all free space
+    command: virt-resize --quiet --expand {{ docker_storage_device }} {{ base_image_location }} {{ qemu_img_location }}
+  when: atomic | default(False) | bool
 
-- name: resize root partition from 6G to 10G
-  command: virt-resize --quiet --resize {{ root_partition }}=+4G {{ base_image_location }} {{ tmp_img_location }}
+- block:
+  - name: create tmp disk for first resize pass
+    command: qemu-img create -f {{ qemu_img_format }} -o preallocation=full {{ tmp_img_location }} {{ (extend_disk_gb+10)|int|abs }}G
 
-- name: create tmp disk for adding second partition for docker thinpool
-  command: qemu-img create -f {{ qemu_img_format }} -o preallocation=full {{ qemu_img_location }} {{ (extend_disk_gb+10+1)|int|abs }}G
+  - name: resize root partition from 6G to 10G
+    command: virt-resize --quiet --resize {{ root_partition }}=+4G {{ base_image_location }} {{ tmp_img_location }}
+  
+  - name: create tmp disk for adding second partition for docker thinpool
+    command: qemu-img create -f {{ qemu_img_format }} -o preallocation=full {{ qemu_img_location }} {{ (extend_disk_gb+10+1)|int|abs }}G
 
-- name: resize second partition to use all free space
-  command: virt-resize --quiet --expand {{ docker_storage_device }} {{ tmp_img_location }} {{ qemu_img_location }}
+  - name: resize second partition to use all free space
+    command: virt-resize --quiet --expand {{ docker_storage_device }} {{ tmp_img_location }} {{ qemu_img_location }}
+    
+  - name: run virt-sysprep, set root password and inject ssh public key
+    command:  virt-sysprep -a {{ qemu_img_location }} --root-password password:{{ root_password }} --ssh-inject root:string:"{{ ssh_pub_key }}"
 
-- name: run virt-sysprep, set root password and inject ssh public key
-  command:  virt-sysprep -a {{ qemu_img_location }} --root-password password:{{ root_password }} --ssh-inject root:string:"{{ ssh_pub_key }}"
+  - name: clean up temp images
+    file:
+      path: "{{ tmp_img_location }}"
+      state: absent
+  when: not atomic | default(False) | bool
 
-- name: clean up temp images
-  file:
-    path: "{{ tmp_img_location }}"
-    state: absent

--- a/image_provisioner/playbooks/roles/setup-image/vars/main.yaml
+++ b/image_provisioner/playbooks/roles/setup-image/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-tmp_dir: "/run/"
+tmp_dir: "/tmp/"
 base_image_location: "{{ tmp_dir }}{{ base_image_filename }}" 
 tmp_img_location: "{{ tmp_dir }}osptmp1.{{ qemu_img_format }}"
 qemu_img_format: "raw"

--- a/image_provisioner/playbooks/setup-image.yaml
+++ b/image_provisioner/playbooks/setup-image.yaml
@@ -1,6 +1,6 @@
 ---
 - name: setup base image
+  hosts: all
   user: root
-  hosts: localhost
   roles:
     - setup-image


### PR DESCRIPTION
Not particularly a clean way to get it done from an efficiency perspective, the filenames prevent command reuse.
However this is functionally correct as the atomic qcow does come pre-partitioned with one device and two partitions. We only need to resize the second partition in this step.