### PR TITLE
Image provisioner 3.7.0 reg aws

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -42,6 +42,11 @@ kernel_url=https://example.com
 aos_ansible_path=/root/aos-ansible
 aos_ansible_inventory=/root/aos-ansible/inventory/hosts
 puddle_url=
+# required for authentication for new registry registry.aws-reg.openshift.com:443
+# registry_name=registry.aws-reg.openshift.com:443
+registry_name=
+registry_username=
+registry_password=
 # comment image_version for 'latest'
 image_version=v3.3.0.30
 # image naming

--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -42,8 +42,8 @@ kernel_url=https://example.com
 aos_ansible_path=/root/aos-ansible
 aos_ansible_inventory=/root/aos-ansible/inventory/hosts
 puddle_url=
-# required for authentication for new registry registry.aws-reg.openshift.com:443
-# registry_name=registry.aws-reg.openshift.com:443
+# required for authentication for new registry registry.reg-aws.openshift.com:443
+# registry_name=registry.reg-aws.openshift.com:443
 registry_name=
 registry_username=
 registry_password=

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -49,8 +49,8 @@ existing_dns_ip=10.1.16.4
 target_directory=
 # set atomic to True for atomic image
 atomic=False
-# required for authentication for new registry registry.aws-reg.openshift.com:443
-# registry_name=registry.aws-reg.openshift.com:443
+# required for authentication for new registry registry.reg-aws.openshift.com:443
+# registry_name=registry.reg-aws.openshift.com:443
 registry_name=
 registry_username=
 registry_password=

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -49,3 +49,8 @@ existing_dns_ip=10.1.16.4
 target_directory=
 # set atomic to True for atomic image
 atomic=False
+# required for authentication for new registry registry.aws-reg.openshift.com:443
+# registry_name=registry.aws-reg.openshift.com:443
+registry_name=
+registry_username=
+registry_password=

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -42,6 +42,11 @@ kernel_url=https://example.com
 # aos-ansible
 aos_ansible_path=/root/aos-ansible
 aos_ansible_inventory=/root/aos-ansible/inventory/hosts
+# required for authentication for new registry registry.aws-reg.openshift.com:443
+# registry_name=registry.aws-reg.openshift.com:443
+registry_name=
+registry_username=
+registry_password=
 puddle_url=
 # comment image_version for 'latest'
 image_version=v3.3.0.30

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -42,8 +42,8 @@ kernel_url=https://example.com
 # aos-ansible
 aos_ansible_path=/root/aos-ansible
 aos_ansible_inventory=/root/aos-ansible/inventory/hosts
-# required for authentication for new registry registry.aws-reg.openshift.com:443
-# registry_name=registry.aws-reg.openshift.com:443
+# required for authentication for new registry registry.reg-aws.openshift.com:443
+# registry_name=registry.reg-aws.openshift.com:443
 registry_name=
 registry_username=
 registry_password=

--- a/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
+++ b/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
@@ -16,7 +16,18 @@ aos_repo={{ puddle_url }}
 #qe_repo_image_versions=v3.1.1.6
 #qe_repo_image_versions=v3.1.1.900
 qe_repo_image_versions={{ image_version }}
-docker_login=no
+
+# New variables needed to set up the docker login and required
+# authentication to registry.reg-aws.openshift.com, for image pulls:
+docker_login=yes
+## reg_name=registry.reg-aws.openshift.com:443
+reg_name={{ registry_name }}
+reg_username={{ registry_username }}
+reg_password={{ registry_password }}
+## do not add the trailing slash:
+reg_openshift_prefix={{ registry_name }}/openshift3
+# Pulling s2i images from registry.access.redhat.com:
+reg_s2i_prefix=registry.access.redhat.com/openshift3
 
 [masters]
 {% if not atomic %}

--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -5,7 +5,7 @@
     yum: 
       name: '*' 
       state: latest
-      exclude: redhat-release*
+      exclude: redhat-release*,selinux-policy*,selinux-policy-targeted*
 
   - name: yum update redhat-release-server
     yum:


### PR DESCRIPTION
Added new inventory variables needed to set up the docker login and required authentication to registry.reg-aws.openshift.com when running aos-ansible playbooks.  Also exclude updating selinux-policy and selinux-policy-targeted packages during yum update in os-kickstart role, these packages get updated during openshift rpm install.