### PR TITLE
Set the controller and pbench image policy to Always

### DIFF
--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset-masters.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset-masters.yml
@@ -17,7 +17,7 @@ spec:
       containers:
       - image: docker.io/ravielluri/image:agent
         name: pbench-agent
-        imagePullPolicy: IfNotPresent 
+        imagePullPolicy: Always 
         securityContext:
           privileged: true
         env:

--- a/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
+++ b/openshift_templates/performance_monitoring/pbench/pbench-agent-daemonset.yml
@@ -17,7 +17,7 @@ spec:
       containers:
       - image: docker.io/ravielluri/image:agent
         name: pbench-agent
-        imagePullPolicy: IfNotPresent 
+        imagePullPolicy: Always
         securityContext:
           privileged: true
         env:

--- a/openshift_templates/performance_monitoring/scale-ci-controller/controller-job.yml
+++ b/openshift_templates/performance_monitoring/scale-ci-controller/controller-job.yml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: controller
         image: ravielluri/image:controller
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         securityContext:
           privileged: true
         command:

--- a/openshift_tooling/pbench/controller.sh
+++ b/openshift_tooling/pbench/controller.sh
@@ -10,8 +10,8 @@ wait_time=25
 function cleanup() {
 	oc delete -f $svt_repo_location/svt/openshift_templates/performance_monitoring/scale-ci-controller/controller-job.yml -n $controller_namespace
 	oc delete cm tooling-config -n $controller_namespace
-	sleep $wait_time
 	oc delete project --wait=true $controller_namespace
+	sleep $wait_time
 }
 
 # Create a service account and add it to the privileged scc
@@ -38,7 +38,8 @@ fi
 oc project $controller_namespace &>/dev/null
 if [[ $? == 0 ]]; then
         echo "Looks like the $controller_namespace already exists, deleting it"
-        oc delete project $controller_namespace
+        oc delete project --wait=true $controller_namespace
+	sleep $wait_time
 fi
 
 # Create controller ns, configmap and run the job

--- a/openshift_tooling/prometheus_db_dump/prometheus_dump.sh
+++ b/openshift_tooling/prometheus_db_dump/prometheus_dump.sh
@@ -33,7 +33,7 @@ prometheus_pod=$(oc get pods -n $prometheus_namespace | grep -w "Running" | awk 
 echo "copying prometheus DB from $prometheus_pod"
 oc cp $prometheus_namespace/$prometheus_pod:/prometheus/wal -c prometheus wal/
 echo "creating a tarball of the captured DB at $output_dir"
-XZ_OPT=--threads=0 tar cJf $output_dir/prometheus.tar.gz wal
+XZ_OPT=--threads=0 tar cJf $output_dir/prometheus.tar.xz wal
 if [[ $? == 0 ]]; then
 	rm -rf wal
 fi


### PR DESCRIPTION
This will help in creating the pods using the latest image instead
of the old image in case we have some fixes in repos baked into the
image instead of manually pulling down the image on each node.