### PR TITLE
Add pytimeparse for build_test automation

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -146,3 +146,6 @@
     src: /root/svt
     dest: /var/home/
   when: atomic | default(False) | bool
+
+- name: install pytimeparse module
+  command: pip install pytimeparse


### PR DESCRIPTION
pytimeparse module is required for the build automation to have full functionality.   Timing information is impacted with out it.   It is not available as a yum package in RHEL 7 nor in EPEL so we have to pip install it and I've chosen to do that in the svt repo setup task.  Let me know if you disagree.

It is available in upstream Fedora so will hopefully be a yum package in RHEL 8.

@wabouhamad @chaitanyaenr PTAL and cherry pick to whatever is currently being used to generate images if you approve.