### PR TITLE
Modify conformance to work for ocp 3.10

### DIFF
--- a/conformance/removeNodeSelector.yaml
+++ b/conformance/removeNodeSelector.yaml
@@ -11,11 +11,7 @@
         path: /etc/origin/master/master-config.yaml
         regexp: 'defaultNodeSelector: .*'
         replace: 'defaultNodeSelector: ""'
-    - name: Restart master services
-      systemd:
-        name: "{{ item }}"
-        state: restarted
-      with_items:
-        - atomic-openshift-master-controllers
-        - atomic-openshift-master-api
-
+    - name: Restart the static pod for api
+      shell: /usr/local/bin/master-restart api
+    - name: Restart the static pod for controllers
+      shell: /usr/local/bin/master-restart controllers

--- a/conformance/restoreNodeSelector.yaml
+++ b/conformance/restoreNodeSelector.yaml
@@ -8,10 +8,7 @@
       copy: src=/etc/origin/master/master-config.yaml dest=/etc/origin/master/master-config.yaml.after.conformance
     - name: Restore original master-config
       copy: src=/etc/origin/master/master-config.yaml.before.conformance dest=/etc/origin/master/master-config.yaml
-    - name: Restart master services
-      systemd:
-        name: "{{ item }}"
-        state: restarted
-      with_items:
-        - atomic-openshift-master-controllers
-        - atomic-openshift-master-api
+    - name: Restart the static pod for api
+      shell: /usr/local/bin/master-restart api
+    - name: Restart the static pod for controllers
+      shell: /usr/local/bin/master-restart controllers

--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -15,7 +15,7 @@ SERIAL_TESTS="Serial"
 SERIAL_SKIP="Flaky|Disruptive|Slow"
 
 setup_prereqs() {
-   yum -y install atomic-openshift-tests
+   yum -y install go atomic-openshift-tests
    mkdir /root/go
    export GOPATH=/root/go
    export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
This commit modifies the script to restart the api and controller
pods instead of services.