### PR TITLE
Updated openshift_scalability/ci/scripts and openshift_performance/ose3_perf/scripts/scale_test.py to support OPC 4.x and 

### DIFF
--- a/openshift_performance/ose3_perf/scripts/scale_test.py
+++ b/openshift_performance/ose3_perf/scripts/scale_test.py
@@ -17,7 +17,8 @@ def count_pods(namespace,dc) :
     running = 0
     active = 0
     for pod in pod_list:
-        if not pod == "" and not pod=="No resources found.":
+    ##    if not pod == "" and not pod=="No resources found.":
+        if not pod == "" and "No resources found" not in pod:
             active +=1
             if pod.find("Running") > -1 and pod.find("1/1") > -1:
                 running += 1

--- a/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
@@ -3,7 +3,7 @@
 
 date
 uname -a
-openshift version
+oc get clusterversion
 oc version
 oc get node --show-labels
 oc describe node | grep Runtime

--- a/openshift_scalability/ci/scripts/run-pod-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-pod-affinity-anti-affinity.sh
@@ -3,7 +3,7 @@
 
 date
 uname -a
-openshift version
+oc get clusterversion
 oc version
 oc get node --show-labels
 oc describe node | grep Runtime

--- a/openshift_scalability/ci/scripts/taint_nodes.sh
+++ b/openshift_scalability/ci/scripts/taint_nodes.sh
@@ -3,7 +3,7 @@
 
 date
 uname -a
-## openshift version
+oc version
 oc get clusterversion
 oc get clusterversion -o json
 


### PR DESCRIPTION
1.  relaxed match pattern in python script openshift_performance/ose3_perf/scripts/scale_test.py to handle output that can differ across multiple versions of oc client

2. replaces `openshift version` commands with `oc get clusterversion` in scripts:
  a. 	openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
  b.  openshift_scalability/ci/scripts/run-pod-affinity-anti-affinity.sh
  c.  openshift_scalability/ci/scripts/taint_nodes.sh