### PR TITLE
Note that JMeter stress tool is deprecated

### DIFF
--- a/openshift_scalability/content/centos-stress/README.md
+++ b/openshift_scalability/content/centos-stress/README.md
@@ -31,7 +31,7 @@ Add description.
 
 ### JMeter
 
-Add description.
+This method of traffic generation has been deprecated.
 
 ### mb
 


### PR DESCRIPTION
JMeter centos-stress tool is obsolete.  The mb tool should be used.