### PR TITLE
Transform pyconfigMasterVertScalePause.yaml to GoLang cluster-syntax

### DIFF
--- a/openshift_scalability/config/golang/masterVertScalePause.yaml
+++ b/openshift_scalability/config/golang/masterVertScalePause.yaml
@@ -1,0 +1,22 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 1
+      basename: c
+      templates:
+        - num: 2
+          file: golang/deployment-config-pause-template.json
+          parameters:
+            REPLICAS: "1"
+            ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+
+        - num: 1
+          file: golang/deployment-config-pause-template.json
+          parameters:
+            REPLICAS: "2"
+            ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+
+
+### The result of the templates need to be transformed too
+### The current one is just a proof of concept that $IDENTIFIER works by auto-gen values

--- a/openshift_scalability/content/golang/deployment-config-1rep-pause-template.json
+++ b/openshift_scalability/content/golang/deployment-config-1rep-pause-template.json
@@ -1,0 +1,135 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deployment-config-template",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deploymentConfig with 1 replica, 4 env vars, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploymentconfig${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 1,
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "Rolling"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "generate": "expression",
+      "from": "[a-z0-9]{12}"
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deploymentConfig",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentConfigTemplate"
+  }
+
+}
+

--- a/openshift_scalability/content/golang/deployment-config-pause-template.json
+++ b/openshift_scalability/content/golang/deployment-config-pause-template.json
@@ -1,0 +1,140 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deployment-config-template",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deploymentConfig with 1 replica, 4 env vars, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploymentconfig${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": "${{REPLICAS}}",
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "Rolling"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "generate": "expression",
+      "from": "[a-z0-9]{12}"
+    },
+    {
+      "name": "REPLICAS",
+      "displayName": "Replicas",
+      "value": "1"
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deploymentConfig",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentConfigTemplate"
+  }
+
+}
+


### PR DESCRIPTION
The following templates in content folder
- deployment-config-1rep-pause-template.json
- deployment-config-2rep-pause-template.json

are merged into 1 file in content folder
golang/deployment-config-pause-template.json

The number of replicas for the dc is controlled by the variable REPLICAS.

The variable IDENTIFIER is generated by regex. So no conflict will
occur when being used as a part of resource names.