### PR TITLE
Temporarily skip hanging Prometheus test - needs debug

### DIFF
--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -8,7 +8,8 @@ exitstatus=0
 PARALLEL_NODES=5
 PARALLEL_TESTS="EmptyDir|Conformance"
 PARALLEL_SKIP="Serial|Flaky|Disruptive|Slow|should be applied to XFS filesystem when a pod is created"
-
+# Need to debug
+PARALLEL_SKIP="Prometheus|" + $PARALLEL_SKIP
 SERIAL_TESTS="Serial"
 SERIAL_SKIP="Flaky|Disruptive|Slow" 
 


### PR DESCRIPTION
The prometheus conformance test currently hangs and eventually times out.   Skip this test temporarily until it can be debugged (issue #357)