### PR TITLE
Add script to capture prometheus DB

### DIFF
--- a/openshift_tooling/prometheus_db_dump/README.md
+++ b/openshift_tooling/prometheus_db_dump/README.md
@@ -1,0 +1,14 @@
+# Prometheus DB dump
+Script to capture prometheus DB from the running prometheus pods to local file system. This can be used to look at the metrics later by running
+prometheus locally with the backed up DB.
+
+## Run
+```
+$ ./prometheus_dump.sh <output_dir>
+```
+
+## Visualize the captured data locally on prometheus server
+```
+$ ./prometheus_view.sh <db_tarball_url>
+```
+This installs prometheus server and loads up the DB, the server can be accessed at https://localhost:9090.

--- a/openshift_tooling/prometheus_db_dump/prometheus_dump.sh
+++ b/openshift_tooling/prometheus_db_dump/prometheus_dump.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -eo pipefail
+
+output_dir=$1
+prometheus_namespace=openshift-monitoring
+
+if [[ "$#" -ne 1 ]]; then
+	 echo "syntax: $0 <output_dir>"
+	 exit 1
+fi
+
+# Check for kubeconfig
+if [[ -z $KUBECONFIG ]] && [[ ! -s $HOME/.kube/config ]]; then
+        echo "KUBECONFIG var is not defined and cannot find kube config in the home directory, please check"
+        exit 1
+fi
+
+# Check if oc client is installed
+which oc &>/dev/null
+echo "Checking if oc client is installed"
+if [[ $? != 0 ]]; then
+        echo "oc client is not installed, please install"
+        exit 1
+else
+	echo "oc client is present"
+fi
+
+# pick a prometheus pod
+prometheus_pod=$(oc get pods -n $prometheus_namespace | grep -w "Running" | awk -F " " '/prometheus-k8s/{print $1}' | tail -n1)
+
+# copy the prometheus DB from the prometheus pod
+echo "copying prometheus DB from $prometheus_pod"
+oc cp $prometheus_namespace/$prometheus_pod:/prometheus/wal -c prometheus wal/
+echo "creating a tarball of the captured DB at $output_dir"
+XZ_OPT=--threads=0 tar cJf $output_dir/prometheus.tar.gz wal
+if [[ $? == 0 ]]; then
+	rm -rf wal
+fi

--- a/openshift_tooling/prometheus_db_dump/prometheus_view.sh
+++ b/openshift_tooling/prometheus_db_dump/prometheus_view.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+url=$1
+dir=/tmp/prometheus
+prometheus_url=https://github.com/prometheus/prometheus/releases/download/v2.7.1/prometheus-2.7.1.linux-amd64.tar.gz
+
+if  [[ "$#" -ne 1 ]]; then
+	echo "Syntax: $0 <db_tarball_url>"
+	exit 1
+fi
+
+# create prometheus dir
+rm -rf $dir || true
+mkdir $dir
+
+# download prometheus
+wget -q $prometheus_url -O /tmp/prometheus_server.tar.gz 
+tar xf /tmp/prometheus_server.tar.gz -C /tmp && mv /tmp/prometheus*/prometheus /usr/local/bin && mv /tmp/prometheus*/prometheus.yml $dir/prometheus.yml
+
+# download the prometheus results tarball
+curl $1 | tar xvJf - -C $dir
+echo "open http://localhost:9090 to look at the captured metrics"
+/usr/local/bin/prometheus --storage.tsdb.path=$dir --config.file $dir/prometheus.yml --storage.tsdb.retention=1y


### PR DESCRIPTION
 This commit adds:
    - script to capture DB from running prometheus pod.
    - script to install prometheus server and view the metrics locally
      by running prometheus with the backed up DB. A sample use case 
      would be to look at the prometheus metrics during a pbench run.
