### PR TITLE
Updated playbook scale_up_complete.yaml and check_app.py to run on OCP 4.x

### DIFF
--- a/openshift_performance/ci/content/scale_up_complete.yaml
+++ b/openshift_performance/ci/content/scale_up_complete.yaml
@@ -1,64 +1,97 @@
 ---
-- hosts: all
+- hosts: localhost
   remote_user: root
   tasks:
-    - name: Ensure htpasswd file exits
-      file:
-        path: /etc/origin/htpasswd
-        state: touch
-    - name: Create redhat user
-      shell: htpasswd -b /etc/origin/htpasswd redhat redhat
-    - name: Give redhat user cluster-admin
-      shell: oc adm policy add-cluster-role-to-user cluster-admin redhat
+# Starting in OCP 4.1, we need to pass in the command line when running the playbook 3 variables:
+# - api_url  (obtained from the kubeconfig)
+# - login_username (kubeadim or another user created)
+# - login_passwd
+# Sample command to run this playbook:
+#   ansible-playbook -vv -e api_url="https://api.walid0509204a.perf-testing.devcluster.openshift.com:6443" -e login_username="kubeadmin" -e login_passwd="<kubeadmin-passwd>" scale_up_complete.yaml 2>&1 | tee /root/output_scale_up_complete-$(date +%Y-%m-%d-%H%M).log
+#
+    - name: Give the test user from command line cluster-admin
+      shell: oc adm policy add-cluster-role-to-user cluster-admin {{ login_username }}
+
     - name: Run cluster loader to create all projects
       args: 
          chdir: /root/svt/openshift_scalability
       shell: > 
          python -u /root/svt/openshift_scalability/cluster-loader.py 
          -f /root/svt/openshift_scalability/config/all-quickstarts-no-limits.yaml
-         > /tmp/cluster-loader.out 2>/tmp/cluster-loader.err
+         > /tmp/cluster_loader.out 2>/tmp/cluster_loader.err
+
+# Starting in OCP 4.1, we pass the api_url, login_username, and login_passwd to the updated check_app.py script:
     - name: Wait for all applications to be ready
       shell: > 
          python -u /root/svt/openshift_performance/ose3_perf/scripts/check_app.py
-         cakephp-mysql0:cakephp-mysql-example
-         rails-postgresql0:rails-postgresql-example
-         dancer-mysql0:dancer-mysql-example
-         eap64-mysql0:eap-app
-         rails-postgresql0:rails-postgresql-example
-         django-postgresql0:django-psql-example
-         nodejs-mongodb0:nodejs-mongodb-example
-         tomcat8-mongodb0:jws-app
+         -a "{{ api_url }}"
+         -u "{{ login_username }}"
+         -p "{{ login_passwd }}"
+         -n "cakephp-mysql0:cakephp-mysql-example dancer-mysql0:dancer-mysql-example eap71-mysql0:eap-app rails-postgresql0:rails-postgresql-example django-postgresql0:django-psql-example nodejs-mongodb0:nodejs-mongodb-example tomcat8-mongodb0:jws-app"
          > /tmp/check_app.out 2>/tmp/check_app.err
+
     - name: Scale all applications to zero
       shell: oc scale --replicas=0 -n {{ item.namespace }} dc/{{ item.dc }}
       with_items:
          - { namespace: 'cakephp-mysql0', dc: 'cakephp-mysql-example'}  
          - { namespace: 'dancer-mysql0', dc: 'dancer-mysql-example'}
-         - { namespace: 'eap64-mysql0', dc: 'eap-app'}
+         - { namespace: 'eap71-mysql0', dc: 'eap-app'}
          - { namespace: 'rails-postgresql0', dc: 'rails-postgresql-example'}
          - { namespace: 'django-postgresql0', dc: 'django-psql-example'}
          - { namespace: 'nodejs-mongodb0', dc: 'nodejs-mongodb-example'}
          - { namespace: 'tomcat8-mongodb0', dc: 'jws-app'}
+
     - name: Run scale-up test for cakephp
       shell: >
          python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
+         -m "{{ api_url }}"
+         -u "{{ login_username }}" 
+         -p "{{ login_passwd }}" 
          -n cakephp-mysql0 
          -d cakephp-mysql-example 
-         -r 200
+         -r 20
          -s 20 
          -w 10 
          -z
          -0
          > /tmp/scale_test.out 2>/tmp/scale_test.err
-    - name: Run scale-up test for rails  
+
+    - name: Run scale-up test for dancer
       shell: >
          python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
+         -m "{{ api_url }}"
+         -u "{{ login_username }}"
+         -p "{{ login_passwd }}"
+         -n dancer-mysql0
+         -d dancer-mysql-example
+         -r 40
+         -s 20
+         -w 10
+         -z
+         -0
+         >> /tmp/scale_test.out 2>/tmp/scale_test.err
+
+    - name: Run scale-up test for eap-app
+      shell: >
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         -m "{{ api_url }}"
+         -u "{{ login_username }}"
+         -p "{{ login_passwd }}"
+         -n eap71-mysql0
+         -d eap-app
+         -r 20
+         -s 10
+         -w 10
+         -z
+         -0
+         >> /tmp/scale_test.out 2>/tmp/scale_test.err
+
+    - name: Run scale-up test for ruby rails  
+      shell: >
+         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
+         -m "{{ api_url }}"
+         -u "{{ login_username }}" 
+         -p "{{ login_passwd }}" 
          -n rails-postgresql0
          -d rails-postgresql-example 
          -r 20 
@@ -67,12 +100,13 @@
          -z
          -0
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
+
     - name: Run scale-up test for django  
       shell: >
          python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
+         -m "{{ api_url }}"
+         -u "{{ login_username }}" 
+         -p "{{ login_passwd }}" 
          -n django-postgresql0
          -d django-psql-example
          -r 100 
@@ -81,26 +115,14 @@
          -z
          -0
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
-    - name: Run scale-up test for dancer  
-      shell: >
-         python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
-         -n dancer-mysql0
-         -d dancer-mysql-example
-         -r 40 
-         -s 20 
-         -w 10 
-         -z
-         -0
-         >> /tmp/scale_test.out 2>/tmp/scale_test.err
+
+
     - name: Run scale-up test for nodejs  
       shell: >
          python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
+         -m "{{ api_url }}"
+         -u "{{ login_username }}" 
+         -p "{{ login_passwd }}" 
          -n nodejs-mongodb0
          -d nodejs-mongodb-example
          -r 200
@@ -109,22 +131,25 @@
          -z
          -0
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
-    - name: Run scale-up test for eap-app  
+
+    - name: Run scale-up test for tomcat jws-app
       shell: >
          python -u /root/svt/openshift_performance/ose3_perf/scripts/scale_test.py
-         -m localhost:8443 
-         -u redhat 
-         -p redhat 
-         -n eap64-mysql0
-         -d eap-app
+         -m "{{ api_url }}"
+         -u "{{ login_username }}"
+         -p "{{ login_passwd }}"
+         -n tomcat8-mongodb0
+         -d jws-app
          -r 20
-         -s 10 
-         -w 10 
+         -s 10
+         -w 10
          -z
          -0
          >> /tmp/scale_test.out 2>/tmp/scale_test.err
+
     - name: Delete test projects
       shell: oc delete project -l purpose=test
+
     - name: Fetch cluster_loader output
       fetch: src={{ item }} dest=.
       with_items:
@@ -134,3 +159,4 @@
        - "/tmp/check_app.err"
        - "/tmp/scale_test.out"
        - "/tmp/scale_test.err"
+

--- a/openshift_performance/ose3_perf/scripts/check_app.py
+++ b/openshift_performance/ose3_perf/scripts/check_app.py
@@ -13,39 +13,60 @@ def run(cmd):
     result = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
     return result
 
+# Starting in OCP 4.1, added arguments for login() method:
+if __name__ ==  "__main__":
 
+    parser = OptionParser()
+    parser.add_option("-a", "--apiurl", dest="apiurl",
+                     help="url of the OpenShift master to login to")
+    parser.add_option("-u", "--user", dest="oseuser",
+                     help="OpenShift user for login")
+    parser.add_option("-p", "--password", dest="osepass",
+                     help="OpenShift password for login")
+    parser.add_option("-n", "--namespace-dc-pairs", dest="namespace_dc_pairs",
+                     help="Comma separated string containing namespace:dc pairs")
 
-login("localhost:8443", "redhat", "redhat")
+    globalconfig = {}
 
+    (options, args) = parser.parse_args()
+    globalconfig["apiurl"] = options.apiurl
+    globalconfig["oseuser"] = options.oseuser
+    globalconfig["password"] = options.osepass
+    globalconfig["namespace_dc_pairs"] = options.namespace_dc_pairs
 
-sleep_time = 15
-max_retries = 40
-retries=0
-apps_found = 0;
-apps_not_running = sys.argv[1:]
-apps_needed = len(apps_not_running)
+    login(globalconfig["apiurl"],globalconfig["oseuser"],globalconfig["password"])
 
-while apps_found < apps_needed and retries < max_retries:
-    result = run("oc get dc --all-namespaces")
-    print result
-    apps_to_look_for = apps_not_running[0:]
-    for app in apps_to_look_for:
-        namespace,dc = app.split(":")
-        print namespace + " " + dc
-        # dancer-mysql0        dancer-mysql-example       1          1         1         config,image(dancer-mysql-example:latest)
-        dc_running_regex = ".*" + namespace + "\s+" + dc + "\s+\d+\s+1\s+1"
-        if re.search(dc_running_regex, result):
-            print "Found: " + app
-            apps_found += 1
-            apps_not_running.remove(app)
+    sleep_time = 15
+    max_retries = 40
+    retries=0
+    apps_found = 0;
+    namespace_dc_pairs = globalconfig["namespace_dc_pairs"].split()
+    apps_not_running = namespace_dc_pairs
+    print apps_not_running
+    
+    apps_needed = len(apps_not_running)
 
-    print "The following apps still not running: " + str(apps_not_running)
-    if apps_found < apps_needed:
-        time.sleep(sleep_time)
-        retries += 1
+    while apps_found < apps_needed and retries < max_retries:
+        result = run("oc get dc --all-namespaces")
+        print result
+        apps_to_look_for = apps_not_running[0:]
+        for app in apps_to_look_for:
+            namespace,dc = app.split(":")
+            print namespace + " " + dc
+            # dancer-mysql0        dancer-mysql-example       1          1         1         config,image(dancer-mysql-example:latest)
+            dc_running_regex = ".*" + namespace + "\s+" + dc + "\s+\d+\s+1\s+1"
+            if re.search(dc_running_regex, result):
+                print "Found: " + app
+                apps_found += 1
+                apps_not_running.remove(app)
 
-exit_code = apps_needed - apps_found
-print "exiting with code: " + str(exit_code)
-sys.exit(exit_code)
+        print "The following apps still not running: " + str(apps_not_running)
+        if apps_found < apps_needed:
+            time.sleep(sleep_time)
+            retries += 1
+
+    exit_code = apps_needed - apps_found
+    print "exiting with code: " + str(exit_code)
+    sys.exit(exit_code)
 
 


### PR DESCRIPTION
These updates were needed to run the scale_up_comlete.yaml playbook on OCP 4.x:
- Updated script openshift_performance/ose3_perf/scripts/check_app.py to pass 3 arguments to the login method:
- api_url
- login username
- login passwd

Updated  the openshift_performance/ci/content/scale_up_complete.yaml playbook to support passing the api_url, login_username, and login_passwd as arguments when running the playbook from ansible-playbook.  Also updated the eap scale up task to use the eap71 app, and added a new task to scale-up the jws31-tomcat8 app.