### PR TITLE
Rename the image in the pod spec

### DIFF
--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -22,7 +22,7 @@
   command: docker pull ravielluri/image:agent
 
 - name: tag pbench-agent image
-  command: docker tag ravielluri/image:agent pbench-agent:latest
+  command: docker tag ravielluri/image:agent library/pbench-agent:latest
 
 - name: pull pbench-controller image from dockerhub
   command: docker pull ravielluri/image:controller

--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: pbench-agent
+  annotations:
+  openshift.io/scc: privileged
   labels:
     name: pbench-agent
 spec:
@@ -13,9 +15,9 @@ spec:
       hostPID: true
       hostNetwork: true
       containers:
-      - image: pbench-agent
+      - image: library/pbench-agent:latest
         name: pbench-agent
-        imagePullPolicy: "Never"
+        imagePullPolicy: Never
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
openshift 3.9 is looking for library/pbench-agent on the nodes instead
of just pbench-agent. This commit renames the image in the template and
tags the image accordingly while building the gold image.