### PR TITLE
Added new mirror repo rhel-7-server-ansible-2.4-rpms for ansible install

### DIFF
--- a/image_provisioner/playbooks/roles/ansible-update/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/ansible-update/tasks/main.yaml
@@ -4,10 +4,10 @@
     name: ansible
     state: absent
 
-- name: install ansible from aos.repo
+- name: install ansible from rhel7-server-ansible.repo
   yum:
     name: ansible
-    disablerepo: epel,rhel-7-extras-next
-    enablerepo: aos
+    disablerepo: "*"
+    enablerepo: rhel-7-server-ansible
     state: present
 

--- a/image_provisioner/playbooks/roles/repo-install/files/rhel7-server-ansible.repo
+++ b/image_provisioner/playbooks/roles/repo-install/files/rhel7-server-ansible.repo
@@ -1,0 +1,9 @@
+[rhel-7-server-ansible]
+name=rhel-7-server-ansible-2.4-rpms
+baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.4-rpms/
+failovermethod=priority
+enabled=1
+gpgcheck=0
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -69,6 +69,11 @@
           src: rhel7-ceph.repo
           dest: /etc/yum.repos.d
 
+      - name: install rhel-7-server-ansible-rpms mirror.openshift.com repo
+        copy:
+          src: rhel7-server-ansible.repo
+          dest: /etc/yum.repos.d
+
       #- name: install pbench-internal repo
       #  template:
       #    src: etc/yum.repos.d/pbench.repo.j2


### PR DESCRIPTION
Ansible package will no longer be available in the aos.repo.  In OCP 3.9 it will be provided in the ansible repo which is mirrored:
https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.4-rpms/

- created new repo file:  image_provisioner/playbooks/roles/repo-install/files/rhel7-server-ansible.repo
- updated role create-repo to install this new repo
- updated role ansible-update to install ansible only from the newly created rhel7-server-ansible repo

More details are also summarized here:
- https://github.com/openshift/openshift-docs/pull/7890
- https://bugzilla.redhat.com/show_bug.cgi?id=1547973