### PR TITLE
Avoid updating microcode_ctl package

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -5,8 +5,8 @@
     yum: 
       name: '*' 
       state: latest
-      exclude: redhat-release*,initscripts*
-
+      exclude: redhat-release*,initscripts*,microcode_ctl
+ 
   - name: yum update redhat-release-server
     yum:
       name: "{{ item }}"


### PR DESCRIPTION
This is needed as the m5 instance is not booting after updating the
microcode_ctl package. The console logs show that the microde supersedes
the one supported.