### PR TITLE
Create wildfly imagestream without relying on being on first master

### DIFF
--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+
 exitstatus=0
 
 PARALLEL_NODES=5
@@ -17,7 +20,9 @@ export PATH=$PATH:$GOPATH/bin
 go get github.com/onsi/ginkgo/ginkgo
 export KUBECONFIG=/etc/origin/master/admin.kubeconfig
 
-oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-centos7.json
+# create wildfly imagestream
+cd $SCRIPTPATH
+oc create -n openshift -f ./wildfly_imagestream.json
 
 
 TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?

--- a/conformance/wildfly_imagestream.json
+++ b/conformance/wildfly_imagestream.json
@@ -1,0 +1,105 @@
+{
+  "kind": "ImageStreamList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wildfly",
+        "annotations": {
+          "openshift.io/display-name": "WildFly"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": {
+              "openshift.io/display-name": "WildFly (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "description": "Build and run WildFly applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of WildFly available on OpenShift, including major versions updates.",
+              "iconClass": "icon-wildfly",
+              "tags": "builder,wildfly,java",
+              "supports":"jee,java",
+              "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "10.1"
+            }
+          },
+          {
+            "name": "8.1",
+            "annotations": {
+              "openshift.io/display-name": "WildFly 8.1",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "description": "Build and run WildFly 8.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md.",
+              "iconClass": "icon-wildfly",
+              "tags": "builder,wildfly,java",
+              "supports":"wildfly:8.1,jee,java",
+              "version": "8.1",
+              "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/wildfly-81-centos7:latest"
+            }
+          },
+          {
+            "name": "9.0",
+            "annotations": {
+              "openshift.io/display-name": "WildFly 9.0",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "description": "Build and run WildFly 9.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md.",
+              "iconClass": "icon-wildfly",
+              "tags": "builder,wildfly,java",
+              "supports":"wildfly:9.0,jee,java",
+              "version": "9.0",
+              "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/wildfly-90-centos7:latest"
+            }
+          },
+          {
+            "name": "10.0",
+            "annotations": {
+              "openshift.io/display-name": "WildFly 10.0",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "description": "Build and run WildFly 10.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md.",
+              "iconClass": "icon-wildfly",
+              "tags": "builder,wildfly,java",
+              "supports":"wildfly:10.0,jee,java",
+              "version": "10.0",
+              "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/wildfly-100-centos7:latest"
+            }
+          },
+          {
+            "name": "10.1",
+            "annotations": {
+              "openshift.io/display-name": "WildFly 10.1",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "description": "Build and run WildFly 10.1 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md.",
+              "iconClass": "icon-wildfly",
+              "tags": "builder,wildfly,java",
+              "supports":"wildfly:10.1,jee,java",
+              "version": "10.1",
+              "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/wildfly-101-centos7:latest"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The script used to rely on being on the first master to import the wildfly imagestream which is required by the s2i conformance tests.    This causes issues when trying to run from a random master.

Instead, simply create the wildfly imagestream explicitly using a json resource definition in our repo.

/cc: @mbruzek 