### PR TITLE
Modify the max pods per ns test to create 15000 pods

### DIFF
--- a/openshift_scalability/config/cluster-limits-pods-per-namespace.yaml
+++ b/openshift_scalability/config/cluster-limits-pods-per-namespace.yaml
@@ -4,7 +4,7 @@ projects:
     ifexists: delete
     tuning: default
     pods:
-      - total: 3000
+      - total: 15000
       - num: 100
         image: gcr.io/google_containers/pause-amd64:3.0
         basename: pausepods
@@ -20,7 +20,7 @@ tuningsets:
   - name: default
     pods:
       stepping:
-        stepsize: 150
-        pause: 60 s
+        stepsize: 500
+        pause: 30 s
       rate_limit:
         delay: 0 ms

--- a/openshift_scalability/config/golang/cluster-limits-pods-per-namespace.yaml
+++ b/openshift_scalability/config/golang/cluster-limits-pods-per-namespace.yaml
@@ -7,7 +7,7 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 3000
+        - num: 15000
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
           file: pod-pause.json
@@ -15,7 +15,7 @@ ClusterLoader:
     - name: default
       pods:
         stepping:
-          stepsize: 150
-          pause: 60
+          stepsize: 500
+          pause: 30
         ratelimit:
           delay: 0


### PR DESCRIPTION
This commit also increases the step size to 500 and decreases the pause time
to 30 seconds so as to keep the test run duration under 90 min.