### PR TITLE
Parameterize ami_name to avoid conflicts

### DIFF
--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -67,7 +67,7 @@
       region: "{{ region }}"
       state: present
       description: This was provisioned {{ ansible_date_time.iso8601 }}
-      name: ocp-{{ openshift_version }}-gold-auto
+      name: "{{ 'ocp-{{ openshift_version }}-atomic-gold-auto' if atomic | default(False) else 'ocp-{{ openshift_version }}-rhel-gold-auto' }}"
       wait: yes
     register: amioutput
 


### PR DESCRIPTION
This is needed for Jenkins Jobs since they get triggered once a new
puddle is found and builds atomic and rhel ami's in parallel. We need
to have different ami names to differentiate between rhel and atomic.