### PR TITLE
updates for mongo ycsb scripts 

### DIFF
--- a/storage/mongodb/README.md
+++ b/storage/mongodb/README.md
@@ -1,27 +1,96 @@
-# Storage test: Mongodb
+# Storage test:  Performance Benchmarking MongoDB with [YCSB](whttps://github.com/brianfrankcooper/YCSB) on OpenShift Container Platform (OCP)  
 
 ## Prerequisites
 
-On the host to run the test:
+On the host to run the test install below packages prior starting test 
 
 ```
-# yum install -y ansible
+# yum install -y ansible pbench-agent 
 ```
 
-We assume that pbench-agent has been installed and configured on the master node.
+**pbench-agent** will provide pbench scripts necessary for below to run sucessfully
+To read more about pbench, refer to [pbench](http://distributed-system-analysis.github.io/pbench/doc/agent/installation.html) documentation
+We also assume that pbench tools 
+
+**Below will work only if pbench is installed** 
 
 ## Run the test
 
+Clone **svt** repository 
+
+```
+$ git clone https://github.com/openshift/svt.git
+``` 
+
+
+
 ```sh
-$ ansible-playbook -i "ec2-34-215-170-11.us-west-2.compute.amazonaws.com," storage/mongodb/mongodb-test.yaml
+$ cd storage/mongodb 
+$ ansible-playbook -i "<jump_hostname> ," storage/mongodb/mongodb-test.yaml
 ```
 
-where `ec2-34-215-170-11.us-west-2.compute.amazonaws.com` is the master node of the OCP cluster.
+**jump_hostname** is machine with installed pbench-agent and ansible and which has complete view to OCP cluster. This can be 
+machine outside of OCP cluster or OCP master machine. For case when it is machine outside of OCP master it is necessary to copy 
+**/root/.kube** from master to that machine
 
 If authentication is required against the master node, then update the following command accordingly.
 
 ```sh
-$ ansible-playbook -i "ec2-34-215-170-11.us-west-2.compute.amazonaws.com," storage/mongodb/mongodb-test.yaml --extra-vars "ansible_user=root ansible_ssh_private_key_file=/home/hongkliu/.ssh/id_rsa_perf"
+$ ansible-playbook -i "<jump_hostname>," storage/mongodb/mongodb-test.yaml --extra-vars "ansible_user=root ansible_ssh_private_key_file=/path/to/key/file"
 ```
 
 Other params in [external_vars.yaml](external_vars.yaml) can be overridden in the same way.
+
+If executed this way, it will pick up what is specified in **external_vars.yaml** an example of **external_vars.yaml** is showed below 
+
+```
+---
+test_project_name: storage-test-mongo
+delete_test_project_before_test: true
+tmp_folder: /tmp/mongodb-test
+MEMORY_LIMIT: 4096Mi
+MONGODB_USER: redhat
+MONGODB_PASSWORD: redhat
+MONGODB_DATABASE: testdb
+VOLUME_CAPACITY: 150Gi 
+STORAGE_CLASS_NAME: glusterfs-storage
+MONGODB_VERSION: 3.2
+pbench_registration: false
+pbench_copy_result: false
+iteration: 10
+ycsb_threads: 16
+workload: workloada,workloadb,workloadc,workloadd,workloade,workloadf,workload_template
+recordcount: 1000       
+operationcount: 1000
+``` 
+If necessary adapt **external_vars.yaml** to correspond specific test needs 
+
+Also, there is small wrapper script **runmongo.sh** which enable us to specify different values of RAM for MongoDB and run all these combination in one run 
+
+Example of usage is 
+```
+$ ./runmongo.sh memory_limit ycsb_threads jump_host workload iterations recordcount operationcount storageclass volumecapacity
+```
+
+For example if we execute below 
+
+```
+$ ./runmongo.sh 1024 10,20 jump_host_hostname workloada,workloadb 10 1000 1000 gluster-storage 10
+``` 
+This will allocate **1024Mi** RAM for MongoDB, run YCSB with 10,20 threads, execute **workloada** and **workloadb**, run 10 iterations with 
+**recordcount=1000** , **operationcount=1000** using storageclass with name **gluster-storage** to allocated storage for MongoDB pod and size of PVC volume will be **10Gi** 
+
+It is also possible to execute test with various values for memory for MongoDB pod all in one run, eg.
+
+```
+$ ./runmongo.sh 512,1024,2048,4096 10,20,30,40 jump_host_hostname workloada,workloadb,workloadc,workloade 10 1000 1000 gluster-storage 10Gi
+``` 
+
+Last command will execute YCSB test against MongoDB pod for various combination
+
+- run workloada,workloadb,workloadc,workloade tests with 512 MB of RAM for MongoDB and with 10,20,30,40 YCSB threads
+- run workloada,workloadb,workloadc,workloade tests with 1024 MB of RAM for MongoDB pod and with 10,20,30,40 YCSB threads
+- follow same matrix for other **MEMORY_LIMITS** 
+
+**Important:** If **operationcount** and **recordcount** are hight, then in order for test to work it is necessary to 
+start test with bigger PVC size. 

--- a/storage/mongodb/external_vars.yaml
+++ b/storage/mongodb/external_vars.yaml
@@ -1,16 +1,18 @@
 ---
-test_project_name: storage-test
+test_project_name: storage-test-mongo
 delete_test_project_before_test: true
 tmp_folder: /tmp/mongodb-test
 MEMORY_LIMIT: 4096Mi
 MONGODB_USER: redhat
 MONGODB_PASSWORD: redhat
 MONGODB_DATABASE: testdb
-VOLUME_CAPACITY: 1000Gi
-STORAGE_CLASS_NAME: gp2
+VOLUME_CAPACITY: 150Gi 
+STORAGE_CLASS_NAME: glusterfs-storage
 MONGODB_VERSION: 3.2
-pbench_registration: true
-pbench_copy_result: true
-iteration: 2
-ycsb_threads: 60
-workload: workloada,workload_template
+pbench_registration: false
+pbench_copy_result: false
+iteration: 10
+ycsb_threads: 16
+workload: workloada,workloadb,workloadc,workloadd,workloade,workloadf,workload_template
+recordcount: 1000       
+operationcount: 1000

--- a/storage/mongodb/files/scripts/test-mongo.sh
+++ b/storage/mongodb/files/scripts/test-mongo.sh
@@ -6,6 +6,8 @@ readonly NAMESPACE=${1}
 readonly ITERATION=${2}
 readonly THREADS=${3}
 readonly WORKLOAD=${4}
+readonly RECORDCOUNT=${5}
+readonly OPERATIONCOUNT=${6}
 
 output_dir=$(dirname $0)
 
@@ -19,17 +21,33 @@ echo "NAMESPACE: ${NAMESPACE}"
 echo "ITERATION: ${ITERATION}"
 echo "THREADS: ${THREADS}"
 echo "WORKLOADS: ${WORKLOAD}"
+echo "RECORDCOUNT: ${RECORDCOUNT}"
+echo "OPERATIONCOUNT: ${OPERATIONCOUNT}"
 
-for i in $(seq 1 ${ITERATION});
-do
-  for load  in $(echo ${WORKLOAD} | sed -e s/,/" "/g);
-  do
-    echo "iteration: ${i} "and" ${load}"
-    ## TODO support to override other params
-    oc -n ${NAMESPACE} exec $(oc get pod -n ${NAMESPACE} | grep mongodb | awk '{print $1}') -- scl enable rh-mongodb32 -- mongo -u redhat -p redhat ${MONGODB_IP}:27017/testdb --eval "db.usertable.remove({})"
-    oc -n ${NAMESPACE} exec $(oc get pod -n ${NAMESPACE} | grep ycsb | awk '{print $1}') -- ./bin/ycsb load mongodb -s -threads "${THREADS}" -P "workloads/${load}" -p mongodb.url=mongodb://redhat:redhat@${MONGODB_IP}:27017/testdb > ${output_dir}/mongodb_${load}_result_run_${THREADS}_${i}.txt 2>&1
-    grep -E 'RunTime|Throughput' ${output_dir}/mongodb_${load}_result_run_${THREADS}_${i}.txt > ${output_dir}/mongodb_${load}_result_run_${THREADS}_${i}_brief.txt
-    grep Throughput ${output_dir}/mongodb_${load}_result_run_${THREADS}_${i}.txt | cut -d',' -f3 >> ${output_dir}/mongodb_${load}_result_run_${THREADS}_numbers.txt
-  done
+
+for i in $(seq 1 ${ITERATION}); do 
+  for load  in $(echo ${WORKLOAD} | sed -e s/,/" "/g); do 
+	for thread in $(echo ${THREADS} | sed -e s/,/" "/g); do 
+    		oc -n ${NAMESPACE} exec $(oc get pod -n ${NAMESPACE} | grep mongodb | awk '{print $1}') -- scl enable rh-mongodb32 -- mongo -u redhat -p redhat ${MONGODB_IP}:27017/testdb --eval "db.usertable.remove({})"
+		oc -n ${NAMESPACE} exec $(oc get pod -n ${NAMESPACE} | grep ycsb | awk '{print $1}') -- ./bin/ycsb load mongodb -s -threads $thread -P "workloads/${load}" -p mongodb.url=mongodb://redhat:redhat@${MONGODB_IP}:27017/testdb -p recordcount=${RECORDCOUNT} -p operationcount=${OPERATIONCOUNT} 2>&1 | tee -a ${output_dir}/mongodb_load_data_${load}_threads_${thread}.txt
+
+		oc -n ${NAMESPACE} exec $(oc get pod -n ${NAMESPACE} | grep ycsb | awk '{print $1}') -- ./bin/ycsb run mongodb -s -threads $thread -P "workloads/${load}" -p mongodb.url=mongodb://redhat:redhat@${MONGODB_IP}:27017/testdb -p recordcount=${RECORDCOUNT} -p operationcount=${OPERATIONCOUNT}  2>&1 | tee -a ${output_dir}/mongodb_run_load_${load}_threads_${thread}.txt
+	done 
+   done 
 done
+
+# sort result 
+
+for load  in $(echo ${WORKLOAD} | sed -e s/,/" "/g); do
+	for thread in $(echo ${THREADS} | sed -e s/,/" "/g); do
+		echo "Threads-${thread}" > ${output_dir}/result_${load}_threads_${thread}.txt 
+		grep Throughput ${output_dir}/mongodb_run_load_${load}_threads_${thread}.txt | cut -d',' -f3 | cut -d' ' -f2 >> ${output_dir}/result_${load}_threads_${thread}.txt
+	done
+	paste -d',' ${output_dir}/result_${load}_threads_* > ${output_dir}/result_${load}_recordcount_${RECORDCOUNT}_operationcount_${OPERATIONCOUNT}.csv
+done 
+
+
+
+
+# todo - draw results here ... 
 

--- a/storage/mongodb/mongodb-test.yaml
+++ b/storage/mongodb/mongodb-test.yaml
@@ -47,12 +47,12 @@
         shell: oc get project {{ test_project_name }}
         register: get_project_result
         until: get_project_result.stderr.find(" not found") != -1
-        retries: 11
+        retries: 30 
         delay: 10
         ignore_errors: True
-      - name: fail the test if the project is still there after 120s
+      - name: fail the test if the project is still there after 300s
         fail:
-          msg: "the pod is NOT deleted after 120s"
+          msg: "the pod is NOT deleted after 300s"
         when: get_project_result.rc == 0
     when: delete_test_project_before_test|bool == true
     tags:
@@ -73,12 +73,12 @@
         shell: oc get pod -n "{{ test_project_name }}" | grep -v deploy | grep mongodb | grep Running
         register: pod_ready_result
         until: pod_ready_result.rc == 0
-        retries: 11
+        retries: 30
         delay: 10
         ignore_errors: True
-      - name: fail the test if the pod is NOT running after 120s
+      - name: fail the test if the pod is NOT running after 30s
         fail:
-          msg: "the pod is NOT running after 120s"
+          msg: "the pod is NOT running after 300s"
         when: pod_ready_result|failed
     tags:
       - setup
@@ -93,12 +93,12 @@
         shell: oc get pod -n "{{ test_project_name }}" | grep -v deploy | grep ycsb | grep Running
         register: pod_ready_result
         until: pod_ready_result.rc == 0
-        retries: 11
+        retries: 30
         delay: 10
         ignore_errors: True
-      - name: fail the test if the pod is NOT running after 120s
+      - name: fail the test if the pod is NOT running after 300s
         fail:
-          msg: "the pod is NOT running after 120s"
+          msg: "the pod is NOT running after 300s"
         when: pod_ready_result|failed
     tags:
       - setup
@@ -122,7 +122,7 @@
       - run
 
   - name: run the benchmarks
-    command: pbench-user-benchmark --config="mongodb_storage_test_{{ STORAGE_CLASS_NAME }}_{{ workload }}_{{ MEMORY_LIMIT }}" -- "{{ tmp_folder }}/files/scripts/test-mongo.sh" "{{ test_project_name }}" "{{ iteration }}" "{{ ycsb_threads }}" "{{ workload }}"
+    command: pbench-user-benchmark --sysinfo=none --config="mongodb_storage_test_{{ STORAGE_CLASS_NAME }}_{{ workload }}_{{ MEMORY_LIMIT }}_recordcount_{{ recordcount }}_operationcount_{{ operationcount }}" -- "{{ tmp_folder }}/files/scripts/test-mongo.sh" "{{ test_project_name }}" "{{ iteration }}" "{{ ycsb_threads }}" "{{ workload }}" "{{ recordcount }}" "{{ operationcount }}" 
     tags:
       - run
 

--- a/storage/mongodb/runmongo.sh
+++ b/storage/mongodb/runmongo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash 
+
+MEMORY_LIMIT="${1}"
+ycsb_threads="${2}"
+JUMP_HOST="${3}"
+WORKLOAD="${4}"
+ITERATIONS="${5}"
+RECORDCOUNT="${6}"
+OPERATIONCOUNT="${7}"
+STORAGECLASS="${8}"
+VOLUMECAPACITY="${9}"
+
+
+for memory_limit in $(echo ${MEMORY_LIMIT} | sed -e s/,/" "/g); do
+	ansible-playbook -i "${JUMP_HOST}," mongodb-test.yaml --extra-vars "MEMORY_LIMIT=${memory_limit}Mi ycsb_threads=${ycsb_threads} workload=${WORKLOAD} iteration=${ITERATIONS} \
+	recordcount=${RECORDCOUNT} operationcount=${OPERATIONCOUNT} STORAGE_CLASS_NAME=${STORAGECLASS} VOLUME_CAPACITY=${VOLUMECAPACITY}Gi" 
+done 


### PR DESCRIPTION
Below files were updated 
-  external_vars.yaml
-  added recordcount and operationcount options
- files/scripts/test-mongo.sh - sorted results and write them to .csv files for easier drawing afterwards
- mongodb-test.yaml - some aditions for pbench-user-benchmark --config section
runmongo.sh - wrapper script which helps to run multiple tests in one run

With these changes we can run multiple test combinations in one run and ```runmongo.sh``` helps with jenkins parameters 



Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>