### PR TITLE
Updated build_ami.yaml to append the openshift_version string to ami builder instance name

### DIFF
--- a/image_provisioner/playbooks/build_ami.yaml
+++ b/image_provisioner/playbooks/build_ami.yaml
@@ -30,9 +30,9 @@
       user_data: "{{ lookup('file', '../cloud-init/user-data-aws') }}"
       exact_count: 1
       count_tag:
-         Name: "{{ instance_tag | default('ami_builder') }}"
+         Name: "{{ instance_tag | default('ami_builder') }}-{{ openshift_version }}"
       instance_tags:
-         Name: "{{ instance_tag | default('ami_builder') }}"
+         Name: "{{ instance_tag | default('ami_builder') }}-{{ openshift_version }}"
     register: ami_instance
 
   - name: waiting for ssh to start


### PR DESCRIPTION
We have had automated jobs trigger from UMB messages for different OpenShift puddles and using the same ami builder instance.  This PR will make the ami builder instance name more unique to each puddle, by appending the openshift_version string to the instance name.