### PR TITLE
Transform pyconfigStatefulSet.yaml to GoLang cluster-syntax

### DIFF
--- a/openshift_scalability/config/golang/statefulSet.yaml
+++ b/openshift_scalability/config/golang/statefulSet.yaml
@@ -1,0 +1,20 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 2
+      basename: clusterproject
+      tuning: default
+      ifexists: delete
+      templates:
+        - num: 3
+          file: statefulset-pv-template.go.json
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 5
+          pause: 10 s
+        ratelimit:
+          delay: 250 ms
+

--- a/openshift_scalability/content/statefulset-pv-template.go.json
+++ b/openshift_scalability/content/statefulset-pv-template.go.json
@@ -1,0 +1,153 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "statefulset-template",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a statefulset and a headless service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "server${IDENTIFIER}",
+        "labels": {
+          "app": "server"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": "${PORT}",
+            "name": "web"
+          }
+        ],
+        "selector": {
+          "app": "server${IDENTIFIER}"
+        }
+      }
+    },
+    {
+      "apiVersion": "apps/v1beta1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "name": "web${IDENTIFIER}"
+      },
+      "spec": {
+        "serviceName": "server${IDENTIFIER}",
+        "replicas": "${{REPLICAS}}",
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "server${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "server",
+                "image": "${IMAGE}",
+                "resources": {
+                  "requests": {
+                    "memory": "${REQUEST_MEM}",
+                    "cpu": "${REQUEST_CPU}"
+                  },
+                  "limits": {
+                    "memory": "${LIMIT_MEM}",
+                    "cpu": "${LIMIT_CPU}"
+                  }
+                },
+                "ports": [
+                  {
+                    "containerPort": "${PORT}",
+                    "name": "web"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "www",
+                    "mountPath": "/mydata"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "www"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "1Gi"
+                }
+              },
+              "storageClassName": "gp2"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "generate": "expression",
+      "from": "[a-z0-9]{12}"
+    },
+    {
+      "name": "IMAGE",
+      "description": "image",
+      "value": "openshift/hello-openshift",
+      "required": false
+    },
+    {
+      "name": "PORT",
+      "description": "port",
+      "value": "8080",
+      "required": false
+    },
+    {
+      "name": "REPLICAS",
+      "description": "number of replicas",
+      "value": "2",
+      "required": false
+    },
+    {
+      "name": "REQUEST_MEM",
+      "description": "request of memory",
+      "value": "128Mi",
+      "required": false
+    },
+    {
+      "name": "REQUEST_CPU",
+      "description": "request of CPU",
+      "value": "0.5",
+      "required": false
+    },
+    {
+      "name": "LIMIT_MEM",
+      "description": "limit of memory",
+      "value": "256Mi",
+      "required": false
+    },
+    {
+      "name": "LIMIT_CPU",
+      "description": "limit of CPU",
+      "value": "1",
+      "required": false
+    }
+  ]
+
+}
+


### PR DESCRIPTION
We cannot reuse the template file statefulset-pv-template.json
because the current go version of cluster-loader does NOT handle
${IDENTIFIER} as the python one.

Before we embed the same logic into the go-cluster loader, we
generate the variable by regex as a workaround.