### PR TITLE
Update image_provisioner to install ansible from aos.repo

### DIFF
--- a/image_provisioner/playbooks/roles/ansible-update/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/ansible-update/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: remove the currently installed ansible package which normally comes form epel repo
+- name: remove the currently installed ansible package which normally comes form epel or rhel-7-extras-next repos
   yum:
     name: ansible
     state: absent
@@ -7,7 +7,7 @@
 - name: install ansible from aos.repo
   yum:
     name: ansible
-    disablerepo: epel
+    disablerepo: epel,rhel-7-extras-next
     enablerepo: aos
     state: present
 


### PR DESCRIPTION
The correct version of Ansible to be used with OCP is found in the aos.repo on the AWS mirror.  Updated role ansible-update to install ansible from aos.repo instead of epel or rhel7next