### PR TITLE
Update regex for retrieving build name

### DIFF
--- a/openshift_performance/ose3_perf/scripts/build_test.py
+++ b/openshift_performance/ose3_perf/scripts/build_test.py
@@ -31,7 +31,7 @@ def login(url, user, passwd):
 
 
 def run_build(build_def):
-    build_regex = re.compile("build \"(.*)\" started")
+    build_regex = re.compile("build.build.openshift.io \"(.*)\" started")
 
     namespace = build_def["namespace"]
     name = build_def["name"]


### PR DESCRIPTION
The output from oc start-build has changed and now contains the fully qualified build resource type in the message.   Update the regex that searches for the build name to account for this.

@vikaslaad PTAL