### PR TITLE
Update node affinity test for 4.x

### DIFF
--- a/openshift_scalability/config/golang/node-affinity.yaml
+++ b/openshift_scalability/config/golang/node-affinity.yaml
@@ -7,10 +7,10 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 130
+        - num: 200
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
-          file: /root/svt/openshift_scalability/content/pod-pause-node-affinity.json
+          file: ./content/pod-pause-node-affinity.json
 
     - num: 1
       basename: node-anti-affinity-
@@ -20,14 +20,14 @@ ClusterLoader:
         - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: hellopods
-          file: /root/svt/openshift_scalability/content/pod-hello-node-anti-affinity.json
+          file: ./content/pod-hello-node-anti-affinity.json
 
   tuningsets:
     - name: default
       pods:
         stepping:
           stepsize: 50
-          pause: 120
+          pause: 30
         ratelimit:
           delay: 0
 

--- a/openshift_scalability/content/pod-hello-node-anti-affinity.json
+++ b/openshift_scalability/content/pod-hello-node-anti-affinity.json
@@ -48,10 +48,10 @@
              {
               "matchExpressions": [
                 {
-                  "key": "beta.kubernetes.io/arch",
+                  "key": "placement",
                   "operator": "NotIn",
                   "values": [
-                     "amd64"
+                     "affinity"
                   ]
                 }
                ]


### PR DESCRIPTION
- Instead of architecture (not modifiable in 4.x), use placement=affinity or placement=antiaffinity (test case updated in polarion)
- re-size the test for m5.2xlarge
- relative path to content files 

@wabouhamad PTAL 