### PR TITLE
Updated aos-ansible hosts template to set correct registry folder name when pre-pulling images from registry.reg-aws to support ocp v4 and remain backwards compatible with OCP v3

### DIFF
--- a/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
+++ b/image_provisioner/playbooks/roles/aos-ansible/templates/hosts.j2
@@ -24,7 +24,16 @@ reg_name={{ registry_name }}
 reg_username={{ registry_username }}
 reg_password={{ registry_password }}
 ## do not add the trailing slash:
+## reg_openshift_prefix={{ registry_name }}/openshift3
+## For OCP 4.0:
+# reg_openshift_prefix={{ registry_name }}/openshift
+{% if 'v4' in version %}
+reg_openshift_prefix={{ registry_name }}/openshift
+{% else %}
 reg_openshift_prefix={{ registry_name }}/openshift3
+{% endif %}
+
+
 
 # Pulling s2i images from registry.access.redhat.com:
 ## reg_s2i_prefix=registry.access.redhat.com/openshift3


### PR DESCRIPTION
Ose images for OCP v3 are in the "openshift3 folder on registry.reg-aws.openshift.com
while images for OCP v4 are in the "openshift" folder.  This PR sets the correct folder name based on the puddle version in the aos-ansible hosts file template hosts.j2.