### PR TITLE
Initial commit of golang cluster-loader yaml config file and pod json config files for node affinity/anti-affinity testcase

### DIFF
--- a/openshift_scalability/config/golang/node-affinity-anti-affinity.yaml
+++ b/openshift_scalability/config/golang/node-affinity-anti-affinity.yaml
@@ -1,0 +1,33 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 1
+      basename: node-affinity-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: pausepods
+          file: pod-pause-node-affinity.json
+
+    - num: 1
+      basename: node-anti-affinity-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: docker.io/ocpqe/hello-pod
+          basename: hellopods
+          file: pod-hello-node-anti-affinity.json
+
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 40
+          pause: 180
+        ratelimit:
+          delay: 0
+

--- a/openshift_scalability/content/pod-hello-node-anti-affinity.json
+++ b/openshift_scalability/content/pod-hello-node-anti-affinity.json
@@ -1,0 +1,67 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-pod-anti-affinity",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "hello-pod-anti-affinity"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+    "affinity": {
+      "nodeAffinity": {
+         "requiredDuringSchedulingIgnoredDuringExecution": {
+           "nodeSelectorTerms": [
+             {
+              "matchExpressions": [
+                {
+                  "key": "beta.kubernetes.io/arch",
+                  "operator": "NotIn",
+                  "values": [
+                     "amd64"
+                  ]
+                }
+               ]
+             }
+           ]
+         }
+       }
+     }
+  },
+
+  "status": {}
+}
+

--- a/openshift_scalability/content/pod-pause-node-affinity.json
+++ b/openshift_scalability/content/pod-pause-node-affinity.json
@@ -1,0 +1,67 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "pause-amd64",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "pause-amd64"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "pause-amd64",
+        "image": "gcr.io/google_containers/pause-amd64:3.0",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+    "affinity": {
+      "nodeAffinity": {
+         "requiredDuringSchedulingIgnoredDuringExecution": {
+           "nodeSelectorTerms": [
+             {
+              "matchExpressions": [
+                {
+                  "key": "cpu",
+                  "operator": "Gt",
+                  "values": [
+                     "4"
+                  ]
+                }
+               ]
+             }
+           ]
+         }
+       }
+     }
+  },
+
+  "status": {}
+}
+


### PR DESCRIPTION
Initial commit of GoLang cluster-loader config file and pod json config files to for the Node Affinity/Anti-affinity testcase:
- openshift_scalability/config/golang/node-affinity-anti-affinity.yaml
- openshift_scalability/content/pod-hello-node-anti-affinity.json
- openshift_scalability/content/pod-pause-node-affinity.json

When executed from GoLang cluster-loader, 250 pausepods get deployed on one node with cpu label > 4 (affinity), and 250 hellopods get deployed on node with does not have label "beta.kubernetes.io/arch" (anti-affinity).