### PR TITLE
Add extra_tags option for AMI's

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -11,6 +11,7 @@ group_id=
 # for ena to be supported, the instance_type needs to be a C5, F1, G3, H1, I3, M5, P2, P3, R4, X1 or m4.16xlarge
 #instance_type=m5.large
 instance_type=m4.xlarge
+extra_tags=
 vpc_subnet_id=
 base_image=
 instance_tag=

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -79,6 +79,16 @@
     set_fact:
       ami_type: "{{ 'atomic' if atomic | default(False) else 'rhel' }}"
 
+  - name: set ami_name when extra_tags is defined
+    set_fact:
+      ami_name: ocp-{{ openshift_version }}-{{ ami_type }}-{{ extra_tags }}-gold
+    when: extra_tags is defined
+
+  - name: set ami_name when extra_tags is not defined or is empty
+    set_fact:
+      ami_name:  ocp-{{ openshift_version }}-{{ ami_type }}-gold
+    when: extra_tags is not defined or extra_tags == ""
+
   - name: bundle ami
     action: 
       module: ec2_ami
@@ -88,7 +98,7 @@
       region: "{{ region }}"
       state: present
       description: This was provisioned {{ ansible_date_time.iso8601 }}
-      name: ocp-{{ openshift_version }}-{{ ami_type }}-gold
+      name: "{{ ami_name }}"
       wait: yes
     register: amioutput
 


### PR DESCRIPTION
This commit allows us to add extra tags to the gold image name. This
is needed to differentiate m5.x supported images from others.