### PR TITLE
Update imagestream workaround for jenkins for 3.10

### DIFF
--- a/conformance/svt_conformance.sh
+++ b/conformance/svt_conformance.sh
@@ -33,7 +33,7 @@ import_wildfly() {
 
 fix_jenkins() {
    oc get -n openshift -o yaml is jenkins > /tmp/jenkins.yaml
-   sed -i.orig 's/jenkins-2-rhel7:v3.9/jenkins-2-rhel7:latest/g' /tmp/jenkins.yaml
+   sed -i.orig 's/jenkins-2-rhel7:v3.10/jenkins-2-rhel7:latest/g' /tmp/jenkins.yaml
    oc replace --namespace=openshift -f /tmp/jenkins.yaml
 }
 


### PR DESCRIPTION
In 3.10, the jenkins "latest" tag in the imagestream is an alias for the v3.10 image.  However this image is not yet available on registry.access.redhat.com.   As we did in 3.9, update the imagestream to have "latest" point to the actual "latest" tag in the registry.

This allows the build-related conformance tests to pass.

See:  https://bugzilla.redhat.com/show_bug.cgi?id=1535099 and internal mailing lists for discussion. 