### PR TITLE
Modify template to work with kubernetes 1.7

### DIFF
--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
@@ -18,6 +18,12 @@ spec:
         imagePullPolicy: "Never"
         securityContext:
           privileged: true
+        env:
+        - name: SYSTEMD_IGNORE_CHROOT
+          value: "1"
+        command:
+        - /usr/lib/systemd/systemd
+        - --system
         volumeMounts:
           - name: kube-config
             mountPath: /root/.kube


### PR DESCRIPTION
In 1.7 release the shared PID namespaces is enabled by default. This is
causing a problem when running pbench container which runs systemd.

Related issue in upstream kubernetes:
https://github.com/kubernetes/kubernetes/issues/48937

According to my understanding this will be fixed from 1.8 with the
following patch:
https://github.com/kubernetes/kubernetes/pull/51634