### PR TITLE
Parameterize instance_tag to avoid conflicts

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -11,6 +11,7 @@ group_id=
 instance_type=m4.xlarge
 vpc_subnet_id=
 base_image=
+instance_tag=
 # repo install
 rhel_int_repo_hostname=
 # os kickstart

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -25,9 +25,9 @@
       user_data: "{{ lookup('file', '../cloud-init/user-data-aws') }}"
       exact_count: 1
       count_tag:
-         Name: ami_builder
+         Name: "{{ instance_tag | default('ami_builder') }}"
       instance_tags:
-         Name: ami_builder
+         Name: "{{ instance_tag | default('ami_builder') }}"
     register: ami_instance
 
   - name: waiting for ssh to start


### PR DESCRIPTION
- Setting the instance_tag in the inventory before building an AMI will
  avoid conflicts and enable us to build multiple images in parallel.

- A sample use case would be using Jenkins to build to build RHEL and 
  atomic images at once.