### PR TITLE
Support for compiling more recent wolfSSL libraries.

### DIFF
--- a/openshift_scalability/content/centos-stress/Dockerfile
+++ b/openshift_scalability/content/centos-stress/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR ${APP_ROOT}
 COPY root ./
 
 ### Install required packages
-RUN yum -y --setopt=tsflags=nodocs install bc epel-release gcc git gnuplot go \
-        java-1.8.0-openjdk make openssh-clients patch rsync tar unzip && \
+RUN yum -y --setopt=tsflags=nodocs install automake autotools bc epel-release \
+        gcc git gnuplot go java-1.8.0-openjdk libtool make openssh-clients \
+        patch rsync tar unzip && \
     yum -y --setopt=tsflags=nodocs install stress && \
     mkdir -p build && cd build && \
     git clone https://github.com/openshift/svt.git && \
@@ -17,7 +18,7 @@ RUN yum -y --setopt=tsflags=nodocs install bc epel-release gcc git gnuplot go \
     git clone -b stable https://github.com/jmencak/mb.git && \
       cd mb && make && cp ./mb /usr/local/bin && cd .. && \
     cd && rm -rf build && \
-    yum remove gcc go make patch -y && \
+    yum remove automake autotools gcc go libtool make patch -y && \
     yum clean all
 
 ### Setup JMeter

--- a/openshift_scalability/content/centos-stress/root/bin/run
+++ b/openshift_scalability/content/centos-stress/root/bin/run
@@ -205,7 +205,7 @@ main() {
 
     mb)
       local requests_awk=requests-mb.awk
-      local dir_out=${RESULTS_DIR:-${RUN}-${HOSTNAME:-${IDENTIFIER:-0}}}
+      local dir_out=${RUN}-${HOSTNAME}-${IDENTIFIER:-0}
       local SERVER_RESULTS=${SERVER_RESULTS:-$GUN}
       local mb_log=$dir_out/${RUN}.log
       local targets_list=/opt/wlg/targets.txt

--- a/openshift_scalability/content/centos-stress/root/requests-mb.awk
+++ b/openshift_scalability/content/centos-stress/root/requests-mb.awk
@@ -1,4 +1,4 @@
-/^nginx-route-/ { # insecure routes
+/server-http-/ { # insecure routes
   if (i) {printf "\n  },\n" }
   printf "  {\n"
 #  printf "    \"host_from": \"192.168.0.102\",
@@ -21,7 +21,7 @@
   printf "    }"
   i++
 }
-/^secure-nginx-route-/ { # secure routes
+/server-tls-/ { # secure routes
   if (i) {printf "\n  },\n" }
   printf "  {\n"
   printf "    \"scheme\": \"https\",\n"

--- a/openshift_scalability/content/quickstarts/stress/stress-pod.json
+++ b/openshift_scalability/content/quickstarts/stress/stress-pod.json
@@ -98,10 +98,6 @@
                                 "name": "GUN_PORT",
                                 "value": "${GUN_PORT}"
                             },
-                            {   
-                                "name": "RESULTS_DIR",
-                                "value": "${RESULTS_DIR}"
-                            },
                             {
                                 "name": "SERVER_RESULTS",
                                 "value": "${SERVER_RESULTS}"
@@ -284,12 +280,6 @@
             "displayName": "GUN Port Number",
             "description": "The port number of the machine running cluster loader",
             "value": "9090"
-        },
-        {
-            "name": "RESULTS_DIR",
-            "displayName": "Test result directory",
-            "description": "Local/Container test results directory, if empty, default will be used",
-            "value": ""
         },
         {
             "name": "SERVER_RESULTS",


### PR DESCRIPTION
wolfSSL started distributing their libraries without the ./configure script.
Adding automake, autotools and libtool packages to allow compilation and integration
with the mb tool.