### PR TITLE
Use int for replicas parameter in template files

### DIFF
--- a/openshift_scalability/content/logtest/logtest-rc.json
+++ b/openshift_scalability/content/logtest/logtest-rc.json
@@ -26,7 +26,7 @@
                 }
             },
             "spec": {
-                "replicas": "${REPLICAS}",
+                "replicas": "${{REPLICAS}}",
                 "template": {
                     "metadata": {
                         "generateName": "centos-logtest-",

--- a/openshift_scalability/content/logtest/logtest-syslog-rc.json
+++ b/openshift_scalability/content/logtest/logtest-syslog-rc.json
@@ -26,7 +26,7 @@
                 }
             },
             "spec": {
-                "replicas": "${REPLICAS}",
+                "replicas": "${{REPLICAS}}",
                 "template": {
                     "metadata": {
                         "generateName": "centos-logtest-",

--- a/openshift_scalability/content/statefulset-pv-template.json
+++ b/openshift_scalability/content/statefulset-pv-template.json
@@ -39,7 +39,7 @@
       },
       "spec": {
         "serviceName": "server${IDENTIFIER}",
-        "replicas": "${REPLICAS}",
+        "replicas": "${{REPLICAS}}",
         "template": {
           "metadata": {
             "labels": {


### PR DESCRIPTION
In oc 3.8, type checking for oc create is stricter. For example,
the value of replicas is int and cannot be string anymore.
Otherwise,

"""
Error from server (BadRequest): ReplicationController in version "v1"
cannot be handled as a ReplicationController: json: cannot unmarshal
string into Go struct field ReplicationControllerSpec.replicas of
type int32
"""

The right way to specify int value via parameter is shown in
Example 7 [1].

[1]. https://docs.openshift.org/latest/dev_guide/templates.html