### PR TITLE
Default ocp-logtest image location to quay.io

### DIFF
--- a/openshift_scalability/content/logtest/logtest-pod.json
+++ b/openshift_scalability/content/logtest/logtest-pod.json
@@ -67,7 +67,7 @@
         {
             "name": "LOGTEST_IMAGE",
             "displayName": "logtest image",
-            "value": "docker.io/mffiedler/ocp-logtest:latest"
+            "value": "quay.io/mffiedler/ocp-logtest:latest"
         },
 	{
 	    "name": "INITIAL_FLAGS",

--- a/openshift_scalability/content/logtest/logtest-rc.json
+++ b/openshift_scalability/content/logtest/logtest-rc.json
@@ -78,7 +78,7 @@
         {
             "name": "LOGTEST_IMAGE",
             "displayName": "logtest image",
-            "value": "docker.io/mffiedler/ocp-logtest:latest"
+            "value": "quay.io/mffiedler/ocp-logtest:latest"
         },
 	{
 	    "name": "INITIAL_FLAGS",

--- a/openshift_scalability/content/logtest/logtest-syslog-rc.json
+++ b/openshift_scalability/content/logtest/logtest-syslog-rc.json
@@ -92,7 +92,7 @@
         {
             "name": "LOGTEST_IMAGE",
             "displayName": "logtest image",
-            "value": "docker.io/mffiedler/ocp-logtest:latest"
+            "value": "quay.io/mffiedler/ocp-logtest:latest"
         },
 	{
 	    "name": "INITIAL_FLAGS",

--- a/openshift_scalability/content/logtest/ocp_logtest-README.md
+++ b/openshift_scalability/content/logtest/ocp_logtest-README.md
@@ -16,7 +16,7 @@ An example cluster-loader config that works with ocp_logtest.py is [ocp-logtest.
 
 1. Edit **svt/openshift_scalability/config/ocp-logtest.yaml** if you want to change the parameters for the logtest pods.  The following parameters are supported:
 
-LOGTEST_IMAGE:  logtest image built with the content/logtest Dockerfile, default is **docker.io/mffiedler/ocp-logtest:latest**
+LOGTEST_IMAGE:  logtest image built with the content/logtest Dockerfile, default is **quay.io/mffiedler/ocp-logtest:latest**
 
 INITIAL_FLAGS:  Initial flags to pass to ocp_logtest.py, default is **"--num-lines 0 --line-length 200 --word-length 9 --rate 60 --fixed-line\n"**
 


### PR DESCRIPTION
Change default ocp-logtest image location from docker.io to quay.io.   The user can still override it with an alternate location using the LOGTEST_IMAGE parameter in the application templates.

TODO: move to a more generic QE namespace

/cc: @anpingli @RH-ematysek Comments?