### PR TITLE
Update imagestreamtags in SVT quickstart templates for OCP 4.4

### DIFF
--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-build.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-build.json
@@ -117,11 +117,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (7.1 or latest).",
+            "description": "Version of PHP image to be used (7.2 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.1"
+            "value": "7.2"
         },
         {
             "description": "The URL of the repository with your application source code.",

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
@@ -478,11 +478,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (7.1 or latest).",
+            "description": "Version of PHP image to be used (7.2 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.1"
+            "value": "7.2"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
@@ -456,11 +456,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (7.1 or latest).",
+            "description": "Version of PHP image to be used (7.2 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.1"
+            "value": "7.2"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
@@ -724,7 +724,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "mysql:latest"
+                                "name": "mysql:5.7"
                             }
                         }
                     },

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-deploy.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-deploy.json
@@ -198,7 +198,7 @@
 			    "from": {
 				"kind": "ImageStreamTag",
 				"namespace": "openshift",
-				"name": "mongodb:2.6"
+				"name": "mongodb:3.6"
 			    }
 			}
 		    },

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv-deploy.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv-deploy.json
@@ -218,7 +218,7 @@
 			    "from": {
 				"kind": "ImageStreamTag",
 				"namespace": "openshift",
-				"name": "mongodb:2.6"
+				"name": "mongodb:3.6"
 			    }
 			}
 		    },

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb-pv.json
@@ -283,7 +283,7 @@
 			    "from": {
 				"kind": "ImageStreamTag",
 				"namespace": "openshift",
-				"name": "mongodb:2.6"
+				"name": "mongodb:3.6"
 			    }
 			}
 		    },

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb.json
@@ -263,7 +263,7 @@
 			    "from": {
 				"kind": "ImageStreamTag",
 				"namespace": "openshift",
-				"name": "mongodb:2.6"
+				"name": "mongodb:3.6"
 			    }
 			}
 		    },


### PR DESCRIPTION
Update image streams to valid versions for OCP 4.4

Note:  eap64 app cannot use MySQL v8, it needs v5.   We should look at removing eap64 during 4.4.  There are a lot of references to it in scripts and cluster-loader configs, so they will require test/update.

@wabouhamad PTAL.  I've tested them all, mainly looking for a sanity check.