### PR TITLE
Golang needs to be fetched from epel.

### DIFF
--- a/openshift_scalability/content/centos-stress/Dockerfile
+++ b/openshift_scalability/content/centos-stress/Dockerfile
@@ -9,9 +9,9 @@ COPY root ./
 
 ### Install required packages
 RUN yum -y --setopt=tsflags=nodocs install automake autotools bc epel-release \
-        gcc git gnuplot go java-1.8.0-openjdk libtool make openssh-clients \
+        gcc git gnuplot java-1.8.0-openjdk libtool make openssh-clients \
         patch rsync tar unzip && \
-    yum -y --setopt=tsflags=nodocs install stress && \
+    yum -y --setopt=tsflags=nodocs install go stress && \
     mkdir -p build && cd build && \
     git clone https://github.com/openshift/svt.git && \
       cd svt/utils/pctl && go build pctl.go && cp pctl /usr/local/bin && cd ../../.. && \


### PR DESCRIPTION
The centos-stress image doesn't build without this PR. 