### PR TITLE
Update selinux-policy

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -5,7 +5,7 @@
     yum: 
       name: '*' 
       state: latest
-      exclude: redhat-release*,selinux-policy*,selinux-policy-targeted*,initscripts*
+      exclude: redhat-release*,initscripts*
 
   - name: yum update redhat-release-server
     yum:


### PR DESCRIPTION
This commit updates selinux-policy needed for ocp 3.9 installation