### PR TITLE
Modify master vertical test to use a different config

### DIFF
--- a/openshift_scalability/masterVertical.sh
+++ b/openshift_scalability/masterVertical.sh
@@ -22,7 +22,7 @@ golang_clusterloader() {
 }
 
 python_clusterloader() {
-  MY_CONFIG=config/pyconfigMasterVertScale.yaml
+  MY_CONFIG=config/pyconfigMasterVertScalePause.yaml
   python cluster-loader.py -f $MY_CONFIG
 }
 


### PR DESCRIPTION
This commit modifies the test to use pyconfigMasterVertScalePause.yaml
config when using python cluster loader.