### PR TITLE
ovs and atomic-openshift-sdn now run as a daemonset.  Do not install.

### DIFF
--- a/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/openshift-package-install/tasks/main.yaml
@@ -1,11 +1,9 @@
 ---
-- name: install openshift packages with openvswitch from rhel7-fast-datapath-rpms by disabling rhel7-fast-datapath-htb repo 
+- name: install openshift packages 
   yum: 
     name: "{{ item }}"
     state: latest
-    disablerepo: rhel7-fast-datapath-htb
   with_items:
-    - atomic-openshift-sdn-ovs
     - atomic-openshift-tests
     - atomic-openshift-node
     - atomic-openshift-pod

--- a/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/all.repo.j2
+++ b/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/all.repo.j2
@@ -53,15 +53,6 @@ enabled=1
 gpgcheck=0
 sslverify=0
 
-# This htb repo gets us openvswitch-2.6, and is required until the htb bits are promoted to the above GA channel (GA is openvswitch-2.5 for now).
-[rhel7-fast-datapath-htb]
-name=RHEL7 fast-datapath HTB
-baseurl=http://{{ jump_node_ip }}/rhel7-fast-datapath-htb
-failovermethod=priority
-enabled=1
-gpgcheck=0
-sslverify=0
-
 [oso-rhui-rhel-server-extras]
 name=OpenShift Online RHUI Mirror RH Enterprise Linux 7 - Extras
 baseurl=http://{{ jump_node_ip }}/oso-rhui-rhel-server-extras


### PR DESCRIPTION
@wabouhamad @chaitanyaenr PTAL

This is a breaking change for generating images for older releases of OpenShift.  Is it time to have release branches of svt (like openshift-ansible does)?   Thoughts?

In the interim, we need to disable openvswitch on our clusters so that the ovs pods don't crash loop