### PR TITLE
Add a note that the python cluster-loader is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The hierarchy of this repository is as follows:
 ├── image_provisioner:  Ansible playbooks for building AMI and qcow2 images with OpenShift rpms and Docker images baked in.
 ├── networking: Performance tests for the OpenShift SDN and kube-proxy.
 ├── openshift_performance:  Performance tests for container build parallelism, projects and persistent storage (EBS, Ceph, Gluster and NFS)
-├── openshift_scalability: Home of the infamous "cluster-loader", details in openshift_scalability/README.md
+├── openshift_scalability: [DEPRECATED, moved to Origin Extended Tests] Home of the infamous "cluster-loader", details in openshift_scalability/README.md
 └── reliability: Run tests over long periods of time (weeks), cycle object quantity up and down.
 ```
 

--- a/openshift_scalability/README.md
+++ b/openshift_scalability/README.md
@@ -1,3 +1,13 @@
+# DEPRECATION WARNING FOR PYTHON CLUSTER LOADER
+
+The python version of cluster-loader is DEPRECATED in favor of a re-implementation in golang, which is part of OpenShift Origin Extended Tests as of version 3.7.   cluster-loader is now included in the OpenShift product as part of the atomic-openshift-tests RPM.
+
+Documentation on how to use the new golang version of cluster-loader is here:
+
+https://docs.openshift.com/container-platform/3.7/scaling_performance/using_cluster_loader.html
+
+The python version of cluster-loader will be deprecated as soon as all capabilities are re-implemented in the golang version.
+
 # About OSE-Cluster-Loader
 This package is written in python and can be used to create an environment on top of an OpenShift installation. So, basically you can create any number of projects, each having any number of following objects -- ReplicationController, Pods, Services, etc..
 Note : As of now it supports only - Pods, Replicationcontrollers, Services, and Templates.


### PR DESCRIPTION
In favor of the origin extended tests version.

@openshift/svt 