### PR TITLE
Update node labeling on svt openshift_scalability CI scripts for 3.10 and pod limits to stay under 250 per node

### DIFF
--- a/openshift_scalability/ci/scripts/pbench-start-create-loaded-projects.sh
+++ b/openshift_scalability/ci/scripts/pbench-start-create-loaded-projects.sh
@@ -214,15 +214,15 @@ echo -e "\nPbench main results URL:   ${PBENCH_RESULTS_URL}"
 # /EC2::ip-172-31-37-120/${PBENCH_RESULTS_DIR_NAME}/tools-default/ip-172-31-57-127.us-west-2.compute.internal/sar/memory.html"
 
 # Find infra nodes other than master internal ip addresses:
-INFRA_NODES_IPS=$(oc get nodes -l region=infra | grep -v master | grep -v NAME | awk '{print $1}')
+INFRA_NODES_IPS=$(oc get nodes -l 'node-role.kubernetes.io/infra=true' | grep -v NAME | awk '{print $1}')
 echo -e "\nInfra Nodes internal ip addresses: \n${INFRA_NODES_IPS}"
 
 # Find the compute nodes
-COMPUTE_NODES_IPS=$(oc get nodes -l region=primary | grep -v NAME | awk '{print $1}')
+COMPUTE_NODES_IPS=$(oc get nodes -l 'node-role.kubernetes.io/compute=true' | grep -v NAME | awk '{print $1}')
 echo -e "\nCompute Nodes internal ip addresses: \n${COMPUTE_NODES_IPS}"
 
 # Find the Master Nodes
-MASTER_NODES_IPS=$(oc get nodes  | grep master | grep -v NAME | awk '{print $1}') 
+MASTER_NODES_IPS=$(oc get nodes -l 'node-role.kubernetes.io/master=true'  | grep -v NAME | awk '{print $1}')
 echo -e "\nMaster nodes internal ip addresses: \n${MASTER_NODES_IPS}"
 
 # Find Standalone Etcd nodes
@@ -231,5 +231,4 @@ if [ "${STANDALONE_ETCDS_PRIVATE_DNS}" != "" ]; then
 fi
 
 exit
-
 

--- a/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
@@ -9,15 +9,15 @@ oc get node --show-labels
 oc describe node | grep Runtime
 
 
-compute_nodes=$(oc get nodes -l region=primary | awk '{print $1}' | grep -v NAME | xargs)
+compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/compute=true' | awk '{print $1}' | grep -v NAME | xargs)
 
 echo -e "\nComputes nodes are: $compute_nodes"
 
 declare -a node_array
 counter=1
 
-oc get nodes -l region=primary
-oc describe nodes -l region=primary 
+oc get nodes -l 'node-role.kubernetes.io/compute=true'
+oc describe nodes -l 'node-role.kubernetes.io/compute=true' 
 
 initial_node_label="beta.kubernetes.io/arch=amd64"
 

--- a/openshift_scalability/ci/scripts/taint_nodes.sh
+++ b/openshift_scalability/ci/scripts/taint_nodes.sh
@@ -5,15 +5,15 @@ date
 uname -a
 openshift version
 
-compute_nodes=$(oc get nodes -l region=primary | awk '{print $1}' | grep -v NAME | xargs)
+compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/compute=true' | awk '{print $1}' | grep -v NAME | xargs)
 
 echo -e "\nComputes nodes are: $compute_nodes"
 
 declare -a node_array
 counter=1
 
-oc get nodes -l region=primary
-oc describe nodes -l region=primary | grep Taints
+oc get nodes -l 'node-role.kubernetes.io/compute=true'
+oc describe nodes -l 'node-role.kubernetes.io/compute=true' | grep Taints
 
 # Taint nodes
 for n in ${compute_nodes}; do
@@ -24,7 +24,7 @@ for n in ${compute_nodes}; do
   counter=$((counter+1))
 done
 
-oc describe nodes -l region=primary | grep Taints
+oc describe nodes -l 'node-role.kubernetes.io/compute=true' | grep Taints
 
 for i in {1..2}; do
   echo "Array element node_array index $i has value : ${node_array[${i}]}"
@@ -42,7 +42,6 @@ function check_no_error_pods()
 
 sleep 5
 
-oc describe nodes -l region=primary | grep Taint
 
 # start GoLang cluster-loader
 export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}

--- a/openshift_scalability/config/golang/node-affinity-anti-affinity.yaml
+++ b/openshift_scalability/config/golang/node-affinity-anti-affinity.yaml
@@ -7,7 +7,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
           file: pod-pause-node-affinity.json
@@ -17,7 +17,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: docker.io/ocpqe/hello-pod
           basename: hellopods
           file: pod-hello-node-anti-affinity.json
@@ -27,7 +27,7 @@ ClusterLoader:
       pods:
         stepping:
           stepsize: 40
-          pause: 180
+          pause: 120
         ratelimit:
           delay: 0
 

--- a/openshift_scalability/config/golang/node-taints-pod-tolerations.yaml
+++ b/openshift_scalability/config/golang/node-taints-pod-tolerations.yaml
@@ -7,7 +7,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s1
           file: pod-hello-s1-taints-tolerations.json
@@ -17,7 +17,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s2
           file: pod-hello-s2-taints-tolerations.json

--- a/openshift_scalability/config/golang/nodeVertical_484_pods.yaml
+++ b/openshift_scalability/config/golang/nodeVertical_484_pods.yaml
@@ -1,0 +1,21 @@
+provider: local
+ClusterLoader:
+  cleanup: false
+  projects:
+    - num: 1
+      basename: clusterproject
+      tuning: default
+      ifexists: delete
+      pods:
+        - num: 484
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: pausepods
+          file: pod-pause.json
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 50
+          pause: 60
+        ratelimit:
+          delay: 0

--- a/openshift_scalability/config/golang/pod-affinity-anti-affinity.yaml
+++ b/openshift_scalability/config/golang/pod-affinity-anti-affinity.yaml
@@ -7,7 +7,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: docker.io/ocpqe/hello-pod
           basename: pod-affinity-security-in-s1
           file: pod-pod-affinity.json
@@ -17,7 +17,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 250
+        - num: 240
           image: docker.io/ocpqe/hello-pod
           basename: pod-anti-affinity-security-in-s1
           file: pod-pod-anti-affinity.json
@@ -28,7 +28,7 @@ ClusterLoader:
       pods:
         stepping:
           stepsize: 50
-          pause: 180
+          pause: 120
         ratelimit:
           delay: 0
 


### PR DESCRIPTION
- Updated node labeling on svt openshift_scalability CI scripts for 3.10 to use node-role.kubernetes.io label on various scripts used in CI SVT Pipeline
- updated pod counts on golang cluster loader config files to stay under the default kubeletArgument max-pods 250 pods per node value
- Updated number of pods from 250 to 240 for:
   - node-affinity-anti-affinity
   - pods-affinity-anti-affinity
   - taints and tolerations
- Created a new NodeVertical yaml config file with 484 pause pods to help total stay under 250 pods per node
- Updated Node Vertical script to set cleanup to False in nodeVertical.yaml script during test and then revert it back to original after the test