### PR TITLE
conc. build for 3 workers

### DIFF
--- a/openshift_performance/ci/content/conc_builds_cakephp.yaml
+++ b/openshift_performance/ci/content/conc_builds_cakephp.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 50
+  - num: 75
     basename: svt-cakephp-
     ifexists: default
     tuning: default

--- a/openshift_performance/ci/content/conc_builds_django.yaml
+++ b/openshift_performance/ci/content/conc_builds_django.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 50
+  - num: 75
     basename: svt-django-
     ifexists: default
     tuning: default

--- a/openshift_performance/ci/content/conc_builds_eap.yaml
+++ b/openshift_performance/ci/content/conc_builds_eap.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 50
+  - num: 75
     basename: svt-eap-
     ifexists: default
     tuning: default

--- a/openshift_performance/ci/content/conc_builds_nodejs.yaml
+++ b/openshift_performance/ci/content/conc_builds_nodejs.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 50
+  - num: 75
     basename: svt-nodejs-
     ifexists: default
     tuning: default

--- a/openshift_performance/ci/content/conc_builds_rails.yaml
+++ b/openshift_performance/ci/content/conc_builds_rails.yaml
@@ -1,5 +1,5 @@
 projects:
-  - num: 50
+  - num: 75
     basename: svt-rails-
     ifexists: default
     tuning: default

--- a/openshift_performance/ci/scripts/conc_builds.sh
+++ b/openshift_performance/ci/scripts/conc_builds.sh
@@ -6,15 +6,17 @@
 ## build tests.
 ################################################
 master=$1
-build_array=(1 5 10 20 30 40 50)
-app_array=("cakephp" "eap" "django" "nodejs")
+#build_array=(1 5 10 20 30 40 50)
+build_array=(1 8 15 30 45 60 75)
+#app_array=("cakephp" "eap" "django" "nodejs")
+app_array=("django")
 # this number should be equal to the number of the created projects
-readonly PROJECT_NUM=50
+readonly PROJECT_NUM=75
 
 function delete_projects()
 {
   echo "deleting projects"
-  oc delete project -l purpose=test
+  oc delete project -l purpose=test --wait=false
 }
 
 function create_projects()
@@ -86,14 +88,14 @@ function clean_docker_images()
 rm -rf *.out
 
 #setup user for build tests
-oc login -u system:admin
-htpasswd -b /etc/origin/htpasswd redhat redhat
-oadm policy add-cluster-role-to-user admin redhat
-oadm policy add-cluster-role-to-user system:image-pruner redhat
+#oc login -u system:admin
+#htpasswd -b /etc/origin/htpasswd redhat redhat
+#oadm policy add-cluster-role-to-user admin redhat
+#oadm policy add-cluster-role-to-user system:image-pruner redhat
 
 for app in "${app_array[@]}"
 do
-  oc login -u system:admin
+  #oc login -u system:admin
   echo "Starting $app builds" >> conc_builds_$app.out
   create_projects "../content/conc_builds_$app.yaml"
   wait_for_build_completion


### PR DESCRIPTION
On OCP 4+, the default cluster infra is with 3 workers.
We extend our test-case for it.