### PR TITLE
Networking test fixes.

### DIFF
--- a/networking/synthetic/content/uperf-rc-template.json
+++ b/networking/synthetic/content/uperf-rc-template.json
@@ -38,7 +38,7 @@
 		    "spec": {
 			"containers": [
 			    {
-				"image": "centos/uperf",
+				"image": "centos/uperf:latest",
 				"imagePullPolicy": "Never",
 				"name": "uperf",
 				"terminationMessagePath": "/dev/termination-log",

--- a/networking/synthetic/node-ip-test-setup.yaml
+++ b/networking/synthetic/node-ip-test-setup.yaml
@@ -52,7 +52,7 @@
       --runtime=30
       --message-sizes=64,1024,16384
       --protocols=tcp
-      --instances=2
+      --instances=1
       --samples=3
       --max-stddev=10
       --clients={{ sender_host }}
@@ -66,7 +66,7 @@
       --runtime=30
       --message-sizes=64,1024,16384
       --protocols=udp
-      --instances=2
+      --instances=1
       --samples=3
       --max-stddev=10
       --clients={{ sender_host }}

--- a/networking/synthetic/pod-ip-test-setup.yaml
+++ b/networking/synthetic/pod-ip-test-setup.yaml
@@ -54,7 +54,7 @@
     with_items: "{{ groups['receiver'] }}"
 
   - name: Create uperf projects
-    shell: oc new-project uperf-{{ item }}
+    shell: oc adm new-project --node-selector="" uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
 
   - name: Create sender pods

--- a/networking/synthetic/start-network-test.sh
+++ b/networking/synthetic/start-network-test.sh
@@ -27,7 +27,7 @@ master=`cat config.yaml |egrep 'master:' | awk -F: '{print $2}'`
 nodes=`cat config.yaml |egrep 'nodes:' | awk -F: '{print $2}'`
 
 # make the master schedulable
-oc adm manage-node --schedulable "${master}"
+oc adm manage-node --schedulable=true ${master}
 
 i=0;
 for host in ${nodes//,/ }
@@ -35,6 +35,11 @@ do
   nodes_array[i]=${host// /}
   let i=i+1;
 done
+
+echo "INFO : $(date) #################### node to node  ####################"
+python network-test.py nodeIP --master $master --node ${nodes_array[0]} ${nodes_array[1]}
+sleep 120
+wait_for_project_delete
 
 for var in 1 2 4 8
 do

--- a/networking/synthetic/svc-ip-test-setup.yaml
+++ b/networking/synthetic/svc-ip-test-setup.yaml
@@ -64,7 +64,7 @@
     with_items: "{{ groups['receiver'] }}"
 
   - name: Create uperf projects
-    shell: oc new-project uperf-{{ item }}
+    shell: oc adm new-project --node-selector="" uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
 
   - name: Create sender pods


### PR DESCRIPTION
  - changing to the image name to imageName:version as required now in
latest OCP
  - adding node to node tests in the automated script
  - enhance the playbook to create projects without the pre-req of
having to overwrite the default node selector to null.