### PR TITLE
Updated task in role docker-config by reverting PR415 and new docker-storage-setup config params

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -40,7 +40,8 @@ docker_storage_device=/dev/xvdb
 #docker_storage_device=/dev/nvme1n1
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
-docker_storage_mount_path=/var/lib/docker/overlay2
+# docker_storage_mount_path should be: "/var/lib/docker" as of BZ 1568450
+docker_storage_mount_path=/var/lib/docker
 container_root_lv_mount_path=/var/lib/docker
 # updates the kernel if set to true
 update_kernel=false

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -31,7 +31,8 @@ docker_login=no
 docker_storage_device=/dev/nvme0n1
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
-docker_storage_mount_path=/var/lib/docker/overlay2
+# docker_storage_mount_path should be: "/var/lib/docker" as of BZ 1568450
+docker_storage_mount_path=/var/lib/docker
 container_root_lv_mount_path=/var/lib/docker
 update_kernel=true
 # baremetal DNS server config

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -36,7 +36,8 @@ docker_login=no
 docker_storage_device=/dev/xvdb
 docker_storage_vgname=docker_vg
 docker_storage_driver=overlay2
-docker_storage_mount_path=/var/lib/docker/overlay2
+# docker_storage_mount_path should be: "/var/lib/docker" as of BZ 1568450
+docker_storage_mount_path=/var/lib/docker
 container_root_lv_mount_path=/var/lib/docker
 # updates the kernel if set to true
 update_kernel=false

--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -39,19 +39,10 @@
   when: atomic | default(False) | bool
 
 - block:
-   - name: create overlay2 physical volume
-     command: pvcreate -f {{ docker_storage_device }}
-
-   - name: create overlay2 volume group
-     command: vgcreate {{ docker_storage_vgname }}  {{ docker_storage_device }}
-
-   - name: create overlay2 logical volume
-     command: lvcreate --name lvol0 --extents 90%FREE {{ docker_storage_vgname }}
-
    - name: format the partition
      filesystem:
        fstype: xfs
-       dev: "/dev/mapper/{{ docker_storage_vgname }}-lvol0"
+       dev: "{{ docker_storage_device }}"
 
    - name: set docker_storage_mount_path if empty or undefined
      set_fact:
@@ -61,11 +52,11 @@
    - name: update fstab
      lineinfile:
        path: /etc/fstab
-       line: "/dev/mapper/{{ docker_storage_vgname }}-lvol0 {{ docker_storage_mount_path }}                    xfs   defaults        0 0"
+       line: "{{ docker_storage_device }} {{ docker_storage_mount_path }}                    xfs   defaults        0 0"
        insertafter: EOF
   when: docker_storage_driver == "overlay2" and not atomic | default(False) | bool
   
-- name: check that docker-storage has been deleted
+- name: check if docker-storage already exists
   stat:
     path: /etc/sysconfig/docker-storage
   register: ds_config

--- a/image_provisioner/playbooks/roles/docker-config/templates/etc/sysconfig/docker-storage-setup-rhel.j2
+++ b/image_provisioner/playbooks/roles/docker-config/templates/etc/sysconfig/docker-storage-setup-rhel.j2
@@ -1,1 +1,6 @@
 STORAGE_DRIVER="{{ docker_storage_driver }}"
+DEVS="{{ docker_storage_device }}"
+VG="{{ docker_storage_vgname }}"
+CONTAINER_ROOT_LV_MOUNT_PATH="{{ docker_storage_mount_path }}"
+CONTAINER_ROOT_LV_NAME="docker-root-lv"
+CONTAINER_ROOT_LV_SIZE=100%FREE


### PR DESCRIPTION
- Reverting PR 415 changes that use LVM storage for docker overlay2 filesystem
- updated /etc/sysconfig/docker-storage-setup template file to include docker mount and variables specified in BZ 1568450
- updated the docker_storage_mount_path variable in inventory file examples  with the value "/var/lib/docker"