### PR TITLE
Add support to install crio rpm and needed tools

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -71,6 +71,7 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+crio_system_container=False 
 # multipath-blacklist
 multipath_blacklist=False
 # pbench scrape binaries

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -61,6 +61,7 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+crio_system_container=False
 # multipath-blacklist
 multipath_blacklist=False
 # pbench scrape binaries

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -66,6 +66,7 @@ crio=False
 crio_copy_images=False
 crio_registry=registry.access.redhat.com
 image_repository=
+crio_system_container=False
 # multipath-blacklist
 multipath_blacklist=False
 # pbench scrape binaries

--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -59,10 +59,10 @@
     - { role: os-kickstart }
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
-    - { role: cri-o, when: crio | default(False) | bool }
     - { role: multipath-blacklist, when: multipath_blacklist | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool }
     - { role: aos-ansible }
+    - { role: cri-o, when: crio | default(False) | bool }
     - { role: ansible-update, when: not atomic | default(False) | bool }
     - { role: openshift-package-install, when: not atomic | default(False) | bool }
     - { role: pbench-kickstart }

--- a/image_provisioner/playbooks/provision_gold_images.yaml
+++ b/image_provisioner/playbooks/provision_gold_images.yaml
@@ -17,10 +17,10 @@
     - { role: os-kickstart }
     - { role: clone-repos, when: not atomic | default(False) | bool }
     - { role: docker-config }
-    - { role: cri-o, when: crio | default(False) | bool }
     - { role: multipath-blacklist, when: multipath_blacklist | default(False) | bool }
     - { role: pbench-config, when: not atomic | default(False) | bool}
     - { role: aos-ansible }
+    - { role: cri-o, when: crio | default(False) | bool }
     - { role: pbench-kickstart }
     - { role: collectd-install }
     - { role: journald-config }

--- a/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/aos-ansible/tasks/main.yaml
@@ -37,20 +37,3 @@
     name: iptables 
     state: started 
     enabled: yes
-
-- block:
-   - name: check if skopeo is installed
-     command: which skopeo
-     register: skopeo_status
-
-   - name: Install skopeo if not installed
-     yum:
-       name: skopeo
-       state: latest
-     when: not atomic | default(False) | bool and skopeo_status.rc != 0
-
-   - name: copy images to container storage
-     shell: for image in $(docker images {{ image_repository }}  --format {% raw %} '{{.Repository}}:{{.Tag}}' {% endraw %}); do \
-                skopeo copy docker-daemon:$image containers-storage:$image; done
-     when: skopeo_status.rc == 0
-  when: crio | default(False) | bool and crio_copy_images | default(False) | bool

--- a/image_provisioner/playbooks/roles/cri-o/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/cri-o/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure container-selinux, atomic and runc are installed
+- name: Ensure container-selinux atomic, cri-tools, podman and runc are installed
   package:
      name: "{{ item }}"
      state: present
@@ -7,25 +7,35 @@
      - container-selinux
      - atomic
      - runc
+     - cri-tools
+     - podman
   when: not atomic | default(False) | bool
 
-- name: Use RHEL based image
-  set_fact:
-    crio_image_prepend: "{{ crio_registry }}"
-    crio_image_name: "cri-o"
-
-- name: Set the full image name
-  set_fact:
-    crio_image: "{{ crio_image_prepend }}/{{ crio_image_name }}:latest"
-
-- name: Pre-pull CRI-O System Container image
-  atomic_image:
-     name: "{{ crio_image }}"
+- name: Install crio rpm
+  package:
+     name: cri-o
      state: latest
-     backend: ostree
+  when: not atomic | default(False) | bool and not crio_system_container | default(False) | bool
 
-- name: Install CRI-O container
-  command: "atomic install --system-package no --system {{ crio_image }}"
+- block:
+   - name: Use RHEL based image
+     set_fact:
+       crio_image_prepend: "{{ crio_registry }}"
+       crio_image_name: "cri-o"
+
+   - name: Set the full image name
+     set_fact:
+       crio_image: "{{ crio_image_prepend }}/{{ crio_image_name }}:latest"
+
+   - name: Pre-pull CRI-O System Container image
+     atomic_image:
+       name: "{{ crio_image }}"
+       state: latest
+       backend: ostree
+
+   - name: Install CRI-O container
+     command: "atomic install --system-package no --system {{ crio_image }}"
+  when: crio_system_container | default(False) | bool
 
 - name: Ensure that selinux is set to true in the config
   lineinfile:
@@ -88,4 +98,22 @@
   register: crio_status
     
 - debug: msg="{{ crio_status.stdout }}"
-  when: crio_status.rc != 0 
+  when: crio_status.rc != 0
+
+- block:
+   - name: check if skopeo is installed
+     command: which skopeo
+     register: skopeo_status
+
+   - name: Install skopeo if not installed
+     yum:
+       name: skopeo
+       state: latest
+     when: not atomic | default(False) | bool and skopeo_status.rc != 0
+
+   - name: copy images to container storage
+     shell: for image in $(docker images {{ image_repository }}  --format {% raw %} '{{.Repository}}:{{.Tag}}' {% endraw %}); do \
+                skopeo copy docker-daemon:$image containers-storage:$image; done
+     when: skopeo_status.rc == 0
+  when: crio_copy_images | default(False) | bool
+

--- a/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/docker-config/tasks/main.yaml
@@ -49,6 +49,11 @@
         docker_storage_mount_path: "/var/lib/docker"
      when: ( docker_storage_mount_path == "" or docker_storage_mount_path is not defined )
 
+   - name: set docker_storage_mount_path if empty or undefined
+     set_fact:
+        docker_storage_mount_path: "/var/lib/containers"
+     when: crio | default(False) | bool and ( docker_storage_mount_path == "" or docker_storage_mount_path is not defined )
+
    - name: update fstab
      lineinfile:
        path: /etc/fstab

--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -141,13 +141,6 @@
     - { find: "^#?MaxStartups.*", replace: "MaxStartups 200:30:400" }
     - { find: "^#?UseDNS.*", replace: "UseDNS no" }
 
-- name: add token needed for uploading r2r results
-  lineinfile:
-    path: "/root/svt/utils/pbwedge/hosts"
-    regexp: "github_token"
-    line: "github_token={{ scale_ci_results_token }}"
-  when: scale_ci_results_token is defined
-
 - name: copy svt repo to atomic host
   synchronize:
     src: /root/svt

--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -29,3 +29,10 @@
 
 - name: tag pbench-controller image
   command: docker tag ravielluri/image:controller pbench-controller:latest
+
+- name: add token needed for uploading r2r results
+  lineinfile:
+    path: "/root/svt/utils/pbwedge/hosts"
+    regexp: "github_token"
+    line: "github_token={{ scale_ci_results_token }}"
+  when: scale_ci_results_token is defined


### PR DESCRIPTION
This commit modifies the cri-o role to support installing crio as a
system container and rpm. This also moves the r2r token bake in step 
to pbench-kickstart as it needs the svt repo to be cloned to modify 
the token.