### PR TITLE
Updated task install openshift packages ito install latest openvswitch from rhel7-fast-datapath-rpms repo

### DIFF
--- a/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
@@ -1,15 +1,9 @@
 ---
-## pre-installing the openvswitch version 2.9.0 so it won't pick up  
-## version "1:2.8.0-4.el7fdb" from rhel7-fast-datapath-htb  
-- name: install openvswitch-2.9.0 from rhel7-fast-datapath-rpms repo
-  yum:
-    name: openvswitch-2.9.0
-    disablerepo: "*"
-    enablerepo: rhel7-fast-datapath
-    state: present
-
-- name: install openshift packages
-  yum: name={{ item }} state=latest
+- name: install openshift packages with openvswitch from rhel7-fast-datapath-rpms by disabling rhel7-fast-datapath-htb repo 
+  yum: 
+    name: "{{ item }}"
+    state: latest
+    disablerepo: rhel7-fast-datapath-htb
   with_items:
     - atomic-openshift-sdn-ovs
     - atomic-openshift-tests

--- a/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
@@ -1,4 +1,13 @@
 ---
+## pre-installing the openvswitch version 2.9.0 so it won't pick up  
+## version "1:2.8.0-4.el7fdb" from rhel7-fast-datapath-htb  
+- name: install openvswitch-2.9.0 from rhel7-fast-datapath-rpms repo
+  yum:
+    name: openvswitch-2.9.0
+    disablerepo: "*"
+    enablerepo: rhel7-fast-datapath
+    state: present
+
 - name: install openshift packages
   yum: name={{ item }} state=latest
   with_items:

--- a/image_provisioner/playbooks/roles/repo-install/files/rhel7-fast-datapath-stage.repo
+++ b/image_provisioner/playbooks/roles/repo-install/files/rhel7-fast-datapath-stage.repo
@@ -1,0 +1,9 @@
+[rhel-7-fast-datapath-stage]
+name=rhel-7-fast-datapath-stage-rpms
+baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-fast-datapath-stage-rpms/
+failovermethod=priority
+enabled=1
+gpgcheck=0
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -74,6 +74,11 @@
           src: rhel7-server-ansible.repo
           dest: /etc/yum.repos.d
 
+      - name: install rhel-7-fast-datapath-stage-rpms mirror.openshift.com repo
+        copy:
+          src: rhel7-fast-datapath-stage.repo
+          dest: /etc/yum.repos.d
+
       #- name: install pbench-internal repo
       #  template:
       #    src: etc/yum.repos.d/pbench.repo.j2


### PR DESCRIPTION
Installing atomic-openshift-sdn-ovs pkg will also install as a dependency the openvswitch pkg.
In order to install the latest openvswitch pkg from the staging rhel7-fast-datapath-rpms repo, we needed to disable the rhel7-fast-datapath-htb repo.