### PR TITLE
Pod density automation script

### DIFF
--- a/openshift_scalability/cluster_loader_requirements.txt
+++ b/openshift_scalability/cluster_loader_requirements.txt
@@ -1,0 +1,5 @@
+boto3
+flask
+pyyaml
+subprocess.run
+logging

--- a/openshift_scalability/content/pause_template.yaml
+++ b/openshift_scalability/content/pause_template.yaml
@@ -1,0 +1,6 @@
+projects:
+- basename: svt-
+  num: 2000
+  templates:
+  - file: ../../content/deployment-config-1rep-pause-template.json
+    num: 1

--- a/openshift_scalability/scripts/pod_density/README.md
+++ b/openshift_scalability/scripts/pod_density/README.md
@@ -1,0 +1,44 @@
+## pod_density README
+
+### Purpose 
+The pod_density.sh scripts is a tool to test the density of deployments on pods in OpenShift. 
+
+
+### Install [pytimeparse](https://github.com/wroberts/pytimeparse) module
+
+```sh
+$ pip install -r ../../cluster_loader_requirements.txt
+```
+
+### Setup
+
+**Projects and applicatons:**  It is recommended that [cluster-loader](https://github.com/openshift/svt/blob/master/openshift_scalability/README.md) be used to create projects, deployments, build configurations, etc.   **pod_density** is a complimentary tool that can run the pod creation by **cluster_loader**.
+
+An example cluster-loader config that works with build_test.py is [master-vert.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/master-vert-pv.yaml)
+
+This will create namespaces as below.  These projects will be specified in the build_test json config.
+
+```
+# oc get ns
+NAME                 STATUS    AGE
+svt-0                Active    2h
+svt-1                Active    2h
+svt-2                Active    2h
+...
+```
+
+### Usage 
+
+```./pod_density.sh <yamlFile>```
+
+Ex.) ```./pod_density.sh ../../content/pause_template.yaml```
+
+Optional Options:
+
+```-s or --scale_num``` The number of worker nodes that you want. The default is 20
+ 
+```-cp or --cluster_processes``` Number of parallel process you want the cluster loader to run with, default is 5
+
+```-p or --projects``` Number of projects you want to create, this will overwrite the yaml file you give as the first argument, default is 2000
+
+

--- a/openshift_scalability/scripts/pod_density/increase_pods.py
+++ b/openshift_scalability/scripts/pod_density/increase_pods.py
@@ -1,0 +1,40 @@
+import subprocess
+import yaml
+
+
+def run(command):
+    try:
+        output = subprocess.Popen(command, shell=True,
+                                  universal_newlines=True, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+        (out, err) = output.communicate()
+        print("Out " + str(out))
+    except Exception as e:
+        print("Failed to run %s, error: %s" % (command, e))
+    return out
+
+
+def print_new_yaml(num, fileName):
+    # append to file
+    with open(fileName, "r") as f:
+        yaml_file = yaml.load(f, Loader=yaml.FullLoader)
+        print("yaml file " + str(yaml_file))
+        yaml_file['projects'][0]['num'] = num
+        print("new yaml file " + str(yaml_file))
+    with open(fileName, "w+") as f:
+        str_file = yaml.dump(yaml_file)
+        print('type ' + str(type(str_file)))
+        f.write(str_file)
+
+
+def print_new_yaml_temp(num, fileName):
+    # append to file
+    with open(fileName, "r") as f:
+        yaml_file = yaml.load(f, Loader=yaml.FullLoader)
+        print("yaml file " + str(yaml_file))
+        yaml_file['projects'][0]['templates'][0]['num'] = num
+        print("new yaml file " + str(yaml_file))
+    with open(fileName, "w+") as f:
+        str_file = yaml.dump(yaml_file)
+        print('type ' + str(type(str_file)))
+        f.write(str_file)

--- a/openshift_scalability/scripts/pod_density/pod_density.out
+++ b/openshift_scalability/scripts/pod_density/pod_density.out
@@ -1,0 +1,1 @@
+Starting pod density 

--- a/openshift_scalability/scripts/pod_density/pod_density.sh
+++ b/openshift_scalability/scripts/pod_density/pod_density.sh
@@ -1,0 +1,139 @@
+#/!/bin/bash
+################################################
+## Auth=prubenda@redhat.com
+## Desription: Script for running pod density of different number of projects
+################################################
+
+outputfile=pod_density.out
+process_num=5
+scale_num=20
+project_num=2000
+
+if [ "$#" -lt 1 ]; then
+  echo "syntax: $0 <deployment_file_name>"
+  exit 1
+fi
+loader_file=$1
+
+#optional parameters
+while [[ $# -gt 1 ]]
+do
+key="$1"
+echo "key $key"
+
+case $key in
+    -s|--scale_num)
+    scale_num=$2
+    echo "scale $scale_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -cp|--cluster_processes)
+    process_num=$2
+    echo "process_num $process_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -p|--projects)
+    project_num=$2
+    shift
+    shift
+    ;;
+    *)    # unknown option
+    #need to get past file
+    shift # past arg
+    ;;
+esac
+done
+
+function delete_projects() {
+  echo "deleting projects"
+  oc delete project -l purpose=test --wait=false
+}
+
+function create_projects() {
+  echo "create projects variable $1: $2"
+  python ../../cluster-loader.py -f $1 -p $2
+}
+
+function see_if_error() {
+  echo "see if errors $1"
+  echo "import pod_density_helper; pod_density_helper.check_error($1)"
+  python -c "import pod_density_helper; pod_density_helper.check_error('$1')"
+}
+
+function scale_up() {
+  echo "scale up"
+  python -c "import pod_density_helper; pod_density_helper.edit_machine_sets($1)"
+}
+
+function wait_for_pod_creation() {
+  COUNTER=0
+  creating=$(oc get pods --all-namespaces | grep svt | grep "1-deploy" | grep -v -c Completed)
+  while [ $creating -ne 0 ]; do
+    sleep 5
+    creating=$(oc get pods --all-namespaces | grep svt | grep "1-deploy" | grep -v -c Completed)
+    echo "$creating pods are still not completed"
+    COUNTER=$((COUNTER + 1))
+    if [ $COUNTER -ge 60 ]; then
+      echo "$creating pods are still not complete after 5 minutes"
+      break
+    fi
+  done
+}
+
+function pods_per_node() {
+  echo "get pods per node"
+  python -c 'import pod_density_helper; pod_density_helper.get_pods_per_node()'
+}
+
+function rewrite_yaml() {
+  python -c "import increase_pods; increase_pods.print_new_yaml($project_num,'$loader_file')"
+}
+
+function wait_for_project_termination() {
+  COUNTER=0
+  terminating=$(oc get projects | grep svt | grep Terminating | wc -l)
+  while [ $terminating -ne 0 ]; do
+    sleep 15
+    terminating=$(oc get projects | grep svt | grep Terminating | wc -l)
+    echo "$terminating projects are still terminating"
+    COUNTER=$((COUNTER + 1))
+    if [ $COUNTER -ge 20 ]; then
+      echo "$terminating projects are still terminating after 5 minutes"
+      exit 1
+    fi
+  done
+  svt_proj=$(oc get projects | grep svt | wc -l)
+  if [ $svt_proj -ne 0 ]; then
+    echo "$svt_proj svt projects are still there"
+    exit 1
+  fi
+  pods=$(oc get pods -A | grep svt | wc -l)
+  if [ $pods -ne 0 ]; then
+    echo "$pods svt pods are still there"
+    exit 1
+  fi
+
+}
+
+function set_default_project() {
+  oc project default
+}
+
+rm -rf $outputfile
+echo "Starting pod density $now" >>$outputfile
+scale_up $scale_num
+set_default_project
+delete_projects
+wait_for_project_termination
+rewrite_yaml
+SECONDS=0
+create_projects "$loader_file" "$process_num"
+wait_for_pod_creation
+duration=$SECONDS
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed." >>$outputfile
+see_if_error $outputfile
+pods_per_node
+echo "Finished pod density" >>$outputfile
+cat $outputfile

--- a/openshift_scalability/scripts/pod_density/pod_density_helper.py
+++ b/openshift_scalability/scripts/pod_density/pod_density_helper.py
@@ -1,0 +1,131 @@
+import subprocess
+from optparse import OptionParser
+import re
+import time
+
+
+def run(command):
+    try:
+        output = subprocess.Popen(command, shell=True,
+                                  universal_newlines=True, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+        (out, err) = output.communicate()
+    except Exception as e:
+        print("Failed to run %s, error: %s" % (command, e))
+    return out
+
+
+def edit_machine_sets(worker_node_num):
+
+    worker_num = run('oc get nodes | grep worker -c')
+
+    int_worker_num = int(worker_num)
+    print ("worker num types " + str((worker_node_num)) + "|" + str((int_worker_num)))
+    if int_worker_num != worker_node_num:
+        #get machine sets
+        machine_sets = run("oc get machinesets -A").strip()
+        #skip title
+        rand_machine_sets = machine_sets.split('\n')
+        # get number of difference
+        current_machines = -1
+        for machine in rand_machine_sets:
+            if current_machines < 0:
+                current_machines = 0
+                continue
+            machine_info = re.split(r'\s{2,}', machine)
+            last_machine_set_count = int(machine_info[3])
+            current_machines += last_machine_set_count
+            machine_set_name = machine_info[1]
+
+        print('machine set info ' + str(machine_set_name))
+        wanted_replicas = worker_node_num - current_machines + last_machine_set_count
+
+        #get current numbers
+        #add current replcias to wanted num
+        print('wanted replicas ' + str(wanted_replicas))
+        # get current replicas
+        replica_cmd = "oc scale --replicas=" + str(wanted_replicas) + " machineset " + machine_set_name +" -n openshift-machine-api"
+        print('replic cmd ' + str(replica_cmd))
+        run(replica_cmd)
+
+        counter = 0
+        while worker_node_num != int_worker_num:
+            worker_num = run('oc get nodes | grep worker -c')
+            int_worker_num = int(worker_num)
+            time.sleep(30)
+            print("waiting 10 seconds for nodes to come up" + str(worker_node_num) + str(int_worker_num))
+            counter += 1
+            if counter >= 60:
+                break
+
+
+def get_pods_per_node():
+
+    worker_node = run('oc get nodes | grep worker').strip()
+    worker_node_list = worker_node.split("\n")
+    for node in worker_node_list:
+        node_name = re.split(r'\s{2,}', node)[0]
+        pods_in_node = run('oc get pods --all-namespaces -o wide | grep ' + str(node_name) + ' | grep svt -c').strip()
+        print("There are " + str(pods_in_node) + " running in node " + str(node_name))
+
+
+def see_if_error(output_file):
+    print('here')
+    errorpods=run('oc get pods --all-namespaces | grep svt | egrep -v "Running|Complete|Creating|Pending"')
+    with open(output_file, "a") as f:
+        f.write(str(errorpods))
+    print ("errorpods" + str(errorpods) + str(type(errorpods)))
+    COUNTER=0
+    error_pods_list = errorpods.split("\n")
+    pods = []
+
+    for val in error_pods_list:
+        COUNTER = 0
+        error_pods = []
+        line = re.split(r'\s{2,}', val)
+        for word in line:
+            if ((COUNTER % 6 ) == 0 ):
+                error_pods.append(word)
+            elif ((COUNTER % 6 ) == 1):
+
+                error_pods.append(word)
+                pods.append(error_pods)
+            else:
+                break
+
+            COUNTER += 1
+
+    return pods
+
+
+def get_error_logs(pod_item, output_file):
+    namespace = pod_item[0]
+    name = pod_item[1]
+    #append to file
+    with open(output_file, "a") as f:
+        f.write("Debugging info for " + name + " in namespace "+ namespace + '\n')
+        #logs = run("oc describe pod/" + str(name) + " -n " + namespace)
+        #f.write("Describe pod " + str(logs) + '\n')
+        logs = run("oc logs " + str(name) + " -n " + namespace)
+        f.write("Logs " + str(logs) + '\n')
+        #replicationcontroller=run("oc get replicationcontrollers -n " + namespace)
+        #f.write("replication controller output " + str(replicationcontroller) + "\n\n\n")
+        #describe_deploy = run("oc describe replicationcontrollers " + replicationcontroller + " -n " + str(namespace))
+        #f.write("describe_deploy" + str(describe_deploy))
+
+
+def check_error(global_output_file):
+    pods_list = see_if_error(global_output_file)
+    skip_first = True
+    for pod_item in pods_list:
+        if skip_first:
+            skip_first = False
+        else:
+            get_error_logs(pod_item, global_output_file)
+
+def terminating_pods():
+
+    while True:
+        pods = run("oc get pods -A | grep svt | grep Terminating")
+        print("pods " + str(pods))
+        time.sleep(30)

--- a/openshift_scalability/scripts/pod_density/pod_density_increase-README.md
+++ b/openshift_scalability/scripts/pod_density/pod_density_increase-README.md
@@ -1,0 +1,57 @@
+## pod_density_increase README
+
+### Purpose 
+The pod_density_increase.sh scripts is a tool to test the density of deployments on pods in OpenShift. This uses an underlying script (pod_density.sh). 
+This specific script is used to test a slower increase in the number of pods 
+
+This script stops if it encounters any error pods between each iteration of the run
+
+For this script you set a base number of pods you want to create, an increment (how many new pods you want to create each time) and the max number of pods you want to create in your run
+
+
+
+### Install [pytimeparse](https://github.com/wroberts/pytimeparse) module
+
+```sh
+$ pip install -r ../../cluster_loader_requirements.txt
+```
+
+### Setup
+
+**Projects and applicatons:**  It is recommended that [cluster-loader](https://github.com/openshift/svt/blob/master/openshift_scalability/README.md) be used to create projects, deployments, build configurations, etc.   **pod_density** is a complimentary tool that can run the pod creation by **cluster_loader**.
+
+An example cluster-loader config that works with build_test.py is [master-vert.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/master-vert-pv.yaml)
+
+This will create namespaces as below.  These projects will be specified in the build_test json config.
+
+```
+# oc get ns
+NAME                 STATUS    AGE
+svt-0                Active    2h
+svt-1                Active    2h
+svt-2                Active    2h
+...
+```
+
+### Usage 
+
+```./pod_density.sh <yamlFile>```
+
+Ex.) ```./pod_density.sh ../../content/pause_template.yaml```
+
+
+Optional Options:
+
+```-s or --start_num``` The number of pods/projects you want to start your pod density test at. Default is 200
+
+```-i or --increase_counter``` Number of new pods/projects you want to increase by in each iteration. Default is 20
+
+```-m or --max_pods``` The max amount of pods/projects you want to create. Default is 2000
+
+Pod Density Options: 
+```-sc or --scale_num``` The number of worker nodes that you want. The default is 20
+ 
+```-cp or --cluster_processes``` Number of parallel process you want the cluster loader to run with, default is 5
+
+```-p or --projects``` Number of projects you want to create, this will overwrite the yaml file you give as the first argument, default is 2000
+

--- a/openshift_scalability/scripts/pod_density/pod_density_increase.sh
+++ b/openshift_scalability/scripts/pod_density/pod_density_increase.sh
@@ -1,0 +1,105 @@
+#/!/bin/bash
+################################################
+## Auth=prubenda@redhat.com
+## Desription: Script for running pod density of different number of projects
+################################################
+
+outputfile=pod_density.out
+proj_yaml="test.yaml"
+
+function deployments_running(){
+  oc get pods -A | grep svt | egrep -v 1-deploy
+}
+
+
+function deployments_running(){
+  running_deploys=$(oc get pods -A | grep svt | grep 1-deploy | grep Running | wc -l)
+  while [ $running_deploys -ne 0 ]; do
+    sleep 5
+    running_deploys=$(oc get pods -A | grep svt | grep 1-deploy | grep Running | wc -l)
+    echo "Some deploy pods are still running"
+  done
+
+}
+
+function create_projects() {
+
+  COUNTER=$1
+  while [ $COUNTER -le $3 ]; do
+    python -c "import increase_pods; increase_pods.print_new_yaml($COUNTER,'$proj_yaml')"
+    echo "running project count $COUNTER"
+    ./pod_density.sh $proj_yaml -s $scale_num -cp $cluster_processes -p $project_num
+    deployments_running
+    error=$(oc get pods --all-namespaces | grep svt | grep Error | wc -l)
+    echo "error pods $error"
+    sleep 10
+    COUNTER=$((COUNTER + $2))
+    if [ $error -ne 0 ]; then
+      echo error
+      break
+    fi
+  done
+}
+
+max_num=2000
+start_num=200
+increase_counter=20
+process_num=5
+scale_num=20
+project_num=2000
+#optional parameters
+while [[ $# -gt 1 ]]
+do
+key="$1"
+echo "key $key"
+
+case $key in
+    -s|--start_num)
+    start_num=$2
+    echo "start $start_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -i|--increase_counter)
+    increase_counter=$2
+    echo "increase_counter $increase_counter"
+    shift # past argument
+    shift # past value
+    ;;
+    -m|--max_pods)
+    max_num=$2
+    echo "max_num $max_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -f|--file_name)
+    proj_yaml=$2
+    shift
+    shift
+    ;;
+    -sc|--scale_num)
+    scale_num=$2
+    echo "scale $scale_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -cp|--cluster_processes)
+    process_num=$2
+    echo "process_num $process_num"
+    shift # past argument
+    shift # past value
+    ;;
+    -p|--projects)
+    project_num=$2
+    shift
+    shift
+    ;;
+    *)    # unknown option
+    #need to get past file
+    shift # past arg
+    ;;
+esac
+done
+
+echo "params $start_num $increase_counter $max_num"
+create_projects $start_num $increase_counter $max_num


### PR DESCRIPTION
This PR will add in 2 different automation scripts for the pod_density test case. The first is a typical pod_density test run that will scale the cluster up to 20 worker nodes and uses cluster loader to load the content/pause_template.yaml template file. 
At the end of cluster loader finishing it checks to see if any pods have errors and spits out how many pods were put on each node (not sure if this is necessary)

The second script does more of a gradual increase in the number of pods it creates. It uses both the pod_density and cluster loader scripts to create a certain amount of projects and then slowly increase by a number you set. 
