### PR TITLE
Prevent yum update failures when not updating to RHEL 7.5

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -5,12 +5,15 @@
     yum: 
       name: '*' 
       state: latest
-      exclude: redhat-release*,selinux-policy*,selinux-policy-targeted*
+      exclude: redhat-release*,selinux-policy*,selinux-policy-targeted*,initscripts*
 
   - name: yum update redhat-release-server
     yum:
-      name: 'redhat-release-server'
+      name: "{{ item }}"
       state: latest
+    with_items:
+      - redhat-release-server
+      - initscripts
     when: update_rhel_server | default(False) | bool
 
   - name: install packages


### PR DESCRIPTION
This was needed to prevent yum update failure when trying to update pkg initscripts when redhat-release-server is not updated to higher version 7.5 beta. Modified role os-kickstart task yum update to exclude pkg initscripts and only update it when pkg redhat-release-server gets updated