### PR TITLE
Bake in pbench agent and controller images even when not atomic

### DIFF
--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -63,7 +63,7 @@
     - { role: aos-ansible }
     - { role: ansible-update, when: not atomic | default(False) | bool }
     - { role: openshift-package-install, when: not atomic | default(False) | bool }
-    - { role: pbench-kickstart, when: atomic | default(False) | bool }
+    - { role: pbench-kickstart }
     - { role: collectd-install }
     - { role: journald-config }
     - { role: seal-image, when: not atomic | default(False) | bool }

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -19,7 +19,7 @@
     - { role: docker-config }
     - { role: pbench-config, when: not atomic | default(False) | bool}
     - { role: aos-ansible }
-    - { role: pbench-kickstart, when: atomic | default(False) | bool }
+    - { role: pbench-kickstart }
     - { role: collectd-install }
     - { role: journald-config }
     - { role: ansible-update, when: not atomic | default(False) | bool }

--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -1,19 +1,21 @@
 ---
-- name: create directory to store pbench results, store openshift templates for pbench
-  file: 
-    path: "{{ item }}"
-    state: directory
-  with_items:
-     - /var/lib/pbench-agent
-     - /var/home/openshift-templates/pbench
+- block:
+    - name: create directory to store pbench results, store openshift templates for pbench
+      file: 
+        path: "{{ item }}"
+        state: directory
+      with_items:
+         - /var/lib/pbench-agent
+         - /var/home/openshift-templates/pbench
 
-- name: copy openshift template for pbench
-  copy: 
-    src: pbench-agent-daemonset.yml  
-    dest: /var/home/openshift-templates/pbench 
-    owner: root 
-    group: root 
-    mode: 0644
+    - name: copy openshift template for pbench
+      copy: 
+        src: pbench-agent-daemonset.yml  
+        dest: /var/home/openshift-templates/pbench 
+        owner: root 
+        group: root 
+        mode: 0644i
+  when: atomic | default(False) | bool
      
 # not using docker_image module of ansible since that requires docker-py package to be installed on the atomic host
 - name: pull pbench-agent from dockerhub


### PR DESCRIPTION
For scale tests, jump host and cns nodes are RHEL based, so we need 
to bake in pbench images even not atomic.
