### PR TITLE
Updated role os-kickstart to always installs pbench-agent-internal and also install python-boto package

### DIFF
--- a/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
+++ b/image_provisioner/playbooks/roles/os-kickstart/tasks/main.yaml
@@ -81,6 +81,7 @@
       - libarchive
       - ostree
       - skopeo
+      - python-boto
 
   - name: Download binaries
     get_url:
@@ -95,7 +96,6 @@
     yum: 
       name: pbench-agent-internal 
       state: latest
-    when: internal_image | bool
 
   # yum module doesn't support clean
   - name: clean yum cache


### PR DESCRIPTION
pbench-agent-internal was being installed only when internal_image is set to True, but build_ami.yaml playbook sets that variable to false, so it was not getting installed.

- Removed condition for installing pbench-agent-internal  rpm so it is always installed now
- added pkg python-boto to install packages