### PR TITLE
monogdb test updated 

### DIFF
--- a/storage/mongodb/files/oc/ycsb_pod.yaml
+++ b/storage/mongodb/files/oc/ycsb_pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: ycsb
+  name: ycsb-pod
+spec:
+  containers:
+    - image: "docker.io/hongkailiu/ycsb:002"
+      imagePullPolicy: IfNotPresent
+      name: ycsb-pod
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+      terminationMessagePath: /dev/termination-log
+  dnsPolicy: Default
+  restartPolicy: OnFailure
+  nodeSelector: 
+  serviceAccount: ""
+status: {}

--- a/storage/mongodb/runmongo.sh
+++ b/storage/mongodb/runmongo.sh
@@ -9,9 +9,11 @@ RECORDCOUNT="${6}"
 OPERATIONCOUNT="${7}"
 STORAGECLASS="${8}"
 VOLUMECAPACITY="${9}"
-
+DISTRIBUTION="${10}"
+PROJECTS="${11}"
+PBENCHCONFIG="${12}"
 
 for memory_limit in $(echo ${MEMORY_LIMIT} | sed -e s/,/" "/g); do
 	ansible-playbook -i "${JUMP_HOST}," mongodb-test.yaml --extra-vars "MEMORY_LIMIT=${memory_limit}Mi ycsb_threads=${ycsb_threads} workload=${WORKLOAD} iteration=${ITERATIONS} \
-	recordcount=${RECORDCOUNT} operationcount=${OPERATIONCOUNT} STORAGE_CLASS_NAME=${STORAGECLASS} VOLUME_CAPACITY=${VOLUMECAPACITY}Gi" 
+	recordcount=${RECORDCOUNT} operationcount=${OPERATIONCOUNT} STORAGE_CLASS_NAME=${STORAGECLASS} VOLUME_CAPACITY=${VOLUMECAPACITY}Gi distribution=${DISTRIBUTION} test_project_number=${PROJECTS} PBENCHCONFIG=${PBENCHCONFIG}"
 done 


### PR DESCRIPTION
Changes

- With dc.yaml it was noticed that ycsb pods will not be equally spread across nodes, this is experiment for now. Test works with this too, but when pod object is used to create pods , pods are spread more equally than for case when dc.yaml is used. 
-  updated files/scripts/create-oc-objects.sh to delete project before new ones are created
I noticed in tests that having projects deleted in advance before creating new ones ( for new test ) gives healthier environment  ( especially for case when storage backend is not good with cleaning stuff properly ) when projects are deleted first and then new test start from clean state - without any projects 
-  updated runmongo.sh to support new options