### PR TITLE
Increase timeout for scale down and update python invocation in playbook

### DIFF
--- a/openshift_performance/ci/content/scale_up_complete.yaml
+++ b/openshift_performance/ci/content/scale_up_complete.yaml
@@ -38,7 +38,7 @@
          - { namespace: 'tomcat8-mongodb0', dc: 'jws-app'}
     - name: Run scale-up test for cakephp
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 
@@ -52,7 +52,7 @@
          > /tmp/scale_test.out 2>/tmp/scale_test.err
     - name: Run scale-up test for rails  
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 
@@ -66,7 +66,7 @@
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
     - name: Run scale-up test for django  
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 
@@ -80,7 +80,7 @@
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
     - name: Run scale-up test for dancer  
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 
@@ -94,7 +94,7 @@
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
     - name: Run scale-up test for nodejs  
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 
@@ -108,7 +108,7 @@
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
     - name: Run scale-up test for eap-app  
       shell: >
-         python /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
          -m localhost:8443 
          -u redhat 
          -p redhat 

--- a/openshift_performance/ose3_perf/scripts/scale_test.py
+++ b/openshift_performance/ose3_perf/scripts/scale_test.py
@@ -32,7 +32,7 @@ def scale_down(namespace,dc):
     if active > 0 :
         run("oc scale --replicas=0 -n " + namespace + " dc/" + dc)
         retries = 0
-        while active > 0 and retries < 20:
+        while active > 0 and retries < 100:
             time.sleep(3)
             running,active = count_pods(namespace, dc)
             if active > 0:


### PR DESCRIPTION
1. Wait up to 5 minutes for scale down
2. Use python -u everywhere in playbook so that logs can be tailed

/cc: @hongkailiu  