### PR TITLE
Modify nodevertical cleanup to wait for resources to be deleted

### DIFF
--- a/openshift_scalability/nodeVertical.sh
+++ b/openshift_scalability/nodeVertical.sh
@@ -23,7 +23,7 @@ long_sleep() {
   sleep $sleep_time
 }
 
-clean() { echo "Cleaning environment"; oc delete project clusterproject0; }
+clean() { echo "Cleaning environment"; oc delete project --wait=true clusterproject0; }
 
 golang_clusterloader() {
   # Export kube config


### PR DESCRIPTION
This commit adds a wait flag to the nodevertical scale test to make
sure the resources created by the test are cleaned up.