### PR TITLE
Exclude ansible when performing os updates from ansible

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -2,10 +2,12 @@
 - name: yum update
   yum: name=* state=latest
 
+- name: make sure ansible is installed
+  yum: name=ansible state=present
+
 - name: install packages
   yum: name={{ item }} state=latest
   with_items:
-    - ansible
     - bind-utils
     - blktrace
     - ethtool


### PR DESCRIPTION
Updating the ansible binary when a playbook is running will lead to
task failure.