### PR TITLE
PATH fix for centos-stress Dockerfile.

### DIFF
--- a/openshift_scalability/content/centos-stress/Dockerfile
+++ b/openshift_scalability/content/centos-stress/Dockerfile
@@ -2,7 +2,8 @@
 FROM centos:7
 
 ### Setup user for build execution and application runtime
-ENV APP_ROOT=/opt/stress PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
+ENV APP_ROOT=/opt/stress
+ENV PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
 WORKDIR ${APP_ROOT}
 COPY root ./
 


### PR DESCRIPTION
PATH is not set correctly and uid_entrypoint not found in PATH unless APP_ROOT is defined prior to PATH on a separate line.