### PR TITLE
Add deployments per namespace cluster limit test

### DIFF
--- a/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
+++ b/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
@@ -1,0 +1,13 @@
+projects:
+  - num: 1
+    basename: cluster
+    ifexists: delete
+    templates:
+      - 
+        num: 2000 
+        file: ./content/deployment-config-cluster-limits-deployments.json
+        parameters:
+          -
+            ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+quotas:
+  - name: default

--- a/openshift_scalability/config/golang/cluster-limits-deployments-per-namespace.yaml
+++ b/openshift_scalability/config/golang/cluster-limits-deployments-per-namespace.yaml
@@ -1,0 +1,13 @@
+provider: local
+ClusterLoader:
+  projects:
+    - num: 1
+      basename: clusterproject
+      ifexists: delete
+      templates:
+        -
+          num: 2000
+          file: ./deployment-config-cluster-limits-deployments.json
+          parameters:
+            -
+              ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/content/deployment-config-cluster-limits-deployments.json
+++ b/openshift_scalability/content/deployment-config-cluster-limits-deployments.json
@@ -1,0 +1,109 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentConfigTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deploymentConfig with 1 replica, 4 env vars, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "deploymentconfig${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 1,
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "Rolling"
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deploymentConfig",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentConfigTemplate"
+  }
+
+}
+

--- a/openshift_scalability/deployments_per_ns.sh
+++ b/openshift_scalability/deployments_per_ns.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+if [ "$#" -ne 1 ]; then
+  echo "syntax: $0 <TYPE>"
+  echo "<TYPE> should be either golang or python"
+  exit 1
+fi
+
+TYPE=$1
+
+long_sleep() {
+  local sleep_time=180
+  echo "Sleeping for $sleep_time"
+  sleep $sleep_time
+}
+
+golang_clusterloader() {
+  # Export kube config
+  export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
+  MY_CONFIG=config/golang/cluster-limits-deployments-per-namespace
+  # loading cluster based on yaml config file
+  /usr/libexec/atomic-openshift/extended.test --ginkgo.focus="Load cluster" --viper-config=$MY_CONFIG
+}
+
+python_clusterloader() {
+  MY_CONFIG=config/cluster-limits-deployments-per-namespace.yaml
+  ./cluster-loader.py --file=$MY_CONFIG
+}
+
+# sleeping to gather some steady-state metrics, pre-test
+long_sleep
+
+# Run the test
+if [ "$TYPE" == "golang" ]; then
+  golang_clusterloader
+elif [ "$TYPE" == "python" ]; then
+  python_clusterloader
+  # sleeping again to gather steady-state metrics after environment is loaded
+  long_sleep
+else
+  echo "$TYPE is not a valid option, available options: golang, python"
+  exit 1
+fi
+
+# sleep after test is complete to gather post-test metrics...these should be the same as pre-test
+long_sleep


### PR DESCRIPTION
This test creates a single namespace with 20000 deployments. The
deploymentConfig template creates 1 replica, 4 env vars and a service.