### PR TITLE
Create users using ssh instead of scp

### DIFF
--- a/reliability/lib/Config.rb
+++ b/reliability/lib/Config.rb
@@ -42,7 +42,7 @@ module OpenshiftReliability
       @etcds=@configs["environment"]["etcds"]
       @routers= @configs["environment"]["routers"]
       @authtype= @configs["environment"]["authtype"]
-      @authtype= @configs["environment"]["port"]
+      @port= @configs["environment"]["port"]
       @htpasswd= @configs["environment"]["htpasswd"]
       @gituser= @configs["exection"]["gituser"]
       @templates=@configs["exection"]["templates"]

--- a/reliability/lib/InstructionExecute.rb
+++ b/reliability/lib/InstructionExecute.rb
@@ -86,7 +86,7 @@ module OpenshiftReliability
       stdout=""
       stderr=""
       status=0
-      session=Net::SSH.start(host, user, :password=>@password ) do | session |
+      session=Net::SSH.start(host, user, :password=>@password, :paranoid=>false, :forward_agent=>true) do | session |
         session.open_channel do |channel|
           #channel.send_request "shell", nil, true
           channel.exec(cmd) do |ch, success|

--- a/reliability/lib/User.rb
+++ b/reliability/lib/User.rb
@@ -3,7 +3,7 @@ module OpenshiftReliability
 
     attr_reader :name, :password, :token ,:master
     attr_accessor :status
-    def initialize(name=nil, password=nil, master=nil, port=nil, token:nil, status:1 )
+    def initialize(name=nil, password=nil, master=nil, port=8443, token:nil, status:1 )
       @name = name
       @password = password
       @master=master

--- a/reliability/lib/UsersManager.rb
+++ b/reliability/lib/UsersManager.rb
@@ -40,15 +40,14 @@ module OpenshiftReliability
       host=$config.master
       newusers=[]
       defaultpassword="redhat"
-      usercreatecmds=[]
+      usercreatecmds=""
       (1..number).each do
          newuser="#{$config.prefix}-#{$config.seq}"
          newusers << newuser
-         cmd="htpasswd -b #{$config.htpasswd} #{newuser} #{defaultpassword}"
+         cmd="htpasswd -b #{$config.htpasswd} #{newuser} #{defaultpassword};"
          usercreatecmds << cmd
       end
-      usercreatecmds << "exit 0"
-      $exec.remote_upload("root", host, "/root/bin/addnewusers", usercreatecmds)
+      $exec.remote_exec("root", host, usercreatecmds)
       cmd="root@#{host} sh /root/bin/addnewusers#addnewuser"
       res=$exec.execute(cmd)
       if res[:status] == 0


### PR DESCRIPTION
Create users using ssh instead of scp, cause scp is not able to forward ssh agent and user creation might be done on masters that are protected with identity files.
 
+ setting default port if not specified in `config/config.yml` 

@vikaslaad PTAL