### PR TITLE
Renaming pyconfigMasterVirt -> pyconfigMasterVert

### DIFF
--- a/openshift_scalability/config/pyconfigMasterVertScale.yaml
+++ b/openshift_scalability/config/pyconfigMasterVertScale.yaml
@@ -1,13 +1,7 @@
 projects:
-  - num: 3
-    basename: c
+  - num: 5
+    basename: clusterproject
     tuning: default
-    users:
-      - num: 1
-        role: admin
-        basename: demo
-        password: demo
-        userpassfile: /etc/origin/openshift-passwd
     templates:
       -
         num: 3
@@ -20,13 +14,13 @@ projects:
         file: ./content/image-stream-template.json
       - 
         num: 2   
-        file: ./content/deployment-config-1rep-pause-template.json
+        file: ./content/deployment-config-1rep-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
       -
         num: 1
-        file: ./content/deployment-config-2rep-pause-template.json
+        file: ./content/deployment-config-2rep-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
@@ -37,13 +31,5 @@ projects:
         num: 3
         file: ./content/route-template.json
       # rcs and services are implemented in deployments.
-tuningsets:
-  - name: default
-    pods:
-      stepping:
-        stepsize: 5
-        pause: 10 s
-      rate_limit:
-        delay: 250 ms
 quotas:
   - name: default

--- a/openshift_scalability/config/pyconfigMasterVertScalePause.yaml
+++ b/openshift_scalability/config/pyconfigMasterVertScalePause.yaml
@@ -1,13 +1,7 @@
 projects:
-  - num: 5
-    basename: clusterproject
+  - num: 3
+    basename: c
     tuning: default
-    users:
-      - num: 1
-        role: admin
-        basename: demo
-        password: demo
-        userpassfile: /etc/origin/openshift-passwd
     templates:
       -
         num: 3
@@ -20,13 +14,13 @@ projects:
         file: ./content/image-stream-template.json
       - 
         num: 2   
-        file: ./content/deployment-config-1rep-template.json
+        file: ./content/deployment-config-1rep-pause-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
       -
         num: 1
-        file: ./content/deployment-config-2rep-template.json
+        file: ./content/deployment-config-2rep-pause-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
@@ -37,13 +31,5 @@ projects:
         num: 3
         file: ./content/route-template.json
       # rcs and services are implemented in deployments.
-tuningsets:
-  - name: default
-    pods:
-      stepping:
-        stepsize: 5
-        pause: 10 s
-      rate_limit:
-        delay: 250 ms
 quotas:
   - name: default

--- a/openshift_scalability/masterVertical.sh
+++ b/openshift_scalability/masterVertical.sh
@@ -9,7 +9,7 @@ echo "Startup delay + entropy collection"
 sleep 5m
 
 echo "Run tests" 
-python cluster-loader.py -f ./config/pyconfigMasterVirtScale.yaml
+python cluster-loader.py -f ./config/pyconfigMasterVertScale.yaml
 
 echo "sleeping 15 minutes for settling after tests"
 sleep 15m


### PR DESCRIPTION
Cleaning the templates up.  Pod tuning sets are redundant, confusing and so is the naming of these files.

/cc @openshift/svt 