### PR TITLE
add python deps for openshift_scalability module

### DIFF
--- a/openshift_scalability/prerequisites.sh
+++ b/openshift_scalability/prerequisites.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+yum install gcc libyaml python-virtualenv
+
+virtualenv venv
+source venv/bin/activate
+
+pip install -r requirements.txt
+
+# run test
+python utils.py

--- a/openshift_scalability/requirements.txt
+++ b/openshift_scalability/requirements.txt
@@ -1,0 +1,17 @@
+Flask==0.12.1
+Jinja2==2.9.6
+MarkupSafe==1.0
+PyYAML==3.12
+Werkzeug==0.12.1
+boto3==1.4.4
+botocore==1.5.44
+click==6.7
+docutils==0.13.1
+futures==3.1.1
+itsdangerous==0.24
+jmespath==0.9.2
+python-cephlibs==0.94.5-1
+python-dateutil==2.6.0
+s3transfer==0.1.10
+six==1.10.0
+wsgiref==0.1.2


### PR DESCRIPTION
Add requirements.txt file for python scripts used in svt, and a naive helper script to install 'em.