### PR TITLE
Remove node labels after each test

### DIFF
--- a/networking/synthetic/pod-ip-test-setup.yaml
+++ b/networking/synthetic/pod-ip-test-setup.yaml
@@ -154,3 +154,11 @@
   - name: Delete uperf projects
     shell: oc delete project uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
+
+  - name: Remove label sender nodes
+    shell: oc label node {{ item }} region-
+    with_items: "{{ groups['sender'] }}"
+
+  - name: Remove label receiver nodes
+    shell: oc label node {{ item }} region-
+    with_items: "{{ groups['receiver'] }}"

--- a/networking/synthetic/svc-ip-test-setup.yaml
+++ b/networking/synthetic/svc-ip-test-setup.yaml
@@ -190,3 +190,11 @@
   - name: Delete uperf projects
     shell: oc delete project uperf-{{ item }}
     with_sequence: start=1 end={{ uperf_pod_number }}
+
+  - name: Remove label sender nodes
+    shell: oc label node {{ item }} region-
+    with_items: "{{ groups['sender'] }}"
+
+  - name: Remove label receiver nodes
+    shell: oc label node {{ item }} region-
+    with_items: "{{ groups['receiver'] }}"


### PR DESCRIPTION
To ensure that sequential test execution are successful, the playbooks
needs to remove the added node labels. This will allow follow up test
to only create pods on the specified nodes.