### PR TITLE
Add templates with Deployments to replace DeploymentConfigs

### DIFF
--- a/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
+++ b/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
@@ -5,7 +5,7 @@ projects:
     templates:
       - 
         num: 2000 
-        file: ./content/deployment-config-cluster-limits-deployments.json
+        file: ./content/deployment-cluster-limits-deployments.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/cluster-limits-namespaces.yaml
+++ b/openshift_scalability/config/cluster-limits-namespaces.yaml
@@ -7,7 +7,7 @@ projects:
         file: ./content/image-stream-template.json
       - 
         num: 1   
-        file: ./content/deployment-config-ns-per-cluster-template.json
+        file: ./content/deployment-ns-per-cluster-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/golang/cluster-limits-deployments-per-namespace.yaml
+++ b/openshift_scalability/config/golang/cluster-limits-deployments-per-namespace.yaml
@@ -7,7 +7,7 @@ ClusterLoader:
       templates:
         -
           num: 2000
-          file: ./deployment-config-cluster-limits-deployments.json
+          file: ./deployment-cluster-limits-deployments.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/golang/cluster-limits-namespaces.yaml
+++ b/openshift_scalability/config/golang/cluster-limits-namespaces.yaml
@@ -12,7 +12,7 @@ ClusterLoader:
 
         -
           num: 1
-          file: ./deployment-config-ns-per-cluster-template.json
+          file: ./deployment-ns-per-cluster-template.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/golang/pyconfigMasterVertScale.yaml
+++ b/openshift_scalability/config/golang/pyconfigMasterVertScale.yaml
@@ -17,13 +17,13 @@ ClusterLoader:
           file: ./image-stream-template.json
         - 
           num: 2   
-          file: ./deployment-config-1rep-template.json
+          file: ./deployment-1rep-template.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
         -
           num: 1
-          file: ./deployment-config-2rep-template.json
+          file: ./deployment-2rep-template.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/golang/pyconfigMasterVertScalePause.yaml
+++ b/openshift_scalability/config/golang/pyconfigMasterVertScalePause.yaml
@@ -17,13 +17,13 @@ ClusterLoader:
           file: ./image-stream-template.json
         - 
           num: 2   
-          file: ./deployment-config-1rep-pause-template.json
+          file: ./deployment-1rep-pause-template.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
         -
           num: 1
-          file: ./deployment-config-2rep-pause-template.json
+          file: ./deployment-2rep-pause-template.json
           parameters:
             -
               ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/pyconfigMasterVertScale.yaml
+++ b/openshift_scalability/config/pyconfigMasterVertScale.yaml
@@ -13,13 +13,13 @@ projects:
         file: ./content/image-stream-template.json
       - 
         num: 2   
-        file: ./content/deployment-config-1rep-template.json
+        file: ./content/deployment-1rep-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
       -
         num: 1
-        file: ./content/deployment-config-2rep-template.json
+        file: ./content/deployment-2rep-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/config/pyconfigMasterVertScalePause.yaml
+++ b/openshift_scalability/config/pyconfigMasterVertScalePause.yaml
@@ -14,13 +14,13 @@ projects:
         file: ./content/image-stream-template.json
       -
         num: 2
-        file: ./content/deployment-config-1rep-pause-template.json
+        file: ./content/deployment-1rep-pause-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
       -
         num: 1
-        file: ./content/deployment-config-2rep-pause-template.json
+        file: ./content/deployment-2rep-pause-template.json
         parameters:
           -
             ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"

--- a/openshift_scalability/content/deployment-0rep-pause-template.json
+++ b/openshift_scalability/content/deployment-0rep-pause-template.json
@@ -1,0 +1,135 @@
+{
+  "kind": "Template",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment0v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller0v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause0v${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 0,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller0v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service0v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller0v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport0v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+}

--- a/openshift_scalability/content/deployment-0rep-template.json
+++ b/openshift_scalability/content/deployment-0rep-template.json
@@ -1,0 +1,137 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment0v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller0v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "helloworld0v${IDENTIFIER}",
+                "image": "openshift/${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_0v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 0,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller0v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service0v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller0v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport0v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "hello-openshift",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+
+}
+

--- a/openshift_scalability/content/deployment-1rep-pause-template.json
+++ b/openshift_scalability/content/deployment-1rep-pause-template.json
@@ -1,0 +1,135 @@
+{
+  "kind": "Template",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment1v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller1v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause1v${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller1v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service1v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller1v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport1v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+}

--- a/openshift_scalability/content/deployment-1rep-template.json
+++ b/openshift_scalability/content/deployment-1rep-template.json
@@ -1,0 +1,137 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment1v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller1v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "helloworld1v${IDENTIFIER}",
+                "image": "openshift/${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_1v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller1v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service1v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller1v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport1v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "hello-openshift",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+
+}
+

--- a/openshift_scalability/content/deployment-2rep-pause-template.json
+++ b/openshift_scalability/content/deployment-2rep-pause-template.json
@@ -1,0 +1,135 @@
+{
+  "kind": "Template",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+    {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment2v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller2v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause2v${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 2,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller2v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service2v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller2v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport2v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+}

--- a/openshift_scalability/content/deployment-2rep-template.json
+++ b/openshift_scalability/content/deployment-2rep-template.json
@@ -1,0 +1,137 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment2v${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller2v${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "helloworld2v${IDENTIFIER}",
+                "image": "openshift2v/${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_2v${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 2,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller2v${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service2v${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller2v${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport2v${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "hello-openshift",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+
+}
+

--- a/openshift_scalability/content/deployment-cluster-limits-deployments.json
+++ b/openshift_scalability/content/deployment-cluster-limits-deployments.json
@@ -1,0 +1,111 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment with 1 replica and 4 env vars",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 1,
+        "selector": {
+           "matchLabels": {
+             "name": "replicationcontroller${IDENTIFIER}"
+           }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+
+}
+

--- a/openshift_scalability/content/deployment-ns-per-cluster-template.json
+++ b/openshift_scalability/content/deployment-ns-per-cluster-template.json
@@ -1,0 +1,137 @@
+{
+  "Kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "deploymentTemplate",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This template will create a deployment with 6 replica, 4 env vars, and a service.",
+      "tags": ""
+    }
+  },
+  "objects": [
+      {
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "deployment${IDENTIFIER}"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "replicationcontroller${IDENTIFIER}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "pause${IDENTIFIER}",
+                "image": "${IMAGE}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ENVVAR1_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR2_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR3_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  },
+                  {
+                    "name": "ENVVAR4_${IDENTIFIER}",
+                    "value": "${ENV_VALUE}"
+                  }
+                ],
+                "resources": {},
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccount": ""
+          }
+        },
+        "replicas": 6,
+        "selector": {
+          "matchLabels": {
+             "name": "replicationcontroller${IDENTIFIER}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "strategy": {
+          "type": "RollingUpdate"
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "service${IDENTIFIER}"
+      },
+      "spec": {
+        "selector": {
+          "name": "replicationcontroller${IDENTIFIER}"
+        },
+        "ports": [
+          {
+            "name": "serviceport${IDENTIFIER}",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 8080
+          }
+        ],
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "IDENTIFIER",
+      "description": "Number to append to the name of resources",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "IMAGE",
+      "description": "Image to use for deployment",
+      "value": "gcr.io/google-containers/pause-amd64:3.0",
+      "required": false
+    },
+    {
+      "name": "ENV_VALUE",
+      "description": "Value to use for environment variables",
+      "generate": "expression",
+      "from": "[A-Za-z0-9]{255}",
+      "required": false
+    }
+  ],
+  "labels": {
+    "template": "deploymentTemplate"
+  }
+
+}
+


### PR DESCRIPTION
DeploymentConfigs are an older OCP-only resource type and require more processing for OCP to create them since they involve the creation of a deployment pod.   Deployments are the preferred application type now and can be instantiated without a deployer pod having to spin up.

1. Add deployment templates equivalent to our previous deployconfig templates
2. Update the master vert configs (python and golang) to use the new deployment templates

@chaitanyaenr I did not create a corresponding deployment-config-cluster-limits-deployments.json template which is in use by the cluster limits configurations.   I wasn't sure of the implications, but I can do it if needed - just let me know.

@wabouhamad @chaitanyaenr  PTAL