### PR TITLE
Disable host key checking in fio script

### DIFF
--- a/storage/fio/files/scripts/drop-cache.sh
+++ b/storage/fio/files/scripts/drop-cache.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 
-oc get nodes --no-headers | cut -f1 -d" " | while read i; do ssh -n "$i" 'sync ; echo 3 > /proc/sys/vm/drop_caches'; done
+oc get nodes --no-headers | cut -f1 -d" " | while read i; do ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -n "$i" 'sync ; echo 3 > /proc/sys/vm/drop_caches'; done


### PR DESCRIPTION
On GCE, this is requied to avoid suspension during the execution of pbench-fio.