### PR TITLE
Add Online rhel7 server optional repo as a backup to the rhel7next optional

### DIFF
--- a/image_provisioner/playbooks/roles/repo-install/files/oso-rhui-rhel-server-releases-optional.repo
+++ b/image_provisioner/playbooks/roles/repo-install/files/oso-rhui-rhel-server-releases-optional.repo
@@ -1,0 +1,16 @@
+[oso-rhui-rhel-server-releases-optional]
+name=OpenShift Online RHUI Mirror RH Enterprise Linux 7 Optional
+baseurl=https://mirror.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+        https://use-mirror1.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+        https://use-mirror2.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+        https://euw-mirror1.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+        https://gce-mirror1.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+        https://gce-mirror2.ops.rhcloud.com/libra/rhui-rhel-server-7-releases-optional/
+enabled=1
+gpgcheck=1
+gpgkey=https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+failovermethod=priority
+sslverify=False
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem
+

--- a/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/repo-install/tasks/main.yaml
@@ -48,6 +48,11 @@
           src: oso-rhui-rhel-server-releases.repo
           dest: /etc/yum.repos.d
   
+      - name: install oso-rhui-rhel-server-releases-optional
+        copy:
+          src: oso-rhui-rhel-server-releases-optional.repo
+          dest: /etc/yum.repos.d
+  
       - name: install oso-rhui-rhel-server-extras
         copy:
           src: oso-rhui-rhel-server-extras.repo

--- a/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/all.repo.j2
+++ b/image_provisioner/playbooks/roles/repo-install/templates/etc/yum.repos.d/all.repo.j2
@@ -68,3 +68,11 @@ failovermethod=priority
 enabled=1
 gpgcheck=0
 sslverify=0
+
+[oso-rhui-rhel-server-releases-optional]
+name=OpenShift Online RHUI Mirror RH Enterprise Linux 7 Optional
+baseurl=http://{{ jump_node_ip }}/oso-rhui-rhel-server-releases-optional
+failovermethod=priority
+enabled=1
+gpgcheck=0
+sslverify=0


### PR DESCRIPTION
rhel7next is currently 7.6 and there are some changes like no glolang package in the server optional repo.   Add the online rhel7 server optional repo as a backup while the 7.6 package locations are sorted out.
