### PR TITLE
Remove the root mount from controller, pbench-agent templates

### DIFF
--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset-masters.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset-masters.yml
@@ -37,8 +37,8 @@ spec:
             mountPath: /etc/origin/master
           - name: certs
             mountPath: /etc/pki
-          - name: root
-            mountPath: /
+          - name: ocp-volumes
+            mountPath: /var/lib/kubelet/pods
         ports:
           - containerPort: 2022
           - containerPort: 9090
@@ -58,9 +58,9 @@ spec:
         - name: certs
           hostPath:
             path: /etc/pki
-        - name: root
+        - name: ocp-volumes
           hostPath:
-            path: /
+            path: /var/lib/kubelet/pods
       nodeSelector: 
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
@@ -37,8 +37,8 @@ spec:
             mountPath: /etc/origin/master
           - name: certs
             mountPath: /etc/pki
-          - name: root
-            mountPath: /
+          - name: ocp-volumes
+            mountPath: /var/lib/kubelet/pods
         ports:
           - containerPort: 2022
           - containerPort: 9090
@@ -58,8 +58,7 @@ spec:
         - name: certs
           hostPath:
             path: /etc/pki
-        - name: root
-          hostPath:
-            path: /
+        - name: ocp-volumes
+          mountPath: /var/lib/kubelet/pods
       nodeSelector: 
         pbench_role: agent

--- a/openshift_templates/performance_monitoring/scale-ci-controller/controller-job.yml
+++ b/openshift_templates/performance_monitoring/scale-ci-controller/controller-job.yml
@@ -39,8 +39,8 @@ spec:
             mountPath: /var/lib/pbench-agent
           - name: tools
             mountPath: /var/lib/pbench-agent/tools-default
-          - name: root
-            mountPath: /
+          - name: ocp-volumes
+            mountPath: /var/lib/kubelet/pods
         ports:
           - containerPort: 9090
           - containerPort: 2022
@@ -63,9 +63,9 @@ spec:
         - name: tools
           hostPath: 
             path: /var/lib/pbench-agent/tools-default
-        - name: root
+        - name: ocp-volumes
           hostPath:
-            path: /
+            path: /var/lib/kubelet/pods
       serviceAccountName: useroot 
       nodeSelector:
         role: controller


### PR DESCRIPTION
The reason for having the / volume mount was to be able to get info
about the pvc's but it will replace the existing contents of the
pod which is not the intended behavior.We can achieve the same
by mounting /var/lib/kubelet/pods.