### PR TITLE
Updated eap and tomcat quickstart templates and reliability testClust…

### DIFF
--- a/openshift_scalability/config/all-quickstarts-no-limits.yaml
+++ b/openshift_scalability/config/all-quickstarts-no-limits.yaml
@@ -45,11 +45,12 @@ projects:
          - MEMORY_LIMIT: "0"
 
   - num: 1
-    basename: eap64-mysql
+    basename: eap71-mysql
     tuning: default
     templates:
       - num: 1
-        file: ./content/quickstarts/eap/eap64-mysql.json
+        file: ./content/quickstarts/eap/eap71-mysql.json
+
         parameters: 
          - MEMORY_LIMIT: "0"
 
@@ -58,7 +59,7 @@ projects:
     tuning: default
     templates:
       - num: 1
-        file: ./content/quickstarts/tomcat/tomcat8-mongodb.json
+        file: ./content/quickstarts/tomcat/jws31-tomcat8-mongodb.json
         parameters: 
          - MEMORY_LIMIT: "0"
 

--- a/openshift_scalability/content/quickstarts/eap/eap71-mysql.json
+++ b/openshift_scalability/content/quickstarts/eap/eap71-mysql.json
@@ -1,0 +1,904 @@
+{
+    "apiVersion": "template.openshift.io/v1",
+    "kind": "Template",
+    "labels": {
+        "template": "eap71-mysql-s2i",
+        "xpaas": "1.4.16"
+    },
+    "message": "A new EAP 7 and MySQL based application with SSL support has been created in your project. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "metadata": {
+        "annotations": {
+            "description": "An example EAP 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "iconClass": "icon-eap",
+            "openshift.io/display-name": "JBoss EAP 7.1 + MySQL (Ephemeral with https)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "samples.operator.openshift.io/version": "4.0.0-alpha1-69362431c",
+            "tags": "eap,javaee,java,jboss,hidden",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Enterprise Application Server 7.1 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using ephemeral (temporary) storage and secure communication using https.",
+            "template.openshift.io/support-url": "https://access.redhat.com",
+            "version": "1.4.16"
+        },
+        "creationTimestamp": "2019-02-20T11:29:52Z",
+        "labels": {
+            "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "eap71-mysql-s2i",
+        "namespace": "openshift",
+        "resourceVersion": "13291",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/openshift/templates/eap71-mysql-s2i",
+        "uid": "d6df4601-3502-11e9-9faf-0a580a82000b"
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The web server's http port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "secure-${APPLICATION_NAME}"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The database server's port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-mysql"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 3306,
+                        "targetPort": 3306
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
+                }
+            }
+        },
+        {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "eap-service-account"
+            },
+            "secrets": [
+                {
+                    "name": "eap7-app-secret"
+                }
+            ]
+        },
+        {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "annotations": {
+                    "description": "Default HTTPS keystore (keystore.jks) with name 'jboss' and password 'mykeystorepass' and JGoups keystore (jgroups.jceks) with name 'secret-key' and password 'password'"
+                },
+                "name": "eap7-app-secret"
+            },
+            "data": {
+                "keystore.jks": "/u3+7QAAAAIAAAABAAAAAQAFamJvc3MAAAFVFbYp5AAABQIwggT+MA4GCisGAQQBKgIRAQEFAASCBOqe/lTeehnds9ffJp/EYKY2K7o9CvvyvgiqvdaGqiZxwWjmoYBEuBxJBUkr7uyYr2g3Viui18djJh9paWdBfPRCEWsLxbMBmig+5OXe1U536PTNZlzkdrwSJpusiwwWLiog/kQ+Gp82VzHxsueNVkewKZ6LvdAq+5Pw7148cxgfnm+2j0La1YnX4/TAtY6A33HjU3HxPxpkLCBP66THxjJvm+n5xg+6eAPu6n/c3mWShhudf0k7FAHLgqMqZt22GMlIv73azdz5kf+opcF8nHN/SDnrgmBbX+GBFvMQ64a3zfLGMnCH8R7L2v5K0uH4AvOHHU9+g7KGk/obPOFyqjloPGIGwzyX4UhxsxP9+wU45RVg02SdoOsqsKYeF7JV1t+uj1+WXDkEaxGYx9u5bFIpkQOuuh6kyf6P6MK8gP6u8cRJeLU/LZCkNMSHq6afbgu/Uu0ZlPFKMLBiX6aKYO0nhp/h3QBzLOVCrWB5nnj90WnZ6Ug8bUjozTTKcdOu8oU47cOesSxPsZzs/KXEuqNP+T34fb4iOKjDXpTZDhIDYanfXb+GMHi/XdY5Q5Xu5w+6ES4ue9grlqfXtMa3G/FgUuJ6dLIXCDAHtS6nxvN3VBd3+pkQKG3iiBMbmBSg03bau5stsD8ol6NGQkoqIhvr1cxFHz+wVzh3UE6FOF+T96rqSuK17UNWnNTSFntHpMYUq+CbD1sTsAmaZ1tIbWBVYEw9G0hpzfFgIqndnEOJ2hD1Z30cStVvSamTlY1hYwxw9/qVUGxzRyQF1a4U8wuYyJNSLZmLwF4jmtkP/kvzhOJ9nr9ZHpuZcW8v5OuHpeTGb+bq+23T+1w0uK3x+O0TnZAFKN4UyZN6JWH2LI+jS+95sTt1fgV1gpY7/qtgX26BWPGQw6+ynRT68EREneUH7c8z3W8mkyfeOl+ffi3n4BYmkki6feSJNbkNdRncpFO83qIk3EtE9RNOMjU1ih8w+KrzZXm2LIINYqc6FkR+tACeGcJwPRkv7paGE3fI7JacYPrJsIf8C055NqbW1HFhplhY/zTbSuGH0SaseZ2lzkGVaVG8pzsNBlBX8eR4oL7LWAXhos1uJdg9cVIC2UZ+bBkBlUpEeWi7LryLL+Glg//iMp3W93nm+S6UJVUipVMgCMgHrXZjWQN0tGvPOxBUIM5IrxcrWsjEA0OJDsa0KCbI8R397FP3QZqB9hJPDs6Lb+64XGmkmAixLYLP2LczlmmoJ6pnGTdzqGjf/au1FzTq/Pikundn47Lt0ZsA9D5Wq958zr0U8Zc3X2OewAd/MKh7u5TOAJs870wHZPIjZss9lTwYJ1VfCP9/x4c8wfoas1mLrxoaTx4axIiTn8bMK60fq5s2DLpnDNgGS0g2tsyqw6+BPCKuwNj1dc5dl0fupIZxLB4+FeTcr7WaDslBl5QIyrM6ljknzd+r3U5ndtBiTBnFutD4+YFOcGPXm1qE7R/1Olmt+ZwnB8O7CtOGldTv/Imoa+en8YFT0TH9gPstso6ERJIP4UbIxxxJF+soqNVkK5fY0qRSksosJJJTKdD8BNl9skcPo8S9J7TRtcBsbPytU/1DhnL19D+bp0o5NRLAWse2sTOv3dSZiBPIAeL5oSaSBkJ9GbZcVc95d7ga3cNgbZuvcNPLov+F1WsEYYZcM/zjhvevAAAAAQAFWC41MDkAAAOBMIIDfTCCAmWgAwIBAgIEHPuEUDANBgkqhkiG9w0BAQsFADBvMQswCQYDVQQGEwJVUzEQMA4GA1UECBMHTXlTdGF0ZTEPMA0GA1UEBxMGTXlDaXR5MRcwFQYDVQQKEw5NeU9yZ2FuaXphdGlvbjESMBAGA1UECxMJTXlPcmdVbml0MRAwDgYDVQQDEwdFeGFtcGxlMB4XDTE2MDYwMzEwMDE0NVoXDTI2MDYwMTEwMDE0NVowbzELMAkGA1UEBhMCVVMxEDAOBgNVBAgTB015U3RhdGUxDzANBgNVBAcTBk15Q2l0eTEXMBUGA1UEChMOTXlPcmdhbml6YXRpb24xEjAQBgNVBAsTCU15T3JnVW5pdDEQMA4GA1UEAxMHRXhhbXBsZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL12YRIsnxFfnXSOLn8GtCWf0pJr/NzSFDV7M1I0nLlytu7dD/XAwvRTV6CFEvZJ8a4Q5NmKDkB1XofN7uebEhIANcizwtu61JXyic26kQB3IhK4nb5BChIgJbvfXg4IiazbWIHR6cAyRWT/M6rXVVUNDIPRZ84O7rng2vKvZezGHS9BbsoewyhF71fWTmvu2s7Dcm1sI6bRxJnF4BCQdMEc8dfPqjWCQUqkvkPN4wyHUzVlQE0/pbOW4YN668dBSmTGHTWaUvEXgX333gAlG07YcbJtjqJznurkCKLrGssX2ozGQg84GKg9+Sq+nwN5a09Rfhn4UBRGrJ4MpZDpKAkCAwEAAaMhMB8wHQYDVR0OBBYEFJMKA17Zl2R5M8pqpmdUWFEERulHMA0GCSqGSIb3DQEBCwUAA4IBAQCFJQeVl+7XD9Is6lGHPgOr8Ep8pSHwCBY+95C4I7KPYapXB+U9gi9bKvVElfDD+IMPfqg2hRuFCnW3MQId/6QU+/c7+fwOnqE0oi6xo8nl7qx48Y/Ih3jXo3q7JON6CfrJHMSw47+gYi8c66S6EOePi2aGySQNBwqop85kEUhDEl6eGAAEo66+BrCUjwPNK3R5mGtx38FM54OibLkmDMS8pFfBN7qQ1C35JUdFDDJcNEBZ1WGIbkLxyIFsogJa1x6j235Fst9MASxeu5+xO3/WVHcLHQAZqJ/xZadEJAg2+YkPEhsrIEoFhRr3Hg13ECqD1W6aSW5kE5wPoWjru1gNUXYHaE8+iikx9yyc8V8V4CG63qk=",
+                "jgroups.jceks": "zs7OzgAAAAIAAAABAAAAAwAKc2VjcmV0LWtleQAAAVDQhuHmrO0ABXNyADNjb20uc3VuLmNyeXB0by5wcm92aWRlci5TZWFsZWRPYmplY3RGb3JLZXlQcm90ZWN0b3LNV8pZ5zC7UwIAAHhyABlqYXZheC5jcnlwdG8uU2VhbGVkT2JqZWN0PjY9psO3VHACAARbAA1lbmNvZGVkUGFyYW1zdAACW0JbABBlbmNyeXB0ZWRDb250ZW50cQB+AAJMAAlwYXJhbXNBbGd0ABJMamF2YS9sYW5nL1N0cmluZztMAAdzZWFsQWxncQB+AAN4cHVyAAJbQqzzF/gGCFTgAgAAeHAAAAAPMA0ECHcwLGK6EDyLAgEUdXEAfgAFAAAAmCu9wRKf1aYYUOEWe406ncPtIdm3147G7MJyWUu2kJVY15a2QxeZi9w5J3AF6T64CvylUuQjpcC4DWXwVn9BefntkBR8CzTiH7VxEqVOQ/OkFS29Inoq8t7/NBaTgTdmMkb4ETV1gIsy/+W6kk7QTqxItCkdKKGFE90Be/7yL3tG16TCy/ABKl7CO6PHa44CqK2PUE1oaJ+WdAAWUEJFV2l0aE1ENUFuZFRyaXBsZURFU3QAFlBCRVdpdGhNRDVBbmRUcmlwbGVERVMN658veJP01V2j9y8bQCYIzViutw=="
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The JGroups ping port for clustering.",
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-ping"
+            },
+            "spec": {
+                "clusterIP": "None",
+                "ports": [
+                    {
+                        "name": "ping",
+                        "port": 8888
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-http",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "description": "Route for application's http service."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "description": "Route for application's https service."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "secure-${APPLICATION_NAME}"
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTPS}",
+                "tls": {
+                    "termination": "passthrough"
+                },
+                "to": {
+                    "name": "secure-${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "BuildConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "${APPLICATION_NAME}:latest"
+                    }
+                },
+                "source": {
+                    "contextDir": "${CONTEXT_DIR}",
+                    "git": {
+                        "ref": "${SOURCE_REPOSITORY_REF}",
+                        "uri": "${SOURCE_REPOSITORY_URL}"
+                    },
+                    "type": "Git"
+                },
+                "strategy": {
+                    "sourceStrategy": {
+                        "env": [
+                            {
+                                "name": "MAVEN_MIRROR_URL",
+                                "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND",
+                                "value": "${MAVEN_ARGS_APPEND}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
+                            }
+                        ],
+                        "forcePull": true,
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "jboss-eap71-openshift:1.3",
+                            "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                        }
+                    },
+                    "type": "Source"
+                },
+                "triggers": [
+                    {
+                        "github": {
+                            "secret": "${GITHUB_WEBHOOK_SECRET}"
+                        },
+                        "type": "GitHub"
+                    },
+                    {
+                        "generic": {
+                            "secret": "${GENERIC_WEBHOOK_SECRET}"
+                        },
+                        "type": "Generic"
+                    },
+                    {
+                        "imageChange": {},
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}"
+                        },
+                        "name": "${APPLICATION_NAME}"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "DB_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-mysql=DB"
+                                    },
+                                    {
+                                        "name": "DB_JNDI",
+                                        "value": "${DB_JNDI}"
+                                    },
+                                    {
+                                        "name": "DB_USERNAME",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "DB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "TX_DATABASE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-mysql=DB"
+                                    },
+                                    {
+                                        "name": "DB_MIN_POOL_SIZE",
+                                        "value": "${DB_MIN_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_MAX_POOL_SIZE",
+                                        "value": "${DB_MAX_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_TX_ISOLATION",
+                                        "value": "${DB_TX_ISOLATION}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_PING_PROTOCOL",
+                                        "value": "openshift.DNS_PING"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-ping"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+                                        "value": "8888"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE_DIR",
+                                        "value": "/etc/eap-secret-volume"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE",
+                                        "value": "${HTTPS_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE_TYPE",
+                                        "value": "${HTTPS_KEYSTORE_TYPE}"
+                                    },
+                                    {
+                                        "name": "HTTPS_NAME",
+                                        "value": "${HTTPS_NAME}"
+                                    },
+                                    {
+                                        "name": "HTTPS_PASSWORD",
+                                        "value": "${HTTPS_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_CLUSTER_PASSWORD",
+                                        "value": "${MQ_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_SECRET",
+                                        "value": "${JGROUPS_ENCRYPT_SECRET}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE",
+                                        "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_NAME",
+                                        "value": "${JGROUPS_ENCRYPT_NAME}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_PASSWORD",
+                                        "value": "${JGROUPS_ENCRYPT_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_CLUSTER_PASSWORD",
+                                        "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AUTO_DEPLOY_EXPLODED",
+                                        "value": "${AUTO_DEPLOY_EXPLODED}"
+                                    },
+                                    {
+                                        "name": "DEFAULT_JOB_REPOSITORY",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
+                                        "name": "TIMER_SERVICE_DATA_STORE",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    }
+                                ],
+                                "image": "${APPLICATION_NAME}",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/livenessProbe.sh"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 60
+                                },
+                                "name": "${APPLICATION_NAME}",
+                                "ports": [
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8443,
+                                        "name": "https",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8888,
+                                        "name": "ping",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/eap/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${MEMORY_LIMIT}"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/eap-secret-volume",
+                                        "name": "eap-keystore-volume",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/jgroups-encrypt-secret-volume",
+                                        "name": "eap-jgroups-keystore-volume",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 75,
+                        "volumes": [
+                            {
+                                "name": "eap-keystore-volume",
+                                "secret": {
+                                    "secretName": "${HTTPS_SECRET}"
+                                }
+                            },
+                            {
+                                "name": "eap-jgroups-keystore-volume",
+                                "secret": {
+                                    "secretName": "${JGROUPS_ENCRYPT_SECRET}"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "${APPLICATION_NAME}:latest"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-mysql"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}-mysql"
+                        },
+                        "name": "${APPLICATION_NAME}-mysql"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MYSQL_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                                        "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+                                    },
+                                    {
+                                        "name": "MYSQL_MAX_CONNECTIONS",
+                                        "value": "${MYSQL_MAX_CONNECTIONS}"
+                                    },
+                                    {
+                                        "name": "MYSQL_FT_MIN_WORD_LEN",
+                                        "value": "${MYSQL_FT_MIN_WORD_LEN}"
+                                    },
+                                    {
+                                        "name": "MYSQL_FT_MAX_WORD_LEN",
+                                        "value": "${MYSQL_FT_MAX_WORD_LEN}"
+                                    },
+                                    {
+                                        "name": "MYSQL_AIO",
+                                        "value": "${MYSQL_AIO}"
+                                    }
+                                ],
+                                "image": "mysql",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 3306
+                                    },
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "${APPLICATION_NAME}-mysql",
+                                "ports": [
+                                    {
+                                        "containerPort": 3306,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/mysql/data",
+                                        "name": "${APPLICATION_NAME}-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 60,
+                        "volumes": [
+                            {
+                                "emptyDir": {
+                                    "medium": ""
+                                },
+                                "name": "${APPLICATION_NAME}-data"
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-mysql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "description": "The name for the application.",
+            "displayName": "Application Name",
+            "name": "APPLICATION_NAME",
+            "required": true,
+            "value": "eap-app"
+        },
+        {
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e",
+            "displayName": "Custom http Route Hostname",
+            "name": "HOSTNAME_HTTP"
+        },
+        {
+            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e",
+            "displayName": "Custom https Route Hostname",
+            "name": "HOSTNAME_HTTPS"
+        },
+        {
+            "description": "Git source URI for application",
+            "displayName": "Git Repository URL",
+            "name": "SOURCE_REPOSITORY_URL",
+            "required": true,
+            "value": "https://github.com/jboss-openshift/openshift-quickstarts"
+        },
+        {
+            "description": "Git branch/tag reference",
+            "displayName": "Git Reference",
+            "name": "SOURCE_REPOSITORY_REF",
+            "value": "1.4"
+        },
+        {
+            "description": "Path within Git project to build; empty for root project directory.",
+            "displayName": "Context Directory",
+            "name": "CONTEXT_DIR",
+            "value": "todolist/todolist-jdbc"
+        },
+        {
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql",
+            "displayName": "Database JNDI Name",
+            "name": "DB_JNDI",
+            "value": "java:jboss/datasources/TodoListDS"
+        },
+        {
+            "description": "Database name",
+            "displayName": "Database Name",
+            "name": "DB_DATABASE",
+            "required": true,
+            "value": "root"
+        },
+        {
+            "description": "Queue names",
+            "displayName": "Queues",
+            "name": "MQ_QUEUES"
+        },
+        {
+            "description": "Topic names",
+            "displayName": "Topics",
+            "name": "MQ_TOPICS"
+        },
+        {
+            "description": "The name of the secret containing the keystore file",
+            "displayName": "Server Keystore Secret Name",
+            "name": "HTTPS_SECRET",
+            "required": true,
+            "value": "eap7-app-secret"
+        },
+        {
+            "description": "The name of the keystore file within the secret",
+            "displayName": "Server Keystore Filename",
+            "name": "HTTPS_KEYSTORE",
+            "value": "keystore.jks"
+        },
+        {
+            "description": "The type of the keystore file (JKS or JCEKS)",
+            "displayName": "Server Keystore Type",
+            "name": "HTTPS_KEYSTORE_TYPE"
+        },
+        {
+            "description": "The name associated with the server certificate",
+            "displayName": "Server Certificate Name",
+            "name": "HTTPS_NAME"
+        },
+        {
+            "description": "The password for the keystore and certificate",
+            "displayName": "Server Keystore Password",
+            "name": "HTTPS_PASSWORD"
+        },
+        {
+            "description": "Sets xa-pool/min-pool-size for the configured datasource.",
+            "displayName": "Datasource Minimum Pool Size",
+            "name": "DB_MIN_POOL_SIZE"
+        },
+        {
+            "description": "Sets xa-pool/max-pool-size for the configured datasource.",
+            "displayName": "Datasource Maximum Pool Size",
+            "name": "DB_MAX_POOL_SIZE"
+        },
+        {
+            "description": "Sets transaction-isolation for the configured datasource.",
+            "displayName": "Datasource Transaction Isolation",
+            "name": "DB_TX_ISOLATION"
+        },
+        {
+            "description": "Sets how the table names are stored and compared.",
+            "displayName": "MySQL Lower Case Table Names",
+            "name": "MYSQL_LOWER_CASE_TABLE_NAMES"
+        },
+        {
+            "description": "The maximum permitted number of simultaneous client connections.",
+            "displayName": "MySQL Maximum number of connections",
+            "name": "MYSQL_MAX_CONNECTIONS"
+        },
+        {
+            "description": "The minimum length of the word to be included in a FULLTEXT index.",
+            "displayName": "MySQL FullText Minimum Word Length",
+            "name": "MYSQL_FT_MIN_WORD_LEN"
+        },
+        {
+            "description": "The maximum length of the word to be included in a FULLTEXT index.",
+            "displayName": "MySQL FullText Maximum Word Length",
+            "name": "MYSQL_FT_MAX_WORD_LEN"
+        },
+        {
+            "description": "Controls the innodb_use_native_aio setting value if the native AIO is broken.",
+            "displayName": "MySQL AIO",
+            "name": "MYSQL_AIO"
+        },
+        {
+            "description": "A-MQ cluster admin password",
+            "displayName": "A-MQ cluster password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "MQ_CLUSTER_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Database user name",
+            "displayName": "Database Username",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "name": "DB_USERNAME",
+            "required": true
+        },
+        {
+            "description": "Database user password",
+            "displayName": "Database Password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "DB_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "GitHub trigger secret",
+            "displayName": "Github Webhook Secret",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "GITHUB_WEBHOOK_SECRET",
+            "required": true
+        },
+        {
+            "description": "Generic build trigger secret",
+            "displayName": "Generic Webhook Secret",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "GENERIC_WEBHOOK_SECRET",
+            "required": true
+        },
+        {
+            "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+            "displayName": "ImageStream Namespace",
+            "name": "IMAGE_STREAM_NAMESPACE",
+            "required": true,
+            "value": "openshift"
+        },
+        {
+            "description": "The name of the secret containing the keystore file",
+            "displayName": "JGroups Secret Name",
+            "name": "JGROUPS_ENCRYPT_SECRET",
+            "value": "eap7-app-secret"
+        },
+        {
+            "description": "The name of the keystore file within the secret",
+            "displayName": "JGroups Keystore Filename",
+            "name": "JGROUPS_ENCRYPT_KEYSTORE",
+            "value": "jgroups.jceks"
+        },
+        {
+            "description": "The name associated with the server certificate",
+            "displayName": "JGroups Certificate Name",
+            "name": "JGROUPS_ENCRYPT_NAME"
+        },
+        {
+            "description": "The password for the keystore and certificate",
+            "displayName": "JGroups Keystore Password",
+            "name": "JGROUPS_ENCRYPT_PASSWORD"
+        },
+        {
+            "description": "JGroups cluster password",
+            "displayName": "JGroups Cluster Password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "JGROUPS_CLUSTER_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Controls whether exploded deployment content should be automatically deployed",
+            "displayName": "Deploy Exploded Archives",
+            "name": "AUTO_DEPLOY_EXPLODED",
+            "value": "false"
+        },
+        {
+            "description": "Maven mirror to use for S2I builds",
+            "displayName": "Maven mirror URL",
+            "name": "MAVEN_MIRROR_URL"
+        },
+        {
+            "description": "Maven additional arguments to use for S2I builds",
+            "displayName": "Maven Additional Arguments",
+            "name": "MAVEN_ARGS_APPEND"
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR"
+        },
+        {
+            "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+            "displayName": "MySQL Image Stream Tag",
+            "name": "MYSQL_IMAGE_STREAM_TAG",
+            "required": true,
+            "value": "5.7"
+        },
+        {
+            "description": "Container memory limit",
+            "name": "MEMORY_LIMIT",
+            "value": "1Gi"
+        },
+        {
+         "name": "IDENTIFIER",
+         "description": "Number to append to the name of resources",
+         "value": "1"
+        }
+    ]
+}

--- a/openshift_scalability/content/quickstarts/tomcat/jws31-tomcat8-mongodb.json
+++ b/openshift_scalability/content/quickstarts/tomcat/jws31-tomcat8-mongodb.json
@@ -1,0 +1,736 @@
+{
+    "apiVersion": "template.openshift.io/v1",
+    "kind": "Template",
+    "labels": {
+        "template": "jws31-tomcat8-mongodb-s2i",
+        "xpaas": "1.4.16"
+    },
+    "message": "A new JWS application for Apache Tomcat 8 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+    "metadata": {
+        "annotations": {
+            "description": "Application template for JWS MongoDB applications built using S2I.",
+            "iconClass": "icon-rh-tomcat",
+            "openshift.io/display-name": "JBoss Web Server 3.1 Apache Tomcat 8 + MongoDB (Ephemeral with https)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "samples.operator.openshift.io/version": "4.0.0-alpha1-69362431c",
+            "tags": "tomcat,tomcat8,java,jboss,hidden",
+            "version": "1.4.16"
+        },
+        "creationTimestamp": "2019-02-20T11:29:58Z",
+        "labels": {
+            "samples.operator.openshift.io/managed": "true"
+        },
+        "name": "jws31-tomcat8-mongodb-s2i",
+        "namespace": "openshift",
+        "resourceVersion": "13400",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/openshift/templates/jws31-tomcat8-mongodb-s2i",
+        "uid": "da71e449-3502-11e9-8aaf-0a580a81001e"
+    },
+    "objects": [
+	{
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jws-service-account"
+            },
+            "secrets": [
+                {
+                    "name": "jws-app-secret"
+                }
+            ]
+        },
+        {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "annotations": {
+                    "description": "Default server certificate 'server.crt' and private key 'server.key' with no certificate password"
+                },
+                "name": "jws-app-secret"
+            },
+            "data": {
+                "server.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURhakNDQWxLZ0F3SUJBZ0lKQUlTd2g5UGtlUUhNTUEwR0NTcUdTSWIzRFFFQkJRVUFNQ3d4Q3pBSkJnTlYKQkFZVEFrTkJNUXN3Q1FZRFZRUUlFd0pDUXpFUU1BNEdBMVVFQ2hNSFVtVmtJRWhoZERBZUZ3MHhOVEE1TVRZeQpNRFEzTXpSYUZ3MHhPREE1TVRVeU1EUTNNelJhTUN3eEN6QUpCZ05WQkFZVEFrTkJNUXN3Q1FZRFZRUUlFd0pDClF6RVFNQTRHQTFVRUNoTUhVbVZrSUVoaGREQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0MKZ2dFQkFLVWRnNFhkSXhONVBFQlZGOG1GcXZCZk12Z3JaOXEveVJLZnNNdGVIdjdPNjJsdVNFSmhyalFCNnRULwpxODkxL3FnbnYvN2RuamlBek5udU5OeVFmMHIzTTNjV3dkRzhLY0pQUmVzcmF3TUZUaVo3KzRnTUlSa3lsOUZkCno4Z05rYktWOTBjQjZteWpNZ2hkTVY0aGh4K0Y4VHA5dGh2ek5kVmcrNHpPQkNTUkdkYWNHTFoxbzJadjZzVjMKb2tqSzRLNVBuVllFR0R3ODFoeE5NRnVGMXAwN1ViQjlVQitadjI0SmUxTXpFWWxtbmZiTSsybVNoSXNxWlJrUgp3NTErUVJnWDlrNXQzL0I3MzZ2QUdZU3BuUktnc3ZPQUFpdmY4NnQ4MWVFSExFY3NnQjZUWUwyamJoVW1yVGFPCmpDcS9RZ1lIbzdVdnlSVTNrRTg2bWlFdW5ia0NBd0VBQWFPQmpqQ0JpekFkQmdOVkhRNEVGZ1FVL2V4QlppRGYKaU9ISHhscmczZzdPMkYvelU4Y3dYQVlEVlIwakJGVXdVNEFVL2V4QlppRGZpT0hIeGxyZzNnN08yRi96VThlaApNS1F1TUN3eEN6QUpCZ05WQkFZVEFrTkJNUXN3Q1FZRFZRUUlFd0pDUXpFUU1BNEdBMVVFQ2hNSFVtVmtJRWhoCmRJSUpBSVN3aDlQa2VRSE1NQXdHQTFVZEV3UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUZCUUFEZ2dFQkFIbm8KUU1aeXYzTEQzNi9WV1JOOHMyYm5ZVzN2N3Y5YUNJNUNBbyswQklsZExyaTNVWlR3M0NQaVdpbHVwTUxweENQZQpVbGF0RHJ3Nkx2NVdRajlyN3EzR0tHQW1ZS3hva2VKMmZuL2wweVF2R1grVkRKZW9kTWgyZXl3YW1yLytjdjllCnhWOGtpeWozVFNSNC9hUWgwUUxlUytaMjhoanp3bFBiVkxpTW90L083R3dmM042WDhtWGs5ODczK3psT1FPZncKN0NQeEl4SStYNnNmMlkvOXlkV05jdWdnYStkK3JOam5Rd1ViZ1hWUytxWjZGc1FjQk8wMm5WbDBSMmFDS3pMUQpWd0tXZUJLRlN6Q2lKKy9lUmlaREQ2VHh3K3B1WERVR1hjNWR0TE5leEhrR1dmdUx5T1hmNzNvbEgzTVRsZW8wClcxZzJVeEVJdXRuWU5qQWpwT1E9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+                "server.key": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcFIyRGhkMGpFM2s4UUZVWHlZV3E4Rjh5K0N0bjJyL0pFcCt3eTE0ZS9zN3JhVzVJClFtR3VOQUhxMVArcnozWCtxQ2UvL3QyZU9JRE0yZTQwM0pCL1N2Y3pkeGJCMGJ3cHdrOUY2eXRyQXdWT0pudjcKaUF3aEdUS1gwVjNQeUEyUnNwWDNSd0hxYktNeUNGMHhYaUdISDRYeE9uMjJHL00xMVdEN2pNNEVKSkVaMXB3WQp0bldqWm0vcXhYZWlTTXJncmsrZFZnUVlQRHpXSEUwd1c0WFduVHRSc0gxUUg1bS9iZ2w3VXpNUmlXYWQ5c3o3CmFaS0VpeXBsR1JIRG5YNUJHQmYyVG0zZjhIdmZxOEFaaEttZEVxQ3k4NEFDSzkvenEzelY0UWNzUnl5QUhwTmcKdmFOdUZTYXRObzZNS3I5Q0JnZWp0Uy9KRlRlUVR6cWFJUzZkdVFJREFRQUJBb0lCQUJ4ZnJBQk85ZjRjc1V2awowNGVmM3JZYnhlaDduUWNzT2VObmFid28ybTZ6SkNVai9HcmIybEc1bXA4cnFGeW9URENkVkJMNkJueHpOY0NsCmZKUUNpTDFiS1k3bmJEc2NlSmlaZ3N4YzA3RGJNb2pPZVhUeGtLYUIyVER6VEFkMnZYalE2SU5kUXVtVVNiN0MKTlArV0IyQlZaaFRGRVl4UUNRbzM5a0pHRE5RempFL0NQSXl3UVVIYXJkYmMra1F4cVRlSGt3endXWjZGV0UweApDb1hiWHR5U2pxYThTQzRxVFZOZHNTNWt4RzR3VjdudUlkWVBOeGd2eEZkR0NJR2Nid09kakd6eDB6cjNmWC83ClQxaEdUL0FOQnpqWlZnSWFUMHNSYUFsdWl1WGdRNjNvMzJWWXYrMG5qU0JaVVNleW9EZWttUEdLZko0S0hSUGsKNmNTUDRoa0NnWUVBMnFFejVoSnJPaW1sOWkrWDFjMTdyVzlvZFU4aHUvaVhxMnJkK2N1eW8rdUpZR20yZ0RNRwpNR2JDMlpyMTREd2FjLzU0V0VZeFBOTy9UK0laUWNiTUxoNU8vTnowcTJRUWdxOUw4TkY0MkRzcE5oQ0s5THYvCmRLcEVNR2RzRUY4cEtZSEJhNXJ2T24yVDNWcGtFN0QwVE1YQ2lXMEZBUi9BZUhVaUtIcTZheThDZ1lFQXdWYWcKczJwVWo5VXVXQVhJM0NQQUFaNXlpQlBtY0htdHBrczBOWXFOd3FGTDJlRVoyZ0cwbnlFMlFMTlVpcWpqR2cxSwp4dlZaRWhXTlFqNlpsaFBkN213em9QWTM5bUlUeXFkcmxQUzF2Z09XeUZ0M1NJMGFLQXlHaTFDaGd3R0pYMHEvCllROFBqVzJyT0JBSFZ0c1dlUzF1RFJnM2pXKytOMzVseUpZdnE1Y0NnWUVBa0lTSW91ZS8rNFYyVUFMcjBnZHYKWHBqTEt1Z3crMmo3RVBPbVlhMjFtMGRoMnRwbUtkNFFsRVFKUHdDQTBVWEprcTArYmRPUVRvNEY0MDhvdE9NdApLcnNjS1dnQlQ1M29rQXBDSDZESHlkOXBnWFJ6OWd5amMwSHRxelZpS0h4TzRFSUdVaFByV1BXVG5YbFh0L0I3CnZKZm8zU0MwY3liQytwMHJCQ2tFT3o4Q2dZQUdzOW9lWGpGUVN6T3dHWU05SG9BcGpqU3FRd1phSDkzRlJoWXAKUlFSbEd2Sm1PMGVLSjBUN3Ywc0NNelZiR1QvR1IyK3dOaEZBYno3V2JSVWwvc3BTMmExd2h4aXBrZnpkcWJBeApHY3F6SzZ5dWhYMDlKcWNoZkUydHhyM1NyTnIyVXNFUHZGWHRzVCtlVWUvdk11azBpajZtZFpCM2RzaEJaRUJqCkU5SFRRUUtCZ0VSUFVoNFFvZnI1Wk9JWjMwMXhjazFVTjRuSzFNOGl5cU9vSHREZzg1OFNoTEUvZ2pZL0xvWHgKNi9vUmhTdjFtT2ZRUUYzS1ZZek5FbE5YLzhzbUF6M2s1U3I2RDNhM1BSQk9MUzc0aTgyd083aWFiU1JHbk41YQpSaktYMXhJaGkzTjhMK0ttOUgwUDhIK01SdnIxMkplV09GNU9sdGtuSSthN1VRUkxvK3RRCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=="
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The web server's http port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "secure-${APPLICATION_NAME}"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The database server's port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-mongodb"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 27017,
+                        "targetPort": 27017
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-mongodb"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-http",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "description": "Route for application's http service."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "description": "Route for application's https service."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "secure-${APPLICATION_NAME}"
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTPS}",
+                "tls": {
+                    "termination": "passthrough"
+                },
+                "to": {
+                    "name": "secure-${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "BuildConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "${APPLICATION_NAME}:latest"
+                    }
+                },
+                "source": {
+                    "contextDir": "${CONTEXT_DIR}",
+                    "git": {
+                        "ref": "${SOURCE_REPOSITORY_REF}",
+                        "uri": "${SOURCE_REPOSITORY_URL}"
+                    },
+                    "type": "Git"
+                },
+                "strategy": {
+                    "sourceStrategy": {
+                        "env": [
+                            {
+                                "name": "MAVEN_MIRROR_URL",
+                                "value": "${MAVEN_MIRROR_URL}"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
+                            }
+                        ],
+                        "forcePull": true,
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "jboss-webserver31-tomcat8-openshift:1.2",
+                            "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                        }
+                    },
+                    "type": "Source"
+                },
+                "triggers": [
+                    {
+                        "github": {
+                            "secret": "${GITHUB_WEBHOOK_SECRET}"
+                        },
+                        "type": "GitHub"
+                    },
+                    {
+                        "generic": {
+                            "secret": "${GENERIC_WEBHOOK_SECRET}"
+                        },
+                        "type": "Generic"
+                    },
+                    {
+                        "imageChange": {},
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}"
+                        },
+                        "name": "${APPLICATION_NAME}"
+                    },
+                    "spec": {
+                        "serviceAccount": "jws-service-account",
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "DB_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-mongodb=DB"
+                                    },
+                                    {
+                                        "name": "DB_JNDI",
+                                        "value": "${DB_JNDI}"
+                                    },
+                                    {
+                                        "name": "DB_USERNAME",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "DB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "DB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_MIN_POOL_SIZE",
+                                        "value": "${DB_MIN_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_MAX_POOL_SIZE",
+                                        "value": "${DB_MAX_POOL_SIZE}"
+                                    },
+                                    {
+                                        "name": "DB_TX_ISOLATION",
+                                        "value": "${DB_TX_ISOLATION}"
+                                    },
+                                    {
+                                        "name": "JWS_HTTPS_CERTIFICATE_DIR",
+                                        "value": "/etc/jws-secret-volume"
+                                    },
+                                    {
+                                        "name": "JWS_HTTPS_CERTIFICATE",
+                                        "value": "${JWS_HTTPS_CERTIFICATE}"
+                                    },
+                                    {
+                                        "name": "JWS_HTTPS_CERTIFICATE_KEY",
+                                        "value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+                                    },
+                                    {
+                                        "name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+                                        "value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "JWS_ADMIN_USERNAME",
+                                        "value": "${JWS_ADMIN_USERNAME}"
+                                    },
+                                    {
+                                        "name": "JWS_ADMIN_PASSWORD",
+                                        "value": "${JWS_ADMIN_PASSWORD}"
+                                    }
+                                ],
+                                "image": "${APPLICATION_NAME}",
+                                "imagePullPolicy": "Always",
+                                "name": "${APPLICATION_NAME}",
+                                "ports": [
+                                    {
+                                        "containerPort": 8778,
+                                        "name": "jolokia",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8443,
+                                        "name": "https",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+                                        ]
+                                    }
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${MEMORY_LIMIT}"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/jws-secret-volume",
+                                        "name": "jws-certificate-volume",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 60,
+                        "volumes": [
+                            {
+                                "name": "jws-certificate-volume",
+                                "secret": {
+                                    "secretName": "${JWS_HTTPS_SECRET}"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "${APPLICATION_NAME}:latest"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-mongodb"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-mongodb"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}-mongodb"
+                        },
+                        "name": "${APPLICATION_NAME}-mongodb"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "MONGODB_USER",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MONGODB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MONGODB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "MONGODB_ADMIN_PASSWORD",
+                                        "value": "${DB_ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MONGODB_NOPREALLOC",
+                                        "value": "${MONGODB_NOPREALLOC}"
+                                    },
+                                    {
+                                        "name": "MONGODB_SMALLFILES",
+                                        "value": "${MONGODB_SMALLFILES}"
+                                    },
+                                    {
+                                        "name": "MONGODB_QUIET",
+                                        "value": "${MONGODB_QUIET}"
+                                    }
+                                ],
+                                "image": "mongodb",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 27017
+                                    },
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "${APPLICATION_NAME}-mongodb",
+                                "ports": [
+                                    {
+                                        "containerPort": 27017,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 3,
+                                    "timeoutSeconds": 1
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/mongodb/data",
+                                        "name": "${APPLICATION_NAME}-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 60,
+                        "volumes": [
+                            {
+                                "emptyDir": {
+                                    "medium": ""
+                                },
+                                "name": "${APPLICATION_NAME}-data"
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-mongodb"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "description": "The name for the application.",
+            "displayName": "Application Name",
+            "name": "APPLICATION_NAME",
+            "required": true,
+            "value": "jws-app"
+        },
+        {
+            "description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e",
+            "displayName": "Custom http Route Hostname",
+            "name": "HOSTNAME_HTTP"
+        },
+        {
+            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e",
+            "displayName": "Custom https Route Hostname",
+            "name": "HOSTNAME_HTTPS"
+        },
+        {
+            "description": "Git source URI for application",
+            "displayName": "Git Repository URL",
+            "name": "SOURCE_REPOSITORY_URL",
+            "required": true,
+            "value": "https://github.com/jboss-openshift/openshift-quickstarts"
+        },
+        {
+            "description": "Git branch/tag reference",
+            "displayName": "Git Reference",
+            "name": "SOURCE_REPOSITORY_REF",
+            "value": "1.2"
+        },
+        {
+            "description": "Path within Git project to build; empty for root project directory.",
+            "displayName": "Context Directory",
+            "name": "CONTEXT_DIR",
+            "value": "todolist/todolist-mongodb"
+        },
+        {
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb",
+            "displayName": "Database JNDI Name",
+            "name": "DB_JNDI"
+        },
+        {
+            "description": "Database name",
+            "displayName": "Database Name",
+            "name": "DB_DATABASE",
+            "required": true,
+            "value": "root"
+        },
+        {
+            "description": "The name of the secret containing the certificate files",
+            "displayName": "Secret Name",
+            "name": "JWS_HTTPS_SECRET",
+            "required": true,
+            "value": "jws-app-secret"
+        },
+        {
+            "description": "The name of the certificate file within the secret",
+            "displayName": "Certificate Name",
+            "name": "JWS_HTTPS_CERTIFICATE",
+            "value": "server.crt"
+        },
+        {
+            "description": "The name of the certificate key file within the secret",
+            "displayName": "Certificate Key Name",
+            "name": "JWS_HTTPS_CERTIFICATE_KEY",
+            "value": "server.key"
+        },
+        {
+            "description": "The certificate password",
+            "displayName": "Certificate Password",
+            "name": "JWS_HTTPS_CERTIFICATE_PASSWORD"
+        },
+        {
+            "description": "Sets xa-pool/min-pool-size for the configured datasource.",
+            "displayName": "Datasource Minimum Pool Size",
+            "name": "DB_MIN_POOL_SIZE"
+        },
+        {
+            "description": "Sets xa-pool/max-pool-size for the configured datasource.",
+            "displayName": "Datasource Maximum Pool Size",
+            "name": "DB_MAX_POOL_SIZE"
+        },
+        {
+            "description": "Sets transaction-isolation for the configured datasource.",
+            "displayName": "Datasource Transaction Isolation",
+            "name": "DB_TX_ISOLATION"
+        },
+        {
+            "description": "Disable data file preallocation.",
+            "displayName": "MongoDB No Preallocation",
+            "name": "MONGODB_NOPREALLOC"
+        },
+        {
+            "description": "Set MongoDB to use a smaller default data file size.",
+            "displayName": "MongoDB Small Files",
+            "name": "MONGODB_SMALLFILES"
+        },
+        {
+            "description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output.",
+            "displayName": "MongoDB Quiet",
+            "name": "MONGODB_QUIET"
+        },
+        {
+            "description": "Database user name",
+            "displayName": "Database Username",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "name": "DB_USERNAME",
+            "required": true
+        },
+        {
+            "description": "Database user password",
+            "displayName": "Database Password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "DB_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Database admin password",
+            "displayName": "Database admin password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "DB_ADMIN_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "JWS Admin User",
+            "displayName": "JWS Admin Username",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "JWS_ADMIN_USERNAME",
+            "required": true
+        },
+        {
+            "description": "JWS Admin Password",
+            "displayName": "JWS Admin Password",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "JWS_ADMIN_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "GitHub trigger secret",
+            "displayName": "Github Webhook Secret",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "GITHUB_WEBHOOK_SECRET",
+            "required": true
+        },
+        {
+            "description": "Generic build trigger secret",
+            "displayName": "Generic Webhook Secret",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "name": "GENERIC_WEBHOOK_SECRET",
+            "required": true
+        },
+        {
+            "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+            "displayName": "ImageStream Namespace",
+            "name": "IMAGE_STREAM_NAMESPACE",
+            "required": true,
+            "value": "openshift"
+        },
+        {
+            "description": "Maven mirror to use for S2I builds",
+            "displayName": "Maven mirror URL",
+            "name": "MAVEN_MIRROR_URL"
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR"
+        },
+        {
+            "description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
+            "displayName": "MongoDB Image Stream Tag",
+            "name": "MONGODB_IMAGE_STREAM_TAG",
+            "required": true,
+            "value": "3.2"
+        },
+        {
+            "description": "Container memory limit",
+            "name": "MEMORY_LIMIT",
+            "value": "1Gi"
+        },
+        {
+         "name": "IDENTIFIER",
+         "description": "Number to append to the name of resources",
+         "value": "1"
+        }
+    ]
+}

--- a/reliability/testCluster.sh
+++ b/reliability/testCluster.sh
@@ -59,7 +59,7 @@ function access_applications
   do
     proj=${projects[$var]}
     text=${page_text[$var]}
-    content=$(curl -k http://$(oc get routes -n $proj --no-headers | awk '{print$2}'))
+    content=$(curl -k http://$(oc get routes -n $proj --no-headers | awk '{print $2}'))
     echo $content | grep "$text"
     if [[ $? -ne 0 ]]
     then
@@ -89,9 +89,9 @@ oc label namespace cakephp --overwrite purpose=rel
 oc new-app --template=cakephp-mysql-example    
 oc new-project eap
 oc label namespace eap --overwrite purpose=rel
-oc create -f https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/eap-app-secret.json
+oc create -f https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/eap7-app-secret.json
 oc create -f /root/svt/reliability/eap-secret.json
-oc new-app --template=eap64-mysql-s2i
+oc new-app --template=eap71-mysql-s2i
 oc new-project dancer
 oc label namespace dancer --overwrite purpose=rel
 oc new-app --template=dancer-mysql-example


### PR DESCRIPTION
Older openshift quickstart templates for eap64 and tomcat-mongodb are not available on OCP 4.0.

- Updated cluster-loader.py config file "all-quickstarts-no-limits.yaml" to use newer eap71-mysql and tomcat jws31-tomcat8-mongodb quickstart templates.
- Added newer json templates for eap71-mysql and  jws31-tomcat8-mongodb in content dir
- Updated reliability testCluster.sh script to build and deploy the newer eap71-mysql apps from the eap71-mysql-s2i openshift template