### PR TITLE
Use LVM storage for docker overlay2 filesystem

### DIFF
--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -39,10 +39,19 @@
   when: atomic | default(False) | bool
 
 - block:
+   - name: create overlay2 physical volume
+     command: pvcreate -f {{ docker_storage_device }}
+
+   - name: create overlay2 volume group
+     command: vgcreate {{ docker_storage_vgname }}  {{ docker_storage_device }}
+
+   - name: create overlay2 logical volume
+     command: lvcreate --name lvol0 --extents 90%FREE {{ docker_storage_vgname }}
+
    - name: format the partition
      filesystem:
        fstype: xfs
-       dev: "{{ docker_storage_device }}"
+       dev: "/dev/mapper/{{ docker_storage_vgname }}-lvol0"
 
    - name: set docker_storage_mount_path if empty or undefined
      set_fact:
@@ -52,7 +61,7 @@
    - name: update fstab
      lineinfile:
        path: /etc/fstab
-       line: "{{ docker_storage_device }} {{ docker_storage_mount_path }}                    xfs   defaults        0 0"
+       line: "/dev/mapper/{{ docker_storage_vgname }}-lvol0 {{ docker_storage_mount_path }}                    xfs   defaults        0 0"
        insertafter: EOF
   when: docker_storage_driver == "overlay2" and not atomic | default(False) | bool
   


### PR DESCRIPTION
Switch to using LVM storage for the /var/lib/docker/overlay2 filesystem.   Gives more flexibility for resizing, if needed.   