### PR TITLE
Update taint/toleration test for 4.x

### DIFF
--- a/openshift_scalability/config/golang/taints-tolerations.yaml
+++ b/openshift_scalability/config/golang/taints-tolerations.yaml
@@ -4,29 +4,39 @@ ClusterLoader:
   projects:
     - num: 1
       basename: taints-tolerationss1-
-      tuning: default
       ifexists: delete
+      tuning: default
       pods:
-        - num: 130
+        - num: 200
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s1
-          file: /root/svt/openshift_scalability/content/pod-hello-s1-taints-tolerations.json
+          file: ./content/pod-hello-s1-taints-tolerations.json
 
     - num: 1
       basename: taints-tolerationss2-
-      tuning: default
       ifexists: delete
+      tuning: default
       pods:
-        - num: 130
+        - num: 200
           image: docker.io/ocpqe/hello-pod
           basename: hellopods-taints-s2
-          file: /root/svt/openshift_scalability/content/pod-hello-s2-taints-tolerations.json
+          file: ./content/pod-hello-s2-taints-tolerations.json
+    
+    - num: 1
+      basename: taints-tolerationss3-
+      ifexists: delete
+      tuning: default
+      pods:
+        - num: 200
+          image: docker.io/ocpqe/hello-pod
+          basename: hellopods-taints-s3
+          file: ./content/pod-hello-s3-taints-tolerations.json
 
   tuningsets:
     - name: default
       pods:
         stepping:
           stepsize: 50
-          pause: 120
+          pause: 15
         ratelimit:
           delay: 0

--- a/openshift_scalability/content/pod-hello-s3-taints-tolerations.json
+++ b/openshift_scalability/content/pod-hello-s3-taints-tolerations.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-taints-s3",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "taints-tolerations-s3"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-pod",
+        "image": "docker.io/ocpqe/hello-pod",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+				"requests": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu" : "15m",
+					"memory": "50Mi"
+				}
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": "",
+
+    "tolerations": [
+        {
+            "effect": "NoSchedule",
+            "key": "security",
+            "operator": "Equal",
+            "value": "s3"
+        }
+      ]
+  },
+
+  "status": {}
+}


### PR DESCRIPTION
Update for 3 m5.2xlarge worker nodes and 3 masters (test case in Polarion updated to match 4.x).

@wabouhamad PTAL .   Was there any reason to use absolute paths (/root/svt....) in the config file vs. relative paths?   It seems the calling wrapper (shell script, ansible, etc) could set the working directory and use relative paths.   Let me know if that causes problems.