### PR TITLE
Add cri-o support to image provisioner

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -12,6 +12,7 @@ instance_type=m4.xlarge
 vpc_subnet_id=
 base_image=
 instance_tag=
+volume_size=
 # repo install
 rhel_int_repo_hostname=
 # os kickstart
@@ -34,6 +35,8 @@ docker_login=no
 docker_storage_device=/dev/xvdb
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
+docker_storage_mount_path=/var/lib/docker/overlay2
+container_root_lv_mount_path=/var/lib/docker
 # updates the kernel if set to true
 update_kernel=false
 # URL to pull the latest kernel
@@ -57,3 +60,8 @@ target_directory=
 atomic=False
 # To update RHEL redhat-release-server, set to true
 update_rhel_server=False
+# cri-o
+crio=False
+crio_copy_images=False
+crio_registry=registry.access.redhat.com
+image_repository=

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -31,6 +31,8 @@ docker_login=no
 docker_storage_device=/dev/nvme0n1
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
+docker_storage_mount_path=/var/lib/docker/overlay2
+container_root_lv_mount_path=/var/lib/docker
 update_kernel=true
 # baremetal DNS server config
 host=ocp.net
@@ -53,3 +55,8 @@ atomic=False
 registry_name=
 registry_username=
 registry_password=
+# cri-o
+crio=False
+crio_copy_images=False
+crio_registry=registry.access.redhat.com
+image_repository=

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -35,6 +35,8 @@ docker_login=no
 docker_storage_device=/dev/xvdb
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
+docker_storage_mount_path=/var/lib/docker/overlay2
+container_root_lv_mount_path=/var/lib/docker
 # updates the kernel if set to true
 update_kernel=false
 # URL to pull the latest kernel
@@ -57,3 +59,8 @@ openshift_version=3.3.0.30-1
 target_directory=
 # set atomic to True for atomic image
 atomic=False
+# cri-o
+crio=False
+crio_copy_images=False
+crio_registry=registry.access.redhat.com
+image_repository=

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -24,7 +24,7 @@
       volumes:
         - device_name: "{{ '/dev/sda1' if atomic | default(False) else '/dev/sdb' }}"
           volume_type: gp2
-          volume_size: 50
+          volume_size: "{{ volume_size | default(70) }}"
           delete_on_termination: true
       wait: yes
       user_data: "{{ lookup('file', '../cloud-init/user-data-aws') }}"
@@ -59,6 +59,7 @@
     - { role: os-kickstart }
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
+    - { role: cri-o, when: crio | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool }
     - { role: aos-ansible }
     - { role: ansible-update, when: not atomic | default(False) | bool }

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -17,6 +17,7 @@
     - { role: os-kickstart }
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
+    - { role: cri-o, when: crio | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool}
     - { role: aos-ansible }
     - { role: pbench-kickstart }

--- a/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
@@ -37,3 +37,20 @@
     name: iptables 
     state: started 
     enabled: yes
+
+- block:
+   - name: check if skopeo is installed
+     command: which skopeo
+     register: skopeo_status
+
+   - name: Install skopeo if not installed
+     yum:
+       name: skopeo
+       state: latest
+     when: not atomic | default(False) | bool and skopeo_status.rc != 0
+
+   - name: copy images to container storage
+     shell: for image in $(docker images {{ image_repository }}  --format {% raw %} '{{.Repository}}:{{.Tag}}' {% endraw %}); do \
+                skopeo copy docker-daemon:$image containers-storage:$image; done
+     when: skopeo_status.rc == 0
+  when: crio | default(False) | bool and crio_copy_images | default(False) | bool

--- a/image_provisioner/playbooks/roles/cri-o/files/crio-bridge.conf
+++ b/image_provisioner/playbooks/roles/cri-o/files/crio-bridge.conf
@@ -1,0 +1,15 @@
+{
+    "cniVersion": "0.2.0",
+    "name": "crio-bridge",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}

--- a/image_provisioner/playbooks/roles/cri-o/files/loopback.conf
+++ b/image_provisioner/playbooks/roles/cri-o/files/loopback.conf
@@ -1,0 +1,4 @@
+{
+    "cniVersion": "0.2.0",
+    "type": "loopback"
+}

--- a/image_provisioner/playbooks/roles/cri-o/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/cri-o/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+- name: Ensure container-selinux, atomic and runc are installed
+  package:
+     name: "{{ item }}"
+     state: present
+  with_items:
+     - container-selinux
+     - atomic
+     - runc
+  when: not atomic | default(False) | bool
+
+- name: Use RHEL based image
+  set_fact:
+    crio_image_prepend: "{{ crio_registry }}"
+    crio_image_name: "cri-o"
+
+- name: Set the full image name
+  set_fact:
+    crio_image: "{{ crio_image_prepend }}/{{ crio_image_name }}:latest"
+
+- name: Pre-pull CRI-O System Container image
+  atomic_image:
+     name: "{{ crio_image }}"
+     state: latest
+     backend: ostree
+
+- name: Install CRI-O container
+  command: "atomic install --system-package no --system {{ crio_image }}"
+
+- name: Ensure that selinux is set to true in the config
+  lineinfile:
+    path: /etc/crio/crio.conf
+    regexp: '^selinux'
+    line: 'selinux = true'
+
+- name: Ensure that systemd is the cgroup manager
+  lineinfile:
+    path: /etc/crio/crio.conf
+    regexp: '^cgroup_manager'
+    line: "cgroup_manager = \"systemd\""
+
+- name: Ensure that file locking is set to false
+  lineinfile:
+    path: /etc/crio/crio.conf
+    regexp: '^file_locking'
+    line: 'file_locking = false'
+
+- name: override overlay2 kernel check
+  lineinfile:
+    path: /etc/crio/crio.conf
+    insertafter: '^storage_option'
+    line: "\t\"overlay2.override_kernel_check=1\""
+    state: present
+
+- name: create cni directory to store network settings
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+     - /etc/cni/net.d
+     - /opt/cni/net.d
+
+- name: copy crio-bridge conf
+  copy:
+    src: crio-bridge.conf
+    dest: /etc/cni/net.d/10-mynet.conf
+
+- name: copy loopback conf
+  copy:
+    src: loopback.conf
+    dest: /etc/cni/net.d/99-loopback.conf
+
+- name: override overlay2 kernel check
+  lineinfile:
+    path: /etc/containers/storage.conf
+    insertafter: '^\[storage.options\]'
+    line: "override_kernel_check=\"true\""
+
+- name: Start the CRI-O service
+  systemd:
+    name: "cri-o"
+    enabled: yes
+    state: started
+    daemon_reload: yes
+
+- name: systemctl status
+  command: systemctl status cri-o
+  register: crio_status
+    
+- debug: msg="{{ crio_status.stdout }}"
+  when: crio_status.rc != 0 

--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -46,9 +46,9 @@
 
    - name: update fstab
      lineinfile:
-         path: /etc/fstab
-         line: "{{ docker_storage_device }} /var/lib/docker/overlay2                    xfs   defaults        0 0"
-         insertafter: EOF
+       path: /etc/fstab
+       line: "{{ docker_storage_device }} {{ docker_storage_mount_path | default(/var/lib/docker/overlay2) }}                    xfs   defaults        0 0"
+       insertafter: EOF
   when: docker_storage_driver == "overlay2" and not atomic | default(False) | bool
   
 - name: check that docker-storage has been deleted
@@ -116,7 +116,7 @@
 
 - block:
     - name: restore default selinux security context
-      command: restorecon -R /var/lib/docker/overlay2
+      command: restorecon -R {{ docker_storage_mount_path | default(/var/lib/docker/overlay2) }} 
 
     - name: autorelabel
       file:

--- a/image_provisioner/playbooks/roles/docker-config/templates/etc/sysconfig/docker-storage-setup.j2
+++ b/image_provisioner/playbooks/roles/docker-config/templates/etc/sysconfig/docker-storage-setup.j2
@@ -9,7 +9,7 @@ DATA_SIZE=100%FREE
 {% elif docker_storage_driver == 'overlay2' %}
 {% if atomic | bool %}
 CONTAINER_ROOT_LV_NAME=docker-root-lv
-CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/docker
+CONTAINER_ROOT_LV_MOUNT_PATH={{ container_root_lv_mount_path | default(/var/lib/docker) }}
 CONTAINER_ROOT_LV_SIZE=100%FREE
 {% else %}
 DOCKER_ROOT_VOLUME=yes


### PR DESCRIPTION
This commit:
- Adds support to use cri-o as runtime
- Mounts the volume at /var/lib and adds more storage needed to
  store both docker and cri-o images.
- Copies openshift images from docker storage to CRI-O storage.