### PR TITLE
Optionally blacklist NVMe devices from being claimed by multipath.

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -69,3 +69,5 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+# multipath-blacklist
+multipath_blacklist=False

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -60,3 +60,5 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+# multipath-blacklist
+multipath_blacklist=False

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -64,3 +64,5 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+# multipath-blacklist
+multipath_blacklist=False

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -60,6 +60,7 @@
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
     - { role: cri-o, when: crio | default(False) | bool }
+    - { role: multipath-blacklist, when: multipath_blacklist | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool }
     - { role: aos-ansible }
     - { role: ansible-update, when: not atomic | default(False) | bool }

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -18,6 +18,7 @@
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
     - { role: cri-o, when: crio | default(False) | bool }
+    - { role: multipath-blacklist, when: multipath_blacklist | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool}
     - { role: aos-ansible }
     - { role: pbench-kickstart }

--- a/image_provisioner/playbooks/roles/multipath-blacklist/files/blacklist.conf
+++ b/image_provisioner/playbooks/roles/multipath-blacklist/files/blacklist.conf
@@ -1,0 +1,3 @@
+blacklist {
+  devnode "^nvme*"
+}

--- a/image_provisioner/playbooks/roles/multipath-blacklist/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/multipath-blacklist/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Create the multipath configuration directory
+  file: path="{{ multipathd_conf_dir }}" state=directory
+
+- name: Copy the multipathd blacklist file
+  copy:
+    src: blacklist.conf
+    dest: "{{ multipathd_conf_dir }}/50-blacklist.conf"

--- a/image_provisioner/playbooks/roles/multipath-blacklist/vars/main.yaml
+++ b/image_provisioner/playbooks/roles/multipath-blacklist/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+multipathd_conf_dir: "/etc/multipath/conf.d/"


### PR DESCRIPTION
This PR prevents NVMe devices from being claimed by multipath.
Openshift-ansible has iSCSI dependency in osn_storage_plugin_deps,
which in turn depends on multipath.