### PR TITLE
Better defaults for log test until we can fully parameterize it

### DIFF
--- a/openshift_scalability/config/ocp-logtest.yaml
+++ b/openshift_scalability/config/ocp-logtest.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 1
+  - num: 100
     basename: logtest
     ifexists: delete
     tuning: default
@@ -7,8 +7,8 @@ projects:
       - num: 1
         file: ./content/logtest/logtest-rc.json
         parameters:
-         - REPLICAS: "3"
-         - INITIAL_FLAGS: "--num-lines 0 --line-length 200 --word-length 9 --rate 60 --fixed-line\n"
+         - REPLICAS: "1"
+         - INITIAL_FLAGS: "--num-lines 20000 --line-length 1024 --word-length 9 --rate 1200 --fixed-line\n"
 
 tuningsets:
   - name: default


### PR DESCRIPTION
@chaitanyaenr This will run 100 pods each at a rate of 1200 1Kb messages/minutes until 20000 messages have been generated - roughly 15 minutes.  I think this is a reasonable starting point and we can iterate if needed.