### PR TITLE
Add support to run logging tests

### DIFF
--- a/openshift_scalability/config/golang/logtest.yaml
+++ b/openshift_scalability/config/golang/logtest.yaml
@@ -1,0 +1,23 @@
+provider: local
+ClusterLoader:
+  cleanup: true
+  projects:
+    - num: 100
+      basename: logtest
+      ifexists: delete
+      tuning: default
+      templates:
+        - num: 1
+          file: ./logtest/logtest-rc.json
+          parameters:
+           - REPLICAS: "1"
+           - INITIAL_FLAGS: "--num-lines 20000 --line-length 1024 --word-length 9 --rate 1200 --fixed-line\n"
+
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 5
+          pause: 0
+        rate_limit:
+          delay: 0

--- a/openshift_scalability/logging.sh
+++ b/openshift_scalability/logging.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+if [ "$#" -ne 1 ]; then
+  echo "syntax: $0 <TYPE>"
+  echo "<TYPE> should be either golang or python"
+  exit 1
+fi
+
+TYPE=$1
+
+long_sleep() {
+  local sleep_time=180
+  echo "Sleeping for $sleep_time"
+  sleep $sleep_time
+}
+
+golang_clusterloader() {
+  # Export kube config
+  export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
+  MY_CONFIG=config/golang/logtest
+  # loading cluster based on yaml config file
+  /usr/libexec/atomic-openshift/extended.test --ginkgo.focus="Load cluster" --viper-config=$MY_CONFIG
+}
+
+python_clusterloader() {
+  MY_CONFIG=config/ocp-logtest.yaml
+  python cluster-loader.py -f $MY_CONFIG
+}
+
+# sleeping to gather some steady-state metrics, pre-test
+long_sleep
+
+echo "Run tests" 
+if [ "$TYPE" == "golang" ]; then
+  golang_clusterloader
+elif [ "$TYPE" == "python" ]; then
+  python_clusterloader
+else
+  echo "$TYPE is not a valid option, available options: golang, python"
+  exit 1
+fi
+
+# sleep after test is complete to gather post-test metrics
+long_sleep


### PR DESCRIPTION
This commit:
- adds a config supported by golang clusterloader.
- adds a script to run logging tests.