### PR TITLE
Optimize journald configuration for system and scalability testing

### DIFF
--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -65,6 +65,7 @@
     - { role: openshift-package-install, when: not atomic | default(False) | bool }
     - { role: pbench-kickstart, when: atomic | default(False) | bool }
     - { role: collectd-install }
+    - { role: journald-config }
     - { role: seal-image, when: not atomic | default(False) | bool }
     - { role: clean-env, when: atomic | default(False) | bool }
 

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -20,6 +20,7 @@
     - { role: aos-ansible }
     - { role: pbench-kickstart, when: atomic | default(False) | bool }
     - { role: collectd-install }
+    - { role: journald-config }
     - { role: ansible-update, when: not atomic | default(False) | bool }
     - { role: openshift-package-install, when: not atomic | default(False) | bool }
     - { role: seal-image, when: not atomic | default(False) | bool }

--- a/image_provisioner/playbooks/roles/journald-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/journald-config/tasks/main.yaml
@@ -1,0 +1,56 @@
+---
+- name: Stop and disable rsyslog
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  with_items:
+    - rsyslog
+  when: not atomic | default(False) | bool
+
+- name: Enable journald persistence
+  ini_file:
+    dest: "/etc/systemd/journald.conf"
+    section: Journal
+    option: Storage
+    value: "Persistent"
+    no_extra_spaces: yes
+
+- name: Increase journald rate limit burst to 10000
+  ini_file:
+    dest: "/etc/systemd/journald.conf"
+    section: Journal
+    option: RateLimitBurst
+    value: "10000"
+    no_extra_spaces: yes
+
+- name: Decrease journald rate limit interval to 1 sec
+  ini_file:
+    dest: "/etc/systemd/journald.conf"
+    section: Journal
+    option: RateLimitIntervalSec
+    value: "1s"
+    no_extra_spaces: yes
+
+- name: Decrease journald rate limit interval to 1 sec
+  ini_file:
+    dest: "/etc/systemd/journald.conf"
+    section: Journal
+    option: RateLimitInterval
+    value: "1s"
+    no_extra_spaces: yes
+
+- name: Create /var/log/journal
+  file:
+    path: /var/log/journal
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+ 
+- name: Restart journald
+  systemd:
+    name: "{{ item }}"
+    state: restarted
+  with_items:
+    - systemd-journald


### PR DESCRIPTION
1. Disable rsyslog
2. Enable journal persistence on disk instead of /run/systemd/journal
3. Decrease rate limiting to 10K msgs/sec

@wabouhamad @chaitanyaenr  @sjug PTAL

Tested with the AMI playbook but qcow2 should be no different.  @ravisantoshgudimetla made these same updates to the Atomic image successfully.