### PR TITLE
Changes for tolerating bad pods

### DIFF
--- a/openshift_scalability/README.md
+++ b/openshift_scalability/README.md
@@ -104,6 +104,7 @@ tuningsets:
 > * The ***Tuning parameters*** have following function:
 >  * ***stepping*** : This feature makes sure that after each "stepsize" pod/template requests are submitted, they enter the "Running" state. After all the pods/templates in the given step are Running, then there is a delay = "pause" , before the next step.
 >  * ***rate_limit*** : This makes sure that there is a delay of "rate_limit.delay" between each pod/template request submission.
+>  * ***--tolerate-bad-pods*** : This option ensures that cluster-loader utility won't wait till all the pods would come to running state. This is useful when we intentionally give bad pods which are bound to fail. By default the utility waits till all the pods come to running state.
 
 ```
 This Config file will create the following objects :

--- a/openshift_scalability/README.md
+++ b/openshift_scalability/README.md
@@ -22,6 +22,7 @@ Note:
 * The directory "content" contains default file for all the supported object-types.
 * If the "-f" option is not supplied, then the default config file is used -- pyconfig.yaml .
 * For cleaning the environment, use "-d/--clean" option.
+* The "-t" option ensures that cluster-loader utility won't wait till all the pods would come to running state. This is useful when we intentionally give bad pods which are bound to fail. By default the utility waits till all the pods come to running state. The long format for this flag is `--tolerate-bad-pods`.
 
 # Sample Config File
 ```
@@ -104,7 +105,6 @@ tuningsets:
 > * The ***Tuning parameters*** have following function:
 >  * ***stepping*** : This feature makes sure that after each "stepsize" pod/template requests are submitted, they enter the "Running" state. After all the pods/templates in the given step are Running, then there is a delay = "pause" , before the next step.
 >  * ***rate_limit*** : This makes sure that there is a delay of "rate_limit.delay" between each pod/template request submission.
->  * ***--tolerate-bad-pods*** : This option ensures that cluster-loader utility won't wait till all the pods would come to running state. This is useful when we intentionally give bad pods which are bound to fail. By default the utility waits till all the pods come to running state.
 
 ```
 This Config file will create the following objects :

--- a/openshift_scalability/cluster-loader.py
+++ b/openshift_scalability/cluster-loader.py
@@ -43,6 +43,9 @@ cliparser.add_option("-p", "--processes", dest="processes",
 cliparser.add_option("-a", "--auto-gen",
                      action="store_true", dest="autogen", default=False,
                      help="Override config parameters with live OpenShift data.")
+cliparser.add_option("-t", "--tolerate-bad-pods", action="store_true", default=False, dest="tolerate",
+                     help="Tolerates bad pods, by default cluster loader cannot tolerate bad pods as \
+                     it runs till all the pods come to running state.")
 
 (options, args) = cliparser.parse_args()
 
@@ -60,6 +63,7 @@ globalvars["kubeconfig"] = options.kubeconfig
 globalvars["processes"] = options.processes
 globalvars["autogen"] = options.autogen
 globalvars["podnum"] = 0
+globalvars["tolerate"] = options.tolerate
 
 user = options.oseuser
 passwd = options.osepass
@@ -86,3 +90,4 @@ for config in testconfig["projects"]:
             config["quota"])
 
     project_handler(config,globalvars)
+

--- a/openshift_scalability/content/bad-pod1.json
+++ b/openshift_scalability/content/bad-pod1.json
@@ -1,0 +1,42 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-openshift1",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "hello-openshift"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "goproxy",
+        "image": "gcr.io/google_containers/goproxy:0.1",
+        "resources": {
+				"requests": {
+					"cpu" : "50m",
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu" : "400m",
+					"memory": "400Mi"
+				}
+        },
+	"command": ["derekisbad"],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}
+

--- a/openshift_scalability/content/bad-pod2.json
+++ b/openshift_scalability/content/bad-pod2.json
@@ -1,0 +1,42 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-openshift2",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "hello-openshift"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "goproxy",
+        "image": "derekwaynecarr/image-does-not-exist",
+        "resources": {
+				"requests": {
+					"cpu" : "50m",
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu" : "400m",
+					"memory": "400Mi"
+				}
+        },
+	"command": ["derekisbad"],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}
+

--- a/openshift_scalability/content/bad-pod3.json
+++ b/openshift_scalability/content/bad-pod3.json
@@ -1,0 +1,54 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-openshift3",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "never-ready"
+    }
+  },
+
+    "spec": {
+        "containers": [
+            {
+                "image": "gcr.io/google_containers/goproxy:0.1",
+		 "resources": {
+                                "requests": {
+                                        "cpu" : "50m",
+                                        "memory": "100Mi"
+                                },
+                                "limits": {
+                                        "cpu" : "400m",
+                                        "memory": "400Mi"
+                                }
+        },
+                "imagePullPolicy": "IfNotPresent",
+                "livenessProbe": {
+                    "failureThreshold": 3,
+                    "initialDelaySeconds": 15,
+                    "periodSeconds": 20,
+                    "successThreshold": 1,
+                    "tcpSocket": {
+                        "port": 8080
+                    },
+                    "timeoutSeconds": 1
+                },
+                "name": "goproxy",
+                "ports": [
+                    {
+                        "containerPort": 8080,
+                        "protocol": "TCP"
+                    }
+                ],
+                "readinessProbe": {
+                    "failureThreshold": 3,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 10,
+                    "successThreshold": 1,
+                    "tcpSocket": {
+                        "port": 8900
+                    },
+                    "timeoutSeconds": 1
+                }}]}}
+

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -824,8 +824,8 @@ def pod_handler(inputpods, globalvars):
         pod_config["metadata"]["name"] = basename
 
         create_pods(pod_config, num,storagetype, globalvars)
-    tolerate_bad_pods = globalvars["tolerate"]
-    if tolerate_bad_pods is False:
+    
+    if globalvars["tolerate"] is False:
         if len(globalvars["pend_pods"]) > 0:
             pod_data(globalvars)
 

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -279,7 +279,7 @@ def create_pods(podcfg, num, storagetype, globalvars):
                 pause = globalvars["tuningset"]["stepping"]["pause"]
                 globalvars["totalpods"] = globalvars["totalpods"] + 1
                 total_pods_created = int(globalvars["totalpods"])
-                if total_pods_created % stepsize == 0:
+                if total_pods_created % stepsize == 0 and globalvars["tolerate"] is False:
                     pod_data(globalvars)
                     time.sleep(calc_time(pause))
             if "rate_limit" in globalvars["tuningset"]:
@@ -297,7 +297,6 @@ def pod_data(globalvars):
 
     pend_pods = globalvars["pend_pods"]
     namespace = globalvars["namespace"]
-
     while len(pend_pods) > 0:
         if globalvars["kubeopt"]:
             getpods = oc_command("kubectl get pods --namespace " + namespace, globalvars)
@@ -825,14 +824,15 @@ def pod_handler(inputpods, globalvars):
         pod_config["metadata"]["name"] = basename
 
         create_pods(pod_config, num,storagetype, globalvars)
+    tolerate_bad_pods = globalvars["tolerate"]
+    if tolerate_bad_pods is False:
+        if len(globalvars["pend_pods"]) > 0:
+            pod_data(globalvars)
 
-    if len(globalvars["pend_pods"]) > 0:
-        pod_data(globalvars)
-
-    if "podtuningset" in globalvars:
-        del(globalvars["podtuningset"])
-        del(globalvars["totalpods"])
-    del(globalvars["pend_pods"])
+        if "podtuningset" in globalvars:
+            del(globalvars["podtuningset"])
+            del(globalvars["totalpods"])
+        del(globalvars["pend_pods"])
     
 
 def rc_handler(inputrcs, globalvars):
@@ -892,3 +892,4 @@ def find_quota(quotaset, name):
 
     print "Failed to find quota : " + name + "\nExitting ......"
     sys.exit()
+


### PR DESCRIPTION
- This is to ensure that cluster-loader won't wait till all the pods come to running state if "-t" option is provided. 
- By default if -t is not provided cluster-loader will run as usual and will wait. 
- Three examples for bad pods which Derek gave are included in content folder.

cc @jeremyeder @sjug 