### PR TITLE
Add support for nodevertical to schedule pods on labeled nodes

### DIFF
--- a/openshift_scalability/config/golang/nodeVertical-labeled-nodes.yaml
+++ b/openshift_scalability/config/golang/nodeVertical-labeled-nodes.yaml
@@ -1,0 +1,21 @@
+provider: local
+ClusterLoader:
+  cleanup: true
+  projects:
+    - num: 1
+      basename: clusterproject
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 1000
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: pausepods
+          file: pod-pause-labeled-nodes.json
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 50
+          pause: 60
+        ratelimit:
+          delay: 0

--- a/openshift_scalability/content/pod-pause-labeled-nodes.json
+++ b/openshift_scalability/content/pod-pause-labeled-nodes.json
@@ -1,0 +1,42 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "pause-amd64",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "pause-amd64"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "pause-amd64",
+        "image": "gcr.io/google_containers/pause-amd64:3.0",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {
+        },
+        "securityContext": {
+          "capabilities": {
+          },
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+    "nodeSelector": {
+      "nodevertical": "true"
+    }
+  },
+  "status": {
+  }
+}

--- a/openshift_scalability/nodeVertical.sh
+++ b/openshift_scalability/nodeVertical.sh
@@ -1,13 +1,21 @@
 #!/bin/sh
 
-if [ "$#" -ne 2 ]; then
-  echo "syntax: $0 <TESTNAME> <TYPE>"
+if [ "$#" -ne 3 ]; then
+  echo "syntax: $0 <TESTNAME> <TYPE> <ENVIRONMENT>"
   echo "<TYPE> should be either golang or python"
+  echo "<ENVIRONMENT> should be either alderaan or aws"
   exit 1
 fi
 
 TESTNAME=$1
 TYPE=$2
+ENVIRONMENT=$3
+LABEL="node-role.kubernetes.io/compute=true"
+CORE_COMPUTE_LABEL="core_app_node=true"
+TEST_LABEL="nodevertical=true"
+declare -a CORE_NODES
+NODE_COUNT=0
+pod_count=0
 
 long_sleep() {
   local sleep_time=180
@@ -20,7 +28,13 @@ clean() { echo "Cleaning environment"; oc delete project clusterproject0; }
 golang_clusterloader() {
   # Export kube config
   export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
-  MY_CONFIG=config/golang/nodeVertical
+  if [[ "$ENVIRONMENT" == "alderaan" ]]; then
+  	MY_CONFIG=config/golang/nodeVertical-labeled-nodes
+	sed -i "/- num: 1000/c \ \ \ \ \ \ \ \ \- num: $total_pod_count" /root/svt/openshift_scalability/config/golang/nodeVertical-labeled-nodes.yaml
+  else
+  	MY_CONFIG=config/golang/nodeVertical
+	sed -i "/- num: 1000/c \ \ \ \ \ \ \ \ \- num: $total_pod_count" /root/svt/openshift_scalability/config/golang/nodeVertical.yaml
+  fi
   # loading cluster based on yaml config file
   /usr/libexec/atomic-openshift/extended.test --ginkgo.focus="Load cluster" --viper-config=$MY_CONFIG
 }
@@ -32,6 +46,46 @@ python_clusterloader() {
 
 # sleeping to gather some steady-state metrics, pre-test
 long_sleep
+
+# set the number of nodes to label based on environment selected
+if [[ "$ENVIRONMENT" == "alderaan" ]]; then
+	LABEL_COUNT=2
+else
+	LABEL_COUNT=4
+fi
+
+# label the core nodes when using Alderaan env
+if [[ "$ENVIRONMENT" == "alderaan" ]]; then
+	for compute in $(oc get nodes -l "$CORE_COMPUTE_LABEL" -o json | jq '.items[].metadata.name'); do
+        	compute=$(echo $compute | sed "s/\"//g")
+        	CORE_NODES[${#CORE_NODES[@]}]=$compute
+        	oc label node $compute "$TEST_LABEL"
+	done
+fi
+
+# pick two random app nodes and label them
+for app_node in $(oc get nodes -l "$LABEL" -o json | jq '.items[].metadata.name'); do
+	app_node=$(echo $app_node | sed "s/\"//g")
+	if [[ "$ENVIRONMENT" == "alderaan" ]]; then
+		if [[ ! $(echo ${CORE_NODES[@]} | grep -q -w $app_node) ]]; then
+			NODE_COUNT=$(( NODE_COUNT+1 ))
+			oc label node $app_node "$TEST_LABEL"
+		fi
+	else
+		NODE_COUNT=$(( NODE_COUNT+1 ))
+		oc label node $app_node "$TEST_LABEL"
+	fi
+	if [[ $NODE_COUNT -ge $LABEL_COUNT  ]]; then
+		break
+	fi
+done
+
+# Get the pod count on the labeled nodes
+for node in $(oc get nodes -l="nodevertical=true" | awk 'NR > 1 {print $1}'); do
+	pods_running=$(oc describe node $node | grep -w "Non-terminated \Pods:" | awk  '{print $3}' | sed "s/(//g")
+	pod_count=$(( pod_count+pods_running ))
+done
+total_pod_count=$(( 1000-pod_count ))
 
 # Run the test
 if [ "$TYPE" == "golang" ]; then


### PR DESCRIPTION
- This will schedule the pods on nodes with a nodevertical=true label.
  This is needed to hit the max pod count on a node when the cluster
  size is greater than 4.
- This change supports labeling nodes both on Alderaan and AWS
  environments.