### PR TITLE
Pull YCSB image for image provisioner

### DIFF
--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -30,6 +30,11 @@
 - name: tag pbench-controller image
   command: docker tag ravielluri/image:controller pbench-controller:latest
 
+- name: pull ycsb image from docker.io
+  docker_image:
+    name: docker.io/hongkailiu/ycsb
+    tag: 0.15.0
+
 - name: add token needed for uploading r2r results
   lineinfile:
     path: "/root/svt/utils/pbwedge/hosts"


### PR DESCRIPTION
In CNS test for Redis and Mongodb, the ycsb image is used.
Make is present on all instances will save the time and the
bandwidth.