### PR TITLE
Add durations for individual builds

### DIFF
--- a/openshift_performance/ose3_perf/scripts/build_test.py
+++ b/openshift_performance/ose3_perf/scripts/build_test.py
@@ -89,6 +89,7 @@ def parse(executor, result, futures):
             status = words[4]
             namespace = words[0]
             name = words[1]
+            duration_string = words[-1]
             idx = namespace + ":" + name
             if (status.startswith("Failed")) or (status == "Cancelled") or \
                     (status.startswith("Error")):
@@ -101,9 +102,8 @@ def parse(executor, result, futures):
             elif "Complete" == words[4]:
                 if idx in global_build_status.keys():
                     if global_build_status[idx] < STATUS_COMPLETE:
-                        logger.info(idx + " Complete")
+                        logger.info(idx + " Complete, Duration = " + duration_string)
                         global_build_status[idx] = STATUS_COMPLETE
-                    duration_string = words[-1]
                     if global_build_status[idx] < STATUS_LOGGING:
                         futures.append(
                             executor.submit(do_post_actions, namespace,


### PR DESCRIPTION
When performing a large number of iterations of concurrent builds, it is useful to spot check durations during the run and see if they are increasing, etc.   Today, the duration statistics are only printed at the conclusion of all builds.    Add the durations for individual builds - this is the final field in the oc get build output.