### PR TITLE
Increased loop counter for 100 to 150 waiting for pods to terminate a…

### DIFF
--- a/openshift_performance/ci/content/scale_up_complete.yaml
+++ b/openshift_performance/ci/content/scale_up_complete.yaml
@@ -49,7 +49,7 @@
          -p "{{ login_passwd }}" 
          -n cakephp-mysql0 
          -d cakephp-mysql-example 
-         -r 20
+         -r 100
          -s 20 
          -w 10 
          -z

--- a/openshift_performance/ose3_perf/scripts/scale_test.py
+++ b/openshift_performance/ose3_perf/scripts/scale_test.py
@@ -32,7 +32,7 @@ def scale_down(namespace,dc):
     if active > 0 :
         run("oc scale --replicas=0 -n " + namespace + " dc/" + dc)
         retries = 0
-        while active > 0 and retries < 100:
+        while active > 0 and retries < 150:
             time.sleep(3)
             running,active = count_pods(namespace, dc)
             if active > 0:


### PR DESCRIPTION
Updated two scripts:
- svt/openshift_performance/ose3_perf/scripts/scale_test.py:
   increased iteration counter from 100 to 150 to allow waiting longer for pods to terminate after scale down
- svt/openshift_performance/content/scaleup_complete.yaml:
  increased number of replicas for cakephp-mysql-example app from 20 to 100