### PR TITLE
Added --skip-config-write=true to oc new-project command in python cluster-loader utils.py

### DIFF
--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -444,7 +444,7 @@ def single_project(testconfig, projname, globalvars):
                 node_selector = " --node-selector=\"" + testconfig['nodeselector'] + "\""
                 oc_command_with_retry("oc adm new-project " + projname + node_selector,globalvars)
             else:
-                oc_command_with_retry("oc new-project " + projname,globalvars)
+                oc_command_with_retry("oc new-project --skip-config-write=true " + projname,globalvars)
             oc_command_with_retry("oc label --overwrite namespace " + projname +" purpose=test", globalvars)
     else:
         pass


### PR DESCRIPTION
The --skip-config-write=true flag for oc new-project command will speed up bulk project creation.