### PR TITLE
Bake in more packages

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -73,6 +73,14 @@
       - iscsi-initiator-utils
       - deltarpm
       - jq
+      - cockpit
+      - cockpit-docker
+      - device-mapper-multipath
+      - dnsmasq
+      - haproxy
+      - libarchive
+      - ostree
+      - skopeo
 
   - name: Download binaries
     get_url:


### PR DESCRIPTION
Jiri found out the list of packages that are missing from the gold
image that openshift-ansible installs during the ocp installation.
This commit takes care of installing those.