### PR TITLE
Updated scripts run-node-affinity-anti-affinity.sh taint_nodes.sh for…

### DIFF
--- a/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
@@ -8,16 +8,15 @@ oc version
 oc get node --show-labels
 oc describe node | grep Runtime
 
+compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/worker=' | awk '{print $1}' | grep -v NAME | xargs)
 
-compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/compute=true' | awk '{print $1}' | grep -v NAME | xargs)
-
-echo -e "\nComputes nodes are: $compute_nodes"
+echo -e "\nWorker  nodes are: $compute_nodes"
 
 declare -a node_array
 counter=1
 
-oc get nodes -l 'node-role.kubernetes.io/compute=true'
-oc describe nodes -l 'node-role.kubernetes.io/compute=true' 
+oc get nodes -l 'node-role.kubernetes.io/worker='
+oc describe nodes -l 'node-role.kubernetes.io/worker=' 
 
 initial_node_label="beta.kubernetes.io/arch=amd64"
 
@@ -71,8 +70,17 @@ export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
 cd /root/svt/openshift_scalability
 ls -ltr config/golang
 
-echo -e "\nStarting GoLang cluster-loader with config file: config/golang/node-affinity-anti-affinity"
-/usr/libexec/atomic-openshift/extended.test --ginkgo.focus="Load cluster" --viper-config=config/golang/node-affinity-anti-affinity
+#### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
+## - Absolute path to config file needed
+## - .yaml extension is required now in config file name
+## - full path to the config file  must be under 70 characters total
+
+MY_CONFIG=/root/svt/openshift_scalability/config/golang/node-affinity.yaml
+echo -e "\nRunning GoLang cluster-loader from openshift-tests binary with config file: ${MY_CONFIG}"
+echo -e "\nContents of  config file: ${MY_CONFIG}"
+cat ${MY_CONFIG}
+
+VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"
 
 sleep 30
 
@@ -80,11 +88,11 @@ check_no_error_pods
 
 oc get pods --all-namespaces -o wide
 
-## TO DO:  check counts and later chage 10 to 250 in cluster loader yaml file
+## TO DO:  check pod counts expecting 130 pods per namespace
 oc get pods -n node-affinity-0 -o wide | grep "pausepods" | grep ${node_array[2]} | grep Running | wc -l
 oc get pods -n node-anti-affinity-0 -o wide | grep "hellopods" | grep ${node_array[1]} | grep Running | wc -l
 
-sleep 30
+sleep 60
 
 # delete projects:  cleanup
 oc delete project node-affinity-0
@@ -96,7 +104,6 @@ oc delete project node-anti-affinity-0
 sleep 30
 
 ## remove node labels
-
 echo -e "\nRemoving the node labels"
 oc label nodes ${node_array[1]} cpu-
 oc label nodes ${node_array[2]} cpu-

--- a/openshift_scalability/ci/scripts/taint_nodes.sh
+++ b/openshift_scalability/ci/scripts/taint_nodes.sh
@@ -3,32 +3,42 @@
 
 date
 uname -a
-openshift version
+## openshift version
+oc get clusterversion
+oc get clusterversion -o json
 
-compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/compute=true' | awk '{print $1}' | grep -v NAME | xargs)
+compute_nodes=$(oc get nodes -l 'node-role.kubernetes.io/worker=' | awk '{print $1}' | grep -v NAME | xargs)
+
 
 echo -e "\nComputes nodes are: $compute_nodes"
 
 declare -a node_array
 counter=1
 
-oc get nodes -l 'node-role.kubernetes.io/compute=true'
-oc describe nodes -l 'node-role.kubernetes.io/compute=true' | grep Taints
+oc get nodes -l 'node-role.kubernetes.io/worker='
+oc describe nodes -l 'node-role.kubernetes.io/worker=' | grep Taints
 
-# Taint nodes
+# Build node_array of workers:
 for n in ${compute_nodes}; do
   node_array[${counter}]=${n}
-  echo -e "\nTainting node $n with 'security=s${counter}:NoSchedule'"
-  echo "#  oc adm taint nodes $n security=s${counter}:NoSchedule"
-  oc adm taint nodes $n security=s${counter}:NoSchedule
+  echo -e "\nArray element node_array index ${counter} has value : ${node_array[${counter}]}"
   counter=$((counter+1))
 done
 
-oc describe nodes -l 'node-role.kubernetes.io/compute=true' | grep Taints
+oc describe nodes -l 'node-role.kubernetes.io/worker=' | grep Taints
 
-for i in {1..2}; do
+## Testing with 3 worker nodes
+for i in {1..3}; do
   echo "Array element node_array index $i has value : ${node_array[${i}]}"
 done
+
+## For OCP 4.x: Taint all 3 worker nodes in node_array:
+for i in {1..3}; do
+  echo -e "\nTainting node ${node_array[${i}]} with 'security=s${i}:NoSchedule'"
+  echo "#  oc adm taint nodes ${node_array[${i}]} security=s${i}:NoSchedule"
+  oc adm taint nodes ${node_array[${i}]} security=s${i}:NoSchedule
+done
+
 
 function check_no_error_pods()
 {
@@ -49,22 +59,40 @@ export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
 cd /root/svt/openshift_scalability
 ls -ltr config/golang
 
-echo -e "\nStarting GoLang cluster-loader with config file: config/golang/node-taints-pod-tolerations"
-/usr/libexec/atomic-openshift/extended.test --ginkgo.focus="Load cluster" --viper-config=config/golang/node-taints-pod-tolerations
+#### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
+## - Absolute path to config file needed
+## - .yaml extension is required now in config file name
+## - full path to the config file  must be under 70 characters total
+MY_CONFIG=/root/svt/openshift_scalability/config/golang/taints-tolerations.yaml
+echo -e "\nRunning GoLang cluster-loader from openshift-tests binary with config file: ${MY_CONFIG}"
+echo -e "\nContents of  config file: ${MY_CONFIG}"
+cat ${MY_CONFIG}
+VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"
 
-sleep 30
+sleep 180
 
 check_no_error_pods
 
 oc get pods --all-namespaces -o wide
 
-## TO DO:  check running pod counts  and compare to expected counts (250) in cluster loader yaml file
-oc get pods -n taints-toleration-s1-0 -o wide | grep "hellopods-taints-s1" | grep ${node_array[1]} | grep Running | wc -l
-oc get pods -n taints-toleration-s2-0 -o wide | grep "hellopods-taints-s2" | grep ${node_array[2]} | grep Running | wc -l
+## TO DO:  check running pod counts  and compare to expected counts (130) in cluster loader yaml file
+echo -e "\nAfter deploying pods with cluster-loader, number of Running hellopods-taints-s1 pods on node ${node_array[1]} and in namespace taints-tolerationss1-0 is: "
+oc get pods -n taints-tolerationss1-0 -o wide | grep "hellopods-taints-s1" | grep ${node_array[1]} | grep Running | wc -l
+echo -e "\nAfter deploying pods with cluster-loader, number of Running hellopods-taints-s2 pods on node ${node_array[2]} and in namespace taints-tolerationss2-0 is: "
+oc get pods -n taints-tolerationss2-0 -o wide | grep "hellopods-taints-s2" | grep ${node_array[2]} | grep Running | wc -l
+### For OCP 4.1:  added:  05-16-2019
+echo -e "\nAfter deploying pods with cluster-loader, number of Running hellopods-taints-s1 pods on node ${node_array[3]} and in namespace taints-tolerationss1-0 is: "
+oc get pods -n taints-tolerationss1-0 -o wide | grep "hellopods-taints-s1" | grep ${node_array[3]} | grep Running | wc -l
+echo -e "\nAfter deploying pods with cluster-loader, number of Running hellopods-taints-s2 pods on node ${node_array[3]} and in namespace taints-tolerationss2-0 is: "
+oc get pods -n taints-tolerationss2-0 -o wide | grep "hellopods-taints-s2" | grep ${node_array[3]} | grep Running | wc -l
+
+sleep 10
 
 # delete projects:  cleanup
-oc delete project taints-toleration-s1-0
-oc delete project taints-toleration-s2-0
+oc delete project taints-tolerationss1-0
+oc delete project taints-tolerationss2-0
+
+sleep 30
 
 ######### TO DO:
 ######### wait till all pods with tolerations to the tainted nodes are gone
@@ -72,7 +100,8 @@ oc delete project taints-toleration-s2-0
 ## remove taints previously configured on nodes
 echo -e "\nRemoving the previously configured taints on compute nodes"
 
-for i in {1..2}; do
+## For OCP 4.1: remove taints from all 3 worker nodes:
+for i in {1..3}; do
   echo "Removing previously configured taints on node: ${node_array[${i}]}"
   echo "# oc adm taint nodes ${node_array[${i}]} security- "
   oc adm taint nodes ${node_array[${i}]} security-
@@ -80,5 +109,6 @@ done
 
 # check taints are gone
 oc describe nodes | grep Taints
+
 
 

--- a/openshift_scalability/config/golang/node-affinity.yaml
+++ b/openshift_scalability/config/golang/node-affinity.yaml
@@ -7,26 +7,26 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 240
+        - num: 130
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
-          file: pod-pause-node-affinity.json
+          file: /root/svt/openshift_scalability/content/pod-pause-node-affinity.json
 
     - num: 1
       basename: node-anti-affinity-
       tuning: default
       ifexists: delete
       pods:
-        - num: 240
+        - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: hellopods
-          file: pod-hello-node-anti-affinity.json
+          file: /root/svt/openshift_scalability/content/pod-hello-node-anti-affinity.json
 
   tuningsets:
     - name: default
       pods:
         stepping:
-          stepsize: 40
+          stepsize: 50
           pause: 120
         ratelimit:
           delay: 0

--- a/openshift_scalability/config/golang/taints-tolerations.yaml
+++ b/openshift_scalability/config/golang/taints-tolerations.yaml
@@ -3,30 +3,30 @@ ClusterLoader:
   cleanup: false
   projects:
     - num: 1
-      basename: taints-toleration-s1-
+      basename: taints-tolerationss1-
       tuning: default
       ifexists: delete
       pods:
-        - num: 240
+        - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s1
-          file: pod-hello-s1-taints-tolerations.json
+          file: /root/svt/openshift_scalability/content/pod-hello-s1-taints-tolerations.json
 
     - num: 1
-      basename: taints-toleration-s2-
+      basename: taints-tolerationss2-
       tuning: default
       ifexists: delete
       pods:
-        - num: 240
+        - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s2
-          file: pod-hello-s2-taints-tolerations.json
+          file: /root/svt/openshift_scalability/content/pod-hello-s2-taints-tolerations.json
 
   tuningsets:
     - name: default
       pods:
         stepping:
           stepsize: 50
-          pause: 60
+          pause: 120
         ratelimit:
           delay: 0


### PR DESCRIPTION
Updated scripts for OCP 4.2, in openshift_scalability/ci/scripts to use openshift-tests binary for golang cluster-loader, and updated config file paths:
- run-node-affinity-anti-affinity.sh 
- taint_nodes.sh for OCP 4.2

Renamed golang cluster-loader config files with updated pod numbers and paths to json file templates:
- node-affinity.yaml
- taints-tolerations.yaml