### PR TITLE
Make the master schedulable in network test

### DIFF
--- a/networking/synthetic/start-network-test.sh
+++ b/networking/synthetic/start-network-test.sh
@@ -26,6 +26,9 @@ cur_dir=`pwd`
 master=`cat config.yaml |egrep 'master:' | awk -F: '{print $2}'`
 nodes=`cat config.yaml |egrep 'nodes:' | awk -F: '{print $2}'`
 
+# make the master schedulable
+oc adm manage-node --schedulable "${master}"
+
 i=0;
 for host in ${nodes//,/ }
 do


### PR DESCRIPTION
By default, the master of AWS cluster is SchedulingDisabled. As a
result, no pods can be deployed there. In network test, we want to
test the performance of network between the pod on master and
others. So we enble master scheduling.