### PR TITLE
New golang cluster-loader config files and pod json templates for pod…

### DIFF
--- a/openshift_scalability/config/golang/pod-affinity-anti-affinity.yaml
+++ b/openshift_scalability/config/golang/pod-affinity-anti-affinity.yaml
@@ -1,0 +1,34 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 1
+      basename: pod-affinity-s1-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: docker.io/ocpqe/hello-pod
+          basename: pod-affinity-security-in-s1
+          file: pod-pod-affinity.json
+
+    - num: 1
+      basename: pod-anti-affinity-s1-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: docker.io/ocpqe/hello-pod
+          basename: pod-anti-affinity-security-in-s1
+          file: pod-pod-anti-affinity.json
+
+
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 50
+          pause: 180
+        ratelimit:
+          delay: 0
+

--- a/openshift_scalability/content/pod-pod-affinity.json
+++ b/openshift_scalability/content/pod-pod-affinity.json
@@ -1,0 +1,73 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "pod-affinity-ins1",
+    "creationTimestamp": null,
+    "labels": {
+      "security": "s1"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+    "affinity": {
+        "podAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchExpressions": [
+                            {
+                                "key": "security",
+                                "operator": "In",
+                                "values": [
+                                    "s1"
+                                ]
+                            }
+                        ]
+                    },
+                    "namespaces": [
+                            "s1-proj"
+                    ],
+                    "topologyKey": "kubernetes.io/hostname"
+                }
+            ]
+        }
+    }
+
+  },
+
+  "status": {}
+}
+
+

--- a/openshift_scalability/content/pod-pod-anti-affinity.json
+++ b/openshift_scalability/content/pod-pod-anti-affinity.json
@@ -1,0 +1,73 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "pod-anti-affinity-in-s1",
+    "creationTimestamp": null,
+    "labels": {
+      "security": "s1"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+    "affinity": {
+        "podAntiAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchExpressions": [
+                            {
+                                "key": "security",
+                                "operator": "In",
+                                "values": [
+                                    "s1"
+                                ]
+                            }
+                        ]
+                    },
+                    "namespaces": [
+                            "s1-proj"
+                    ],
+                    "topologyKey": "kubernetes.io/hostname"
+                }
+            ]
+        }
+    }
+
+  },
+
+  "status": {}
+}
+
+


### PR DESCRIPTION
Initial commit of config files needed to run the the Pod Affinity and Pod Anti-affinity scalability testcases:

- golang cluster-loader config file to deploy 250 hello-pods using pod affinity scheduling on one node, and 250 hello-pods on another node using pod anti-affinity scheduling:
    - openshift_scalability/config/golang/pod-affinity-anti-affinity.yaml
- pod json config files:  
    - openshift_scalability/content/pod-pod-affinity.json
    - openshift_scalability/content/pod-pod-anti-affinity.json