### PR TITLE
removed memory limits in fio-template

### DIFF
--- a/openshift_scalability/content/fio/fio-template.json
+++ b/openshift_scalability/content/fio/fio-template.json
@@ -59,16 +59,6 @@
                                 "targetPort": 8765
                             }
                         ],
-                        "resources": {
-                           "limits": {
-                                "cpu": "800m",
-                                "memory": "20Mi"
-                            },
-                            "requests": {
-                                "cpu": "10m",
-                                "memory": "10Mi"
-                            }
-                        },
                         "volumeMounts": [
                             {
                                 "name": "${VOL_MOUNT_NAME}",


### PR DESCRIPTION
I found it limiting for fio tests to have memory limits for fio-pods. Removing that limitation from fio template 

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>