### PR TITLE
Add support for logging to syslog in addition to stdout

### DIFF
--- a/openshift_scalability/config/ocp-syslog-logtest.yaml
+++ b/openshift_scalability/config/ocp-syslog-logtest.yaml
@@ -1,0 +1,20 @@
+projects:
+  - num: 1
+    basename: svt-
+    ifexists: delete
+    tuning: default
+    templates:
+      - num: 1
+        file: ./content/logtest/logtest-syslog-rc.json
+        parameters:
+         - REPLICAS: "0"
+         - INITIAL_FLAGS: "--journal --num-lines 0 --line-length 200 --word-length 9 --rate 60 --fixed-line\n"
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 5
+        pause: 0 min
+      rate_limit:
+        delay: 0 ms

--- a/openshift_scalability/content/logtest/logtest-syslog-rc.json
+++ b/openshift_scalability/content/logtest/logtest-syslog-rc.json
@@ -1,0 +1,116 @@
+{
+    "apiVersion": "v1",
+    "kind": "Template",
+    "metadata": {
+        "name": "centos-logtest-template"
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "data": {
+                "ocp_logtest.cfg": "${INITIAL_FLAGS}"
+            },
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "logtest-config"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "name": "centos-logtest",
+                "labels": {
+                    "run": "centos-logtest",
+                    "test": "centos-logtest"
+                }
+            },
+            "spec": {
+                "replicas": "${REPLICAS}",
+                "template": {
+                    "metadata": {
+                        "generateName": "centos-logtest-",
+                        "labels": {
+                            "run": "centos-logtest",
+                            "test": "centos-logtest"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                ],
+                                "image": "${LOGTEST_IMAGE}",
+                                "imagePullPolicy": "Always",
+                                "name": "centos-logtest",
+                                "resources": {},
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": true
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "config",
+                                        "mountPath": "/var/lib/svt"
+                                    },
+                                    {
+                                        "name": "devlog",
+                                        "mountPath": "/dev/log"
+                                    }
+                                ],
+                                "terminationMessagePath": "/dev/termination-log"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "config",
+                                "configMap": {
+                                    "name": "logtest-config"
+                                }
+                            },
+                            {
+                               "hostPath": {
+                                    "path": "/dev/log"
+                               },
+                               "name": "devlog"
+                            }
+                        ],
+                        "imagePullSecrets": [
+                            {
+                                "name": "default-dockercfg-ukomu"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "LOGTEST_IMAGE",
+            "displayName": "logtest image",
+            "value": "docker.io/mffiedler/ocp-logtest:latest"
+        },
+	{
+	    "name": "INITIAL_FLAGS",
+	    "description": "The initial flags to pass to ocp_logtest.py",
+	    "value": "--num-lines 0 --line-length 200 --word-length 9 --rate 60 --fixed-line\n"
+	},
+        {
+            "name": "IDENTIFIER",
+            "displayName": "identifier",
+            "value": "1"
+        },
+        {
+            "name": "REPLICAS",
+            "displayName": "Replicas",
+            "value": "1"
+        },
+        {
+            "name": "PLACEMENT",
+            "displayName": "Placement",
+            "value": "logtest"
+        }
+    ]
+}
+


### PR DESCRIPTION
- switch all logging to use the Python logging framework
- add a syslog logger and a new flag to make us of it.
- provide cluster loader config and pod definitions for privileged containers

Note:  Currently logging to syslog requires that the pod run as privileged.  See the README for details