### PR TITLE
template and cluster loader config for woodshed testing

### DIFF
--- a/openshift_scalability/config/woodshed-master-vert.yaml
+++ b/openshift_scalability/config/woodshed-master-vert.yaml
@@ -1,0 +1,18 @@
+projects:
+  - num: 2
+    basename: myconfig-
+    tuning: default
+    templates:
+      - 
+        num: 1
+        file: ./content/woodshed-template.yaml
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 5
+        pause: 10 s
+      rate_limit:
+        delay: 250 ms
+quotas:
+  - name: default

--- a/openshift_scalability/content/woodshed-template.yaml
+++ b/openshift_scalability/content/woodshed-template.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: woodshed-template
+message: |-
+  The following service(s) have been created in your project: ${NAME}.
+metadata:
+  annotations:
+    description: An example application that serves static content.
+    openshift.io/display-name: woodshed-template
+    tags: quickstart,woodshed
+  name: woodshed-template
+  namespace: openshift
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes and load balances the application pods
+    name: ${NAME}
+  spec:
+    ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+    selector:
+      name: ${NAME}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+    name: ${NAME}
+  spec:
+    host: ${APPLICATION_DOMAIN}
+    to:
+      kind: Service
+      name: ${NAME}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Defines how to deploy the application server
+    name: ${NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          name: ${NAME}
+        name: ${NAME}
+      spec:
+        containers:
+        - env: []
+          name: hello-openshift
+          image: openshift/hello-openshift:v1.0.6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 1
+            timeoutSeconds: 2
+parameters:
+- description: The name assigned to all of the frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: woodshed-example
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: openshift
+- description: The exposed hostname that will route to the httpd service, if left
+    blank a value will be defaulted.
+  displayName: Application Hostname
+  name: APPLICATION_DOMAIN
+- description: Indentifier for use with cluster-loader
+  name: IDENTIFIER
+  value: "1"


### PR DESCRIPTION
Reason for this custom template:

- usage of hello-openshift because it is lightweight and includes a web server.
- built-in web server to respond to healthchecks giving "Ready" some actual teeth.
- built-in web server to respond to back up the svc and routes.