### PR TITLE
Reduce reliability logging - remove pods in good state from output

### DIFF
--- a/reliability/tasks/Pods.py
+++ b/reliability/tasks/Pods.py
@@ -1,4 +1,4 @@
-from  .utils.oc import oc
+from  .utils.oc import shell
 import logging
 
 
@@ -7,7 +7,7 @@ class Pods:
         self.logger = logging.getLogger('reliability')
 
     def check(self):
-        (result, rc) = oc("get pods --all-namespaces")
+        (result, rc) = shell('oc get pods --all-namespaces| egrep -v "Running|Complete"')
         if rc != 0:
            self.logger.error("get pods: failed")
 

--- a/reliability/tasks/utils/oc.py
+++ b/reliability/tasks/utils/oc.py
@@ -1,23 +1,29 @@
 import subprocess
 import logging
 
-def oc(cmd, config=""):
+def shell(cmd):
     logger = logging.getLogger('reliability')
-    cmd = "oc " + cmd
     rc = 0
     result = ""
     logger.info("=>" + cmd)
-    if config:
-        cmd = "KUBECONFIG=" + config + " " + cmd
     try:
         result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError as cpe:
         rc = cpe.returncode
         result = cpe.output
-    
+
     string_result = result.decode("utf-8")
     logger.info(str(rc) + ": " + string_result)
     return string_result, rc
+
+def oc(cmd, config=""):
+    cmd = "oc " + cmd
+    rc = 0
+    result = ""
+    if config:
+        cmd = "KUBECONFIG=" + config + " " + cmd
+    result,rc = shell(cmd)
+    return result,rc
 
 
 


### PR DESCRIPTION
The reliability logs get huge over time, mainly due to the oc get pods --all-namespaces output.  Pods in Running or Complete status aren't interesting for the purpose of monitoring reliability runs, we really care about Error, CrashLoop, stuck in Terminating, etc.  

Reduce the logged output by changing this to oc get pods --all-namespaces | egrep -v "Complete|Running"