### PR TITLE
Fix logtest node selector

### DIFF
--- a/openshift_scalability/content/logtest/logtest-pod.json
+++ b/openshift_scalability/content/logtest/logtest-pod.json
@@ -26,6 +26,9 @@
                 }
             },
             "spec": {
+                "nodeSelector": {
+                    "placement": "${PLACEMENT}"
+                },
                 "containers": [
                     {
                         "env": [

--- a/openshift_scalability/content/logtest/logtest-rc.json
+++ b/openshift_scalability/content/logtest/logtest-rc.json
@@ -36,6 +36,9 @@
                         }
                     },
                     "spec": {
+                        "nodeSelector": {
+                           "placement": "${PLACEMENT}"
+                        },
                         "containers": [
                             {
                                 "env": [

--- a/openshift_scalability/content/logtest/logtest-syslog-rc.json
+++ b/openshift_scalability/content/logtest/logtest-syslog-rc.json
@@ -36,6 +36,9 @@
                         }
                     },
                     "spec": {
+                        "nodeSelector": {
+                           "placement": "${PLACEMENT}"
+                        },
                         "containers": [
                             {
                                 "env": [

--- a/openshift_scalability/content/logtest/ocp_logtest-README.md
+++ b/openshift_scalability/content/logtest/ocp_logtest-README.md
@@ -1,7 +1,7 @@
 ## ocp_logtest README
 
 ### Purpose 
-The **ocp_logtest.py** script is a flexible tool for creating pod logs in OpenShift.  It can log random or fixed test for any given line/word sizes and at any given rate.  It can run forever, for a set number of messages or for a set period of time.
+The **ocp_logtest.py** script is a flexible tool for creating pod logs in OpenShift.  It can log random or fixed text for any given line/word sizes and at any given rate.  It can run forever, for a set number of messages or for a set period of time.
 
 Also included are a docker configuration to run the tool in a container along with OpenShift templates to create a pod running the container and create a replication controller to control the lifecycle of the pods.
 

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -72,11 +72,7 @@ def create_template(templatefile, num, parameters, globalvars):
     if globalvars["debugoption"]:
         print "create_template function called"
 
-    # process parameters flag for oc 3.4 and earlier is -v.  Starting in 3.5 it is -p.
-    if not globalvars["kubeopt"] and (int(globalvars["version_info"]["major"]) <= 3 and int(globalvars["version_info"]["minor"]) <= 4):
-        parameter_flag = "-v"
-    else:
-        parameter_flag = "-p"
+    parameter_flag = "-p"
 
     if globalvars["autogen"] and parameters:
         localhost, router_ip, jmeter_ips = get_route()


### PR DESCRIPTION
The logtest nodeSelector was meant to follow the placement=$PLACEMENT var in the templates with a default value of placement=logtest.   These template updates achieve that.