### PR TITLE
update test to push standard sized alderaan cluster to its pod density limit

### DIFF
--- a/openshift_scalability/config/golang/cluster-limits-pods-per-namespace.yaml
+++ b/openshift_scalability/config/golang/cluster-limits-pods-per-namespace.yaml
@@ -1,13 +1,14 @@
+# 12 projects @ 5,000 pods each creates 60,000 pods which fits into a 250 node cluster
 provider: local
 ClusterLoader:
   cleanup: true
   projects:
-    - num: 1
+    - num: 12
       basename: clusterproject
       tuning: default
       ifexists: delete
       pods:
-        - num: 3000
+        - num: 5000
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
           file: pod-pause.json


### PR DESCRIPTION
Update this test to push cluster roughly to it's pod density limit.

5,000 pods per ns pushes beyond the 3,000 limit we have for 3.10 so we have some headroom.