### PR TITLE
Remove extraneous repo clones, import wildfly imagestream for s2i tests

### DIFF
--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -4,7 +4,7 @@ exitstatus=0
 
 PARALLEL_NODES=5
 PARALLEL_TESTS="EmptyDir|Conformance"
-PARALLEL_SKIP="Serial|Flaky|Disruptive|Slow"
+PARALLEL_SKIP="Serial|Flaky|Disruptive|Slow|should be applied to XFS filesystem when a pod is created"
 
 SERIAL_TESTS="Serial"
 SERIAL_SKIP="Flaky|Disruptive|Slow" 
@@ -15,11 +15,9 @@ mkdir /root/go
 export GOPATH=/root/go
 export PATH=$PATH:$GOPATH/bin
 go get github.com/onsi/ginkgo/ginkgo
-git clone --depth=1 https://github.com/openshift/origin
-cd origin/test
 export KUBECONFIG=/etc/origin/master/admin.kubeconfig
-export KUBE_REPO_ROOT=/root/origin/vendor/k8s.io/kubernetes
-export EXTENDED_TEST_PATH=/root/origin/test/extended
+
+oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
 
 
 TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?


### PR DESCRIPTION
- Remove extraneous env vars and repositories.  No longer needed. 
- Import centos7 imagestreams to pickup wildfly.   Required for s2i build conformance tests.