### PR TITLE
ignore sleep.

### DIFF
--- a/openshift_scalability/podVertical.sh
+++ b/openshift_scalability/podVertical.sh
@@ -11,19 +11,24 @@ fi
 
 TYPE=$1
 CONFIG=$2
+IGNORE_LONG_SLEEP=$3
 
 # use the default config if it's not defined by the user
 if [[ -z "$CONFIG" ]] && [[ "$TYPE" == golang ]]; then
 	CONFIG=config/golang/cluster-limits-pods-per-namespace
 fi
 if [[ -z "$CONFIG" ]] && [[ "$TYPE" == python ]]; then
-        CONFIG=config/cluster-limits-pods-per-namespace.yaml
+  CONFIG=config/cluster-limits-pods-per-namespace.yaml
 fi
 
 long_sleep() {
   local sleep_time=180
-  echo "Sleeping for $sleep_time"
-  sleep $sleep_time
+  if [[ -z "$IGNORE_LONG_SLEEP" ]]; then
+    sleep 1
+  else
+    echo "Sleeping for $sleep_time"
+    sleep $sleep_time
+  fi
 }
 
 golang_clusterloader() {


### PR DESCRIPTION
ignore long sleep on demand for pod vertical.

the motivation comes from some prometheus workloads that dose not need steady state