### PR TITLE
SVT conformance wrapper updates

### DIFF
--- a/conformance/removeNodeSelector.yaml
+++ b/conformance/removeNodeSelector.yaml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+
+  sudo: yes
+  user: root
+  tasks:
+    - name: Backup master-config
+      copy: src=/etc/origin/master/master-config.yaml dest=/etc/origin/master/master-config.yaml.before.conformance
+    - name: Remove defaultNodeSelector
+      replace: 
+        path: /etc/origin/master/master-config.yaml
+        regexp: 'defaultNodeSelector: .*'
+        replace: 'defaultNodeSelector: ""'
+    - name: Restart master services
+      systemd:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - atomic-openshift-master-controllers
+        - atomic-openshift-master-api
+

--- a/conformance/restoreNodeSelector.yaml
+++ b/conformance/restoreNodeSelector.yaml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+
+  sudo: yes
+  user: root
+  tasks:
+    - name: Backup current master-config
+      copy: src=/etc/origin/master/master-config.yaml dest=/etc/origin/master/master-config.yaml.after.conformance
+    - name: Restore original master-config
+      copy: src=/etc/origin/master/master-config.yaml.before.conformance dest=/etc/origin/master/master-config.yaml
+    - name: Restart master services
+      systemd:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - atomic-openshift-master-controllers
+        - atomic-openshift-master-api

--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -12,21 +12,57 @@ PARALLEL_SKIP="Serial|Flaky|Disruptive|Slow|should be applied to XFS filesystem 
 PARALLEL_SKIP="Prometheus|"$PARALLEL_SKIP
 echo $PARALLEL_SKIP
 SERIAL_TESTS="Serial"
-SERIAL_SKIP="Flaky|Disruptive|Slow" 
+SERIAL_SKIP="Flaky|Disruptive|Slow"
 
-cd
-yum install atomic-openshift-tests
-mkdir /root/go
-export GOPATH=/root/go
-export PATH=$PATH:$GOPATH/bin
-go get github.com/onsi/ginkgo/ginkgo
+setup_prereqs() {
+   yum -y install atomic-openshift-tests
+   mkdir /root/go
+   export GOPATH=/root/go
+   export PATH=$PATH:$GOPATH/bin
+   go get github.com/onsi/ginkgo/ginkgo
+
+}
+
+import_wildfly() {
+
+   # create wildfly imagestream
+   cd $SCRIPTPATH
+   oc create -n openshift -f ./wildfly_imagestream.json
+
+}
+
+fix_jenkins() {
+   oc get -n openshift -o yaml is jenkins > /tmp/jenkins.yaml
+   sed -i.orig 's/jenkins-2-rhel7:v3.9/jenkins-2-rhel7:latest/g' /tmp/jenkins.yaml
+   oc replace --namespace=openshift -f /tmp/jenkins.yaml
+}
+
+remove_default_node_selector() {
+	ansible-playbook -i $SCRIPTPATH/masters $SCRIPTPATH/removeNodeSelector.yaml
+}
+
+restore_default_node_selector() {
+	ansible-playbook -i $SCRIPTPATH/masters $SCRIPTPATH/restoreNodeSelector.yaml
+}
+
+create_master_inventory() {
+	oc get nodes --no-headers -l node-role.kubernetes.io/master=true | cut -f1 -d" " > $SCRIPTPATH/masters
+}
+
 export KUBECONFIG=/etc/origin/master/admin.kubeconfig
+cd
 
-# create wildfly imagestream
-cd $SCRIPTPATH
-oc create -n openshift -f ./wildfly_imagestream.json
+setup_prereqs
 
+import_wildfly
+fix_jenkins
+
+create_master_inventory
+remove_default_node_selector
 
 TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-parallel ginkgo -v "-focus=$PARALLEL_TESTS" "-skip=$PARALLEL_SKIP" -p -nodes "$PARALLEL_NODES"  /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
 #TEST_REPORT_DIR=/tmp TEST_REPORT_FILE_NAME=svt-serial ginkgo -v "-focus=$SERIAL_TESTS" "-skip=$SERIAL_SKIP" /usr/libexec/atomic-openshift/extended.test  || exitstatus=$?
- 
+
+restore_default_node_selector
+echo "exitstatus="$exitstatus
+exit $exitstatus


### PR DESCRIPTION
In 3.9 some updates to the wrapper are required to get things to run cleanly:

1. Fix Jenkins image stream to latest
2. Remove defaultNodeSelector prior to running tests and restore it afterwards
3. Return a meaningful exit code.

There is still 1 failure right now that looks like a test bug - the test panics.  Need to debug it.

Tested on HA and single master