### PR TITLE
updates to SVT CI automation scripts and config files

### DIFF
--- a/openshift_performance/ci/content/scale_up_complete.yaml
+++ b/openshift_performance/ci/content/scale_up_complete.yaml
@@ -9,7 +9,7 @@
     - name: Create redhat user
       shell: htpasswd -b /etc/origin/htpasswd redhat redhat
     - name: Give redhat user cluster-admin
-      shell: oadm policy add-cluster-role-to-user cluster-admin redhat
+      shell: oc adm policy add-cluster-role-to-user cluster-admin redhat
     - name: Run cluster loader to create all projects
       args: 
          chdir: /root/svt/openshift_scalability

--- a/openshift_scalability/ci/contents/kitchen-sink-ci.yaml
+++ b/openshift_scalability/ci/contents/kitchen-sink-ci.yaml
@@ -1,47 +1,47 @@
 projects:
-  - num: 5
+  - num: 4
     basename: cakephp-mysql
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/cakephp/cakephp-mysql-pv.json
 
-  - num: 5
+  - num: 4
     basename: dancer-mysql
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/dancer/dancer-mysql-pv.json
 
-  - num: 5
+  - num: 4
     basename: django-postgresql
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/django/django-postgresql-pv.json
 
-  - num: 5
+  - num: 4
     basename: nodejs-mongodb
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/nodejs/nodejs-mongodb-pv.json
 
-  - num: 5
+  - num: 4
     basename: rails-postgresql
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/rails/rails-postgresql-pv.json
 
-  - num: 5
+  - num: 4
     basename: eap64-mysql
     tuning: default
     templates:
       - num: 1
         file: ./content/quickstarts/eap/eap64-mysql-pv.json
 
-  - num: 5
+  - num: 4
     basename: tomcat8-mongodb
     tuning: default
     templates:
@@ -52,7 +52,7 @@ tuningsets:
   - name: default
     pods:
       stepping:
-        stepsize: 5
+        stepsize: 4
         pause: 0 min
       rate_limit:
         delay: 0 ms

--- a/openshift_scalability/ci/scripts/pbench-start-node-vertical-test-client.sh
+++ b/openshift_scalability/ci/scripts/pbench-start-node-vertical-test-client.sh
@@ -57,9 +57,8 @@ echo -e "Creating a new /root/.kube dir on this host "
 mkdir -p /root/.kube
 ls -ltr /root/.kube/config
 
-echo -e "SCP the /root/.kube/config file from Master node ${MASTER_PUBLIC_DNS} to this Test Client host"
-scp root@${MASTER_PUBLIC_DNS}:/root/.kube/config /root/.kube/config
-## may want to copy first: /etc/origin/master/admin.kubeconfig to /root/.kube/config
+echo -e "SCP the /etc/origin/master/admin.kubeconfig file from Master node ${MASTER_PUBLIC_DNS} to this Test Client host"
+scp root@${MASTER_PUBLIC_DNS}:/etc/origin/master/admin.kubeconfig /root/.kube/config
 echo -e "Checking the newly copied /root/.kube/config file on this host: \n"
 
 ls -ltr /root/.kube/config

--- a/openshift_scalability/config/nodeVertical.yaml
+++ b/openshift_scalability/config/nodeVertical.yaml
@@ -4,7 +4,7 @@ projects:
     ifexists: delete
     tuning: default
     pods:
-      - total: 1000
+      - total: 500
       - num: 100
         image: gcr.io/google_containers/pause-amd64:3.0
         basename: pausepods

--- a/openshift_scalability/config/nodeVertical.yaml
+++ b/openshift_scalability/config/nodeVertical.yaml
@@ -4,7 +4,7 @@ projects:
     ifexists: delete
     tuning: default
     pods:
-      - total: 500
+      - total: 1000
       - num: 100
         image: gcr.io/google_containers/pause-amd64:3.0
         basename: pausepods


### PR DESCRIPTION
Updates include:
- substituting "oc adm" instead of "oadm" in App Scale Up Down CI playbook
- Reducing the number of projects from 5 to 4 for kitchen-sink test as 5 was overwhelming the nodes even back on 3.7.
- returning the default number of pods from 1000 back to 500 so we can run the Node Vertical tests from CI with 250 pod per node on 2 compute nodes (we do not officially support 500 pods per node)
- pulling .kube/config from master's /etc/origin/master/admin.kubeconfig in node vertical shell script