### PR TITLE
Update log_avg_msec for storage test

### DIFF
--- a/storage/config/random_io.job
+++ b/storage/config/random_io.job
@@ -16,7 +16,7 @@ write_iops_log=fio
 write_lat_log=fio
 write_hist_log=fio
 per_job_logs=1
-log_avg_msec=60000
+log_avg_msec=10000
 log_hist_msec=60000
 
 [fio-1]

--- a/storage/config/sequential_io.job
+++ b/storage/config/sequential_io.job
@@ -14,7 +14,7 @@ write_iops_log=fio
 write_lat_log=fio
 write_hist_log=fio
 per_job_logs=1
-log_avg_msec=60000
+log_avg_msec=10000
 log_hist_msec=60000
 
 [fio-1]


### PR DESCRIPTION
Since openshift 3.6 and the new version of pbench-fio, storage
test have performed abnomally.

This parameter change on log_avg_msec fixed the issue [1].

[1]. https://github.com/distributed-system-analysis/pbench/issues/654