### PR TITLE
Fix the project prefix filter in metrics checker tool.

### DIFF
--- a/logging_metrics_performance/hawkular_metrics/scripts/README_metricsChecker.md
+++ b/logging_metrics_performance/hawkular_metrics/scripts/README_metricsChecker.md
@@ -31,7 +31,7 @@ This translates to "Check projects starting with svt.  Check past 5 2 minute buc
 ```python metrics_checker.py <optional-arguments>```
 
 - **-B** bearer token from oc whoami -t
-- **-p** project prefix (possibly broken right now, but required)
+- **-p** project sub-string. It will query for pods in the projects that contain this string.
 - **-H** Hawkular hostname from oc get routes.  Or, internal IP of hawkular-metrics pod from oc get pods -o wide
 - **-s** start time of buckets.  Example:  -10mn is 10 minutes in the past.  See:  http://www.hawkular.org/docs/rest/rest-metrics.html
 - **-d** bucket duration.  See:  http://www.hawkular.org/docs/rest/rest-metrics.html

--- a/logging_metrics_performance/hawkular_metrics/scripts/metrics_checker.py
+++ b/logging_metrics_performance/hawkular_metrics/scripts/metrics_checker.py
@@ -21,11 +21,13 @@ def all_pods(prefix):
         current_pod={}
         pod_props = pod.split()
         if len(pod_props) == 4:
-            current_pod["namespace"] = pod_props[0]
-            current_pod["name"] = pod_props[1]
-            current_pod["uid"] = pod_props[2]
-            current_pod["containername"] = pod_props[3]
-            pods.append(current_pod)
+           if pod_props[0].find(prefix) != -1:
+              current_pod["namespace"] = pod_props[0]
+              #print pod_props[0]
+              current_pod["name"] = pod_props[1]
+              current_pod["uid"] = pod_props[2]
+              current_pod["containername"] = pod_props[3]
+              pods.append(current_pod)
     return pods
 
 def test_pod_metrics(pod, hawkular_host, bearer, start_time, bucket_duration):


### PR DESCRIPTION
Currently the -p option of the tools is not filtering the projects based on the prefix. This change will fix it.