### PR TITLE
Add a check to make sure the nodes are labeled

### DIFF
--- a/dockerfiles/pbench/agent/Dockerfile
+++ b/dockerfiles/pbench/agent/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Naga Ravi Chaitanya Elluri <nelluri@redhat.com>
 
 # Setup pbench, sshd install dependencies
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench-interim/repo/epel-7/ndokos-pbench-interim-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo && \
-    yum --enablerepo=ndokos-pbench-interim install -y configtools openssh-clients pbench-agent iproute sysvinit-tools \
+    curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo && \
+    yum --enablerepo=ndokos-pbench install -y perl-JSON-XS configtools openssh-clients pbench-agent iproute sysvinit-tools \
     openssh-server git openssh-server openssh-clients initscripts ansible python-pip which && \
     source /etc/profile.d/pbench-agent.sh && \
     curl -L https://github.com/openshift/origin/releases/download/v1.2.1/openshift-origin-client-tools-v1.2.1-5e723f6-linux-64bit.tar.gz | tar -zx && \
@@ -23,5 +23,6 @@ EXPOSE 2022
 COPY mount.sh /root/mount.sh
 COPY pbench.service /etc/systemd/system/pbench.service
 RUN systemctl enable pbench.service
+RUN mkdir -p /run/systemd/system
 
 ENTRYPOINT ["/usr/sbin/init"]

--- a/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
+++ b/image_provisioner/playbooks/roles/pbench-kickstart/tasks/main.yml
@@ -21,14 +21,8 @@
 - name: pull pbench-agent from dockerhub
   command: docker pull ravielluri/image:agent
 
-- name: tag pbench-agent image
-  command: docker tag ravielluri/image:agent library/pbench-agent:latest
-
 - name: pull pbench-controller image from dockerhub
   command: docker pull ravielluri/image:controller
-
-- name: tag pbench-controller image
-  command: docker tag ravielluri/image:controller pbench-controller:latest
 
 - name: pull ycsb image from docker.io
   docker_image:

--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
@@ -15,9 +15,9 @@ spec:
       hostPID: true
       hostNetwork: true
       containers:
-      - image: library/pbench-agent:latest
+      - image: docker.io/ravielluri/image:agent
         name: pbench-agent
-        imagePullPolicy: Never
+        imagePullPolicy: IfNotPresent 
         securityContext:
           privileged: true
         env:

--- a/openshift_tooling/pbench/setup_pbench_pods.sh
+++ b/openshift_tooling/pbench/setup_pbench_pods.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+cleanup_wait_time=$1
+
+if [[ -z $cleanup_wait_time ]]; then
+	cleanup_wait_time=10
+fi
+
 # Check for kubeconfig
 if [[ ! -s $HOME/.kube/config ]]; then
 	echo "cannot find kube config in the home directory, please check"
@@ -19,48 +25,57 @@ else
 	echo "oc client already present"
 fi
 
-status_check_timeout=20
+status_check_timeout=600
 # pod status check
 function pod_status_check() {
 	namespace=$1
 	counter=1
 	echo "checking the pod status"
-	for pod in $(oc get pods --namespace=$namespace | awk 'NR > 1 {print $1}'); do
-        	while [ $(oc --namespace=$namespace get pods $pod -o json | jq -r ".status.phase") != "Running" ]; do
-        		sleep 1
-			counter=$((counter+1))
-			if [[ $counter > $status_check_timeout ]]; then
-				echo "$pod is not in running state after waiting for $counter seconds, please check the pod logs and events"
-				exit 1
-			fi
-        	done
-        	echo "$pod is up and running"
-	done
-	echo "All the pods in $namespace are up and running"
+	pod_count=$(oc get pods --namespace=$namespace | awk 'NR > 1 {print $1}' | wc -l)
+	# make sure the nodes are labeled
+	labeled_node_count=$(oc get nodes -l pbench_role=agent | awk 'NR > 1 {print $1}'| wc -l)
+	if [[ $pod_count != 0 ]] && [[ $labeled_node_count != 0 ]]; then
+		for pod in $(oc get pods --namespace=$namespace | awk 'NR > 1 {print $1}'); do
+        		while [ $(oc --namespace=$namespace get pods $pod -o json | jq -r ".status.phase") != "Running" ]; do
+        			sleep 1
+				counter=$((counter+1))
+				if [[ $counter > $status_check_timeout ]]; then
+					echo "$pod is not in running state after waiting for $counter seconds, please check the pod logs and events"
+					exit 1
+				fi
+        		done
+        		echo "$pod is up and running"
+		done
+		echo "All the pods in $namespace namespace are up and running"
+	else
+		echo "There are $pod_count pods deployed in the $namespace namespace. This script expects pbench_role=agent label on the nodes, please check the node labels"
+		exit 1
+	fi
 }
 
 function setup_jq() {
 	echo "Checking if jq is installed"
-	if ! jq &> /dev/null; then
+	which jq &>/dev/null
+	if [[ $? != 0 ]]; then
 		echo "jq not installed"
 		echo "Downloading jq"
 		if [[ $(awk -F= '/^NAME/{print $2}' /etc/os-release) == "Fedora" ]]; then
-			dnf install -y jq
+			dnf install -y jq &>/dev/null
 		elif [[ $(awk -F= '/^NAME/{print $2}' /etc/os-release | grep "Red Hat") ]]; then
-			yum install -y jq
+			yum install -y jq &>/dev/null
 		else
 			echo "Not able to install jq"
 			exit 1
 		fi
 		echo "jq installed successfully"
 	else
-		echo "jq already present"
+		echo "jq already installed"
 	fi
 }
 
 
 function short_sleep() {
-        sleep 20
+        sleep $cleanup_wait_time
 }
 
 # cleanup deamonset if already exists
@@ -70,8 +85,8 @@ function cleanup() {
 	oc delete -f openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml -n pbench
 	oc delete -f openshift_templates/performance_monitoring/pbench/pbench-namespace.yml -n pbench
 
-	# sleep for 20 seconds for the pods to get terminated
-	echo "Waiting for 20 seconds for pods to get terminated, namespace to be deleted if exists" 
+	# waiting for the pods to get terminated
+	echo "Waiting for $cleanup_wait_time seconds for namespaces and pods cleanup" 
 	short_sleep
 }
 


### PR DESCRIPTION
This commit:
- Modifies the script to fail in case there are zero nodes
labeled with pbench_role=agent or zero pods running in the pbench
namespace.
- Avoids tagging the pbench images for the templates to work out
of the box.