### PR TITLE
Ignore errors when cloning a particular openshift-ansible branch

### DIFF
--- a/image_provisioner/playbooks/roles/clone-repos/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/clone-repos/tasks/main.yaml
@@ -40,6 +40,7 @@
        dest: /root/openshift-ansible 
        update: yes
        version: "{{ openshift_ansible_branch }}"
+     ignore_errors: yes
   rescue:
    - name: clone master branch of openshift-ansible
      git:


### PR DESCRIPTION
This commit will ensure that the playbook doesn't have a failure in 
the summary when it doesn't find a particular openshift-ansible 
release branch and clones the master branch instead.