### PR TITLE
Update build start regex for 3.11

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -149,3 +149,12 @@
 
 - name: install pytimeparse module
   command: pip install pytimeparse
+
+- name: update vm.max_map_count
+  lineinfile: 
+    dest: /home/mifiedle/tmp/sysctl.conf
+    line: "vm.max_map_count=262144"
+    state: present
+    insertafter: EOF
+    create: True
+

--- a/openshift_performance/ose3_perf/scripts/build_test.py
+++ b/openshift_performance/ose3_perf/scripts/build_test.py
@@ -31,7 +31,7 @@ def login(url, user, passwd):
 
 
 def run_build(build_def):
-    build_regex = re.compile("build.build.openshift.io \"(.*)\" started")
+    build_regex = re.compile("build.build.openshift.io\/(.*) started")
 
     namespace = build_def["namespace"]
     name = build_def["name"]


### PR DESCRIPTION
The output from oc start-build changed again in 3.11.