### PR TITLE
Increase vm.max_map_count for elasticsearch 5

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -149,3 +149,12 @@
 
 - name: install pytimeparse module
   command: pip install pytimeparse
+
+- name: update vm.max_map_count
+  lineinfile: 
+    dest: /etc/sysctl.conf
+    line: "vm.max_map_count=262144"
+    state: present
+    insertafter: EOF
+    create: True
+


### PR DESCRIPTION
@wabouhamad @chaitanyaenr PTAL and merge with any private branches being used currently for provisioning.

This is for Elaticsearch 5.   According to https://access.redhat.com/solutions/99913 this should not have a negative impact for non-ES nodes - it just allows a larger footprint.

/cc: @jeremyeder 