### PR TITLE
Avoid scheduling objects on infra nodes

### DIFF
--- a/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
+++ b/openshift_scalability/config/cluster-limits-deployments-per-namespace.yaml
@@ -2,6 +2,7 @@ projects:
   - num: 1
     basename: cluster
     ifexists: delete
+    nodeselector: "node-role.kubernetes.io/worker="
     templates:
       - 
         num: 2000 

--- a/openshift_scalability/config/cluster-limits-namespaces.yaml
+++ b/openshift_scalability/config/cluster-limits-namespaces.yaml
@@ -1,6 +1,7 @@
 projects:
   - num: 1000
     basename: c
+    nodeselector: "node-role.kubernetes.io/worker="
     templates:
       -
         num: 1

--- a/openshift_scalability/config/cluster-limits-pods-per-namespace.yaml
+++ b/openshift_scalability/config/cluster-limits-pods-per-namespace.yaml
@@ -1,6 +1,7 @@
 projects:
   - num: 1
     basename: clusterproject
+    nodeselector: "node-role.kubernetes.io/worker="
     tuning: default
     pods:
       - total: 15000


### PR DESCRIPTION
The infra nodes run critical components including prometheus, logging,
router and registry. This commit will make sure the application pods
land on worker nodes instead of infra.