### PR TITLE
Update node tuning operator test scripts to work with OCP 4.4

### DIFF
--- a/openshift_tooling/node_tuning_operator/content/tuned-nf-conntrack-max.yml
+++ b/openshift_tooling/node_tuning_operator/content/tuned-nf-conntrack-max.yml
@@ -1,0 +1,23 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: nf-conntrack-max
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Test if user can apply custom tuning: sysctl net.netfilter.nf_conntrack_max
+      include=openshift-node
+
+      [sysctl]
+      net.netfilter.nf_conntrack_max=1048578
+
+    name: nf-conntrack-max
+
+  recommend:
+  - match:
+    - label: tuned.openshift.io/elasticsearch
+      type: pod
+    priority: 15
+    profile: nf-conntrack-max

--- a/openshift_tooling/node_tuning_operator/nto_test_daemon_mode_label_pod.py
+++ b/openshift_tooling/node_tuning_operator/nto_test_daemon_mode_label_pod.py
@@ -5,6 +5,10 @@ from utils import *
 ###########################################
 # Test: Node Tuning Operator: Daemon node #
 ###########################################
+# Changes:                                #
+#   skordas:                              #
+#   Removing wait time after label pod    #
+###########################################
 
 expected_max_map_count = 262144
 
@@ -36,7 +40,6 @@ def test():
     for pod in pods:
         print_step("Labeling pod: {}".format(pod))
         execute_command("oc label pod {} tuned.openshift.io/elasticsearch=".format(pod))
-        countdown(15)
         print_step("Verifying vm.max_map_count value on all nodes")
         max_map_count = []
         for node in nodes:
@@ -50,7 +53,6 @@ def test():
 
         print_step("Removing label from pod: {}".format(pod))
         execute_command("oc label pod {} tuned.openshift.io/elasticsearch-".format(pod))
-        countdown(15)
         print_step("Verifying vm.max_map_count value on all nodes")
         max_map_count = []
         for node in nodes:

--- a/openshift_tooling/node_tuning_operator/nto_test_daemon_mode_remove_pod.py
+++ b/openshift_tooling/node_tuning_operator/nto_test_daemon_mode_remove_pod.py
@@ -5,6 +5,10 @@ from utils import *
 ###########################################
 # Test: Node Tuning Operator: Daemon node #
 ###########################################
+# Changes:                                #
+#   skordas:                              #
+#   Removing wait time after label pod    #
+###########################################
 
 expected_max_map_count = 262144
 
@@ -36,7 +40,6 @@ def test():
     for pod in pods:
         print_step("Labeling pod: {}".format(pod))
         execute_command("oc label pod {} tuned.openshift.io/elasticsearch=".format(pod))
-        countdown(15)
         print_step("Verifying vm.max_map_count value on all nodes")
         max_map_count = []
         for node in nodes:
@@ -50,7 +53,6 @@ def test():
 
         print_step("Removing pod: {}".format(pod))
         execute_command("oc delete pod {}".format(pod))
-        countdown(15)
         print_step("Verifying vm.max_map_count value on all nodes")
         max_map_count = []
         for node in nodes:


### PR DESCRIPTION
Because NTO was rewritten to work in better way I needed to update test scripts for correct verification.
There is no change how to run scripts. 