### PR TITLE
Avoid installing atomic-openshift-master package

### DIFF
--- a/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
@@ -2,7 +2,6 @@
 - name: install openshift packages
   yum: name={{ item }} state=latest
   with_items:
-    - atomic-openshift-master
     - atomic-openshift-sdn-ovs
     - atomic-openshift-tests
     - atomic-openshift-node


### PR DESCRIPTION
The package needs to be installed on just the master in order to
differentiate between master and rest of the nodes. openshift-ansible
will take care of installing it on the master while setting up openshift.