### PR TITLE
Minor fixes in networking test

### DIFF
--- a/networking/synthetic/node-ip-test-setup.yaml
+++ b/networking/synthetic/node-ip-test-setup.yaml
@@ -89,13 +89,10 @@
       --config={{ pbench_label }}_UDP
 
   - name: Copy pbench results
-    shell: pbench-copy-results
+    shell: pbench-move-results --prefix=networking
 
   - name: Kill pbench tools
     shell: pbench-kill-tools
 
 #  - name: Clear pbench tools
 #    shell: pbench-clear-tools
-
-  - name: Clear pbench results
-    shell: pbench-clear-results

--- a/networking/synthetic/pod-ip-test-setup.yaml
+++ b/networking/synthetic/pod-ip-test-setup.yaml
@@ -143,7 +143,7 @@
       --config={{ pbench_label }}_UDP
 
   - name: Copy pbench results
-    shell: pbench-copy-results
+    shell: pbench-move-results --prefix=networking
 
   - name: Kill pbench tools
     shell: pbench-kill-tools
@@ -154,6 +154,3 @@
   - name: Delete uperf projects
     shell: oc delete project uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
-
-  - name: Clear pbench results
-    shell: pbench-clear-results

--- a/networking/synthetic/svc-ip-test-setup.yaml
+++ b/networking/synthetic/svc-ip-test-setup.yaml
@@ -179,7 +179,7 @@
       --config={{ pbench_label }}_UDP
 
   - name: Copy pbench results
-    shell: pbench-copy-results
+    shell: pbench-move-results --prefix=networking
 
   - name: Kill pbench tools
     shell: pbench-kill-tools
@@ -190,6 +190,3 @@
   - name: Delete uperf projects
     shell: oc delete project uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
-
-  - name: Clear pbench results
-    shell: pbench-clear-results


### PR DESCRIPTION
This commit modifies the networking test to move results instead of
copy and groups all the results under networking prefix.