### PR TITLE
Updates to image provisioner role aos-ansible template to support support Terms Based registry registry.redhat.io

### DIFF
--- a/image_provisioner/inventory/hosts.AWS
+++ b/image_provisioner/inventory/hosts.AWS
@@ -79,3 +79,8 @@ multipath_blacklist=False
 binary_url=https://github.com/redhat-performance/pbench-analyzer/releases/download/v0.1-alpha/
 # scale-ci results github token
 scale_ci_results_token=
+
+# required to support Terms Based registry registry.redhat.io:
+registry_redhat_io_login=True
+registry_redhat_io_username=
+registry_redhat_io_password=

--- a/image_provisioner/inventory/hosts.BM
+++ b/image_provisioner/inventory/hosts.BM
@@ -70,3 +70,9 @@ multipath_blacklist=False
 binary_url=https://github.com/redhat-performance/pbench-analyzer/releases/download/v0.1-alpha/
 # scale-ci results github token
 scale_ci_results_token=
+
+# required to support Terms Based registry registry.redhat.io:
+registry_redhat_io_login=True
+registry_redhat_io_username=
+registry_redhat_io_password=
+

--- a/image_provisioner/inventory/hosts.OS
+++ b/image_provisioner/inventory/hosts.OS
@@ -74,3 +74,8 @@ multipath_blacklist=False
 binary_url=https://github.com/redhat-performance/pbench-analyzer/releases/download/v0.1-alpha/
 # scale-ci results github token
 scale_ci_results_token=
+
+# required to support Terms Based registry registry.redhat.io:
+registry_redhat_io_login=True
+registry_redhat_io_username=
+registry_redhat_io_password=

--- a/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
+++ b/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
@@ -25,8 +25,19 @@ reg_username={{ registry_username }}
 reg_password={{ registry_password }}
 ## do not add the trailing slash:
 reg_openshift_prefix={{ registry_name }}/openshift3
+
 # Pulling s2i images from registry.access.redhat.com:
-reg_s2i_prefix=registry.access.redhat.com/openshift3
+## reg_s2i_prefix=registry.access.redhat.com/openshift3
+
+## point to registry.redhat.io
+reg_s2i_prefix=registry.redhat.io/openshift3
+ 
+# support login to Terms based Registry registry.redhat.io
+reg_terms_based_name=registry.redhat.io
+reg_terms_based_login={{ registry_redhat_io_login }}
+reg_terms_based_username={{ registry_redhat_io_username }}
+reg_terms_based_password={{ registry_redhat_io_password }}
+
 
 [masters]
 {% if not atomic %}


### PR DESCRIPTION
- Updated inventory examples files hosts.AWS, hosts.BM, hosts.OS with credential variables needed to support Terms Based registry registry.redhat.io:
 
- Updated role aos-ansible template hosts.j2 with credential variables 