### PR TITLE
Mount volume at /var/lib/docker instead of /var/lib/docker/overlay2

### DIFF
--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -55,7 +55,7 @@
 
    - name: set docker_storage_mount_path if empty or undefined
      set_fact:
-        docker_storage_mount_path: "/var/lib/docker/overlay2"
+        docker_storage_mount_path: "/var/lib/docker"
      when: ( docker_storage_mount_path == "" or docker_storage_mount_path is not defined )
 
    - name: update fstab


### PR DESCRIPTION
This is needed as /var/lib/docker/overlay2 filesystem gets unmounted
when docker is restarted or stopped.
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1568450