### PR TITLE
Add templates to create namespaces

### DIFF
--- a/openshift_templates/performance_monitoring/collectd/collectd-namespace.yml
+++ b/openshift_templates/performance_monitoring/collectd/collectd-namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  name: collectd

--- a/openshift_templates/performance_monitoring/pbench/pbench-namespace.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  name: pbench


### PR DESCRIPTION
This commit adds templates to create pbench and collectd namespaces with an
empty nodeselector like what we have for default namespace. This will avoid
hitting the following bug: https://bugzilla.redhat.com/show_bug.cgi?id=1494709.