### PR TITLE
Remove timeout and on mb client failure only issue a warning.

### DIFF
--- a/openshift_scalability/content/centos-stress/root/bin/run
+++ b/openshift_scalability/content/centos-stress/root/bin/run
@@ -240,13 +240,11 @@ main() {
         die 1 "${RUN} failed: 1: no targets provided."
       fi
 
-      $timeout \
-        $mb \
-          -d${RUN_TIME:-600} \
-          -r${MB_RAMP_UP:-0} \
-          -i ${requests_json} \
-          -o ${results_csv}.$$ > $mb_log 2>&1
-      timeout_exit_status || die $? "${RUN} failed: $?"
+      $mb \
+        -d${RUN_TIME:-600} \
+        -r${MB_RAMP_UP:-0} \
+        -i ${requests_json} \
+        -o ${results_csv}.$$ > $mb_log 2>&1 || warn "${RUN} failed: $?"
       LC_ALL=C sort -t, -n -k1 ${results_csv}.$$ > ${results_csv}
       rm -f ${results_csv}.$$
       $graph_sh ${graph_dir} ${results_csv} $dir_out/graphs $interval


### PR DESCRIPTION
Removing timeout as the real test can take a little longer in some
cases, especially during DNS resolver retries.  The mb tool resolves
the target hosts before running the http(s) tests.  When faced with
a slow DNS server when getaddrinfo() is retried, timeout might kill
the mb client prematurely, also leaving less time for the real
testing.  Timeout command was introduced in the past with badly behaved
clients.  The mb client always exists gracefully after the test
duration, so it is no longer needed.

When mb client exits with a non-zero status, do not fail and try to
copy the mb logs for analysis.  This will help during large-scale
tests, so that possibly other test iterations are not blocked by an
intermittent failure.