### PR TITLE
New golang cluster-loader config files for taints and toleration scalability testcase

### DIFF
--- a/openshift_scalability/config/golang/node-taints-pod-tolerations.yaml
+++ b/openshift_scalability/config/golang/node-taints-pod-tolerations.yaml
@@ -1,0 +1,32 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 1
+      basename: taints-toleration-s1-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: docker.io/ocpqe/hello-pod
+          basename: hellopods-taints-s1
+          file: pod-hello-s1-taints-tolerations.json
+
+    - num: 1
+      basename: taints-toleration-s2-
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 250
+          image: docker.io/ocpqe/hello-pod
+          basename: hellopods-taints-s2
+          file: pod-hello-s2-taints-tolerations.json
+
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 50
+          pause: 60
+        ratelimit:
+          delay: 0

--- a/openshift_scalability/content/pod-hello-s1-taints-tolerations.json
+++ b/openshift_scalability/content/pod-hello-s1-taints-tolerations.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-taints-s1",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "taints-tolerations-s1"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+
+    "tolerations": [
+        {
+            "effect": "NoSchedule",
+            "key": "security",
+            "operator": "Equal",
+            "value": "s1"
+        }
+      ]
+  },
+
+  "status": {}
+}

--- a/openshift_scalability/content/pod-hello-s2-taints-tolerations.json
+++ b/openshift_scalability/content/pod-hello-s2-taints-tolerations.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-taints-s2",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "taints-tolerations-s2"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+
+    "tolerations": [
+        {
+            "effect": "NoSchedule",
+            "key": "security",
+            "operator": "Equal",
+            "value": "s2"
+        }
+      ]
+  },
+
+  "status": {}
+}


### PR DESCRIPTION
GoLang cluster-loader Yaml configuration file for taints and toleration:
- openshift_scalability/config/golang/node-taints-pod-tolerations.yaml

Pod json config files for with tolerations for node taints:
- openshift_scalability/content/pod-hello-s1-taints-tolerations.json
- openshift_scalability/content/pod-hello-s2-taints-tolerations.json