### PR TITLE
Pod and Node Affinity updates

### DIFF
--- a/openshift_scalability/ci/scripts/README.md
+++ b/openshift_scalability/ci/scripts/README.md
@@ -1,0 +1,68 @@
+## Pod and Node Affinity README
+
+### Purpose 
+The pod and node affinity tests, test the ability of pods getting scheduled using Affinity and Anti-Affinity rules as we approach the capacity of compute nodes  
+
+
+### Use Python2 if running using python cluster loader
+
+The following command should return python 2
+```
+$ python --version 
+```
+
+If not, consider using a python 2 virtual environment.
+Information can be found [here](https://docs.python-guide.org/dev/virtualenvs/) on how to install and set the virtual environment 
+
+Activate the virutal environemnt using 
+```
+$ source <virtualenv_name>/bin/activate
+```
+
+Now the same command should return 2.* if done correctly 
+```
+$ python --version 
+```
+
+### Install Requirements 
+
+```
+$ pip install -r ../../../openshift_scalability/cluster_loader_requirements.txt
+```
+
+### Setup
+
+**Projects and applicatons:**  It is recommended that [cluster-loader](https://github.com/openshift/svt/blob/master/openshift_scalability/README.md) be used to create projects, deployments, build configurations, etc.   **pod_density** is a complimentary tool that can run the pod creation by **cluster_loader**.
+
+An example cluster-loader config that works with build_test.py is [master-vert.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/master-vert-pv.yaml)
+
+This will create namespaces as below.  These projects will be specified in their corresponding json configs 
+
+```
+# oc get ns
+NAME                 STATUS    AGE
+pod-affinity-s1-0                                                 Active
+pod-anti-affinity-s1-0                                            Active
+s1-proj                                                           Active
+```
+
+### Usage 
+
+```./run-node-affinity-anti-affinity.sh <golang or python>```
+
+```./run-pod-affinity-anti-affinity.sh <golang or python>```
+
+
+### Common Error Fixes
+
+When running python 
+
+Error: 
+```AttributeError: 'str' object has no attribute 'decode'```
+
+Fix: Make sure to use python 2 
+
+
+Error: ````Error setting pause time: list index out of range````
+
+Fix: Add a time unit to the config yaml file (pod-affinity.yaml or node-affinity.yaml) 

--- a/openshift_scalability/ci/scripts/get_openshift_tests.sh
+++ b/openshift_scalability/ci/scripts/get_openshift_tests.sh
@@ -1,0 +1,16 @@
+chmod +x get_openshift_tests.sh
+#/!/bin/bash
+#need to run as a root user
+tag=$([ -z $1 ] && echo "latest" || echo "$1")
+echo "tag $tag"
+export IMAGE_ID=$(podman create quay.io/openshift/origin-tests:$tag)
+echo $IMAGE_ID
+podman images
+podman ps -a  ; ### you'll see that image was run and no longer running, IMAGE_ID is the ID of running image origin-tests
+mkdir /root/openshift-tests_binaries_dir
+cd /root/openshift-tests_binaries_dir
+podman cp $IMAGE_ID:/bin/openshift-tests .
+ls -ltr
+cp openshift-tests ~/
+cp openshift-tests /usr/bin
+which openshift-tests

--- a/openshift_scalability/ci/scripts/get_pod_total.py
+++ b/openshift_scalability/ci/scripts/get_pod_total.py
@@ -1,0 +1,24 @@
+import yaml
+
+
+# Get the project name and number of pods from the yaml we loaded
+def get_pod_counts_python(file):
+    pod_list = []
+    with open(file, "r") as f:
+        yaml_file = yaml.load(f, Loader=yaml.FullLoader)
+        for proj in yaml_file['projects']:
+            for pod in proj['pods']:
+                if "total" in pod.keys():
+                    print(str(proj['basename']) + " " + str(pod['total']))
+
+
+# Get the project name and number of pods from the yaml we loaded
+def get_pod_counts_golang(file):
+
+    pod_list=[]
+    with open(file, "r") as f:
+        yaml_file = yaml.load(f, Loader=yaml.FullLoader)
+        for proj in yaml_file['ClusterLoader']['projects']:
+            for pod in proj['pods']:
+                if "num" in pod.keys():
+                    print(str(proj['basename']) + " " + str(pod['num']))

--- a/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-node-affinity-anti-affinity.sh
@@ -1,5 +1,74 @@
 #!/bin/bash
 # set -x
+if [ "$#" -ne 1 ]; then
+  echo "syntax: $0 <TYPE>"
+  echo "<TYPE> should be either golang or python"
+  exit 1
+fi
+
+TYPE=$1
+
+function golang_clusterloader() {
+  # Export kube config
+  export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
+
+  #### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
+  ## - Absolute path to config file needed
+  ## - .yaml extension is required now in config file name
+  ## - full path to the config file  must be under 70 characters total
+  MY_CONFIG=../../config/golang/node-affinity.yaml
+  # loading cluster based on yaml config file
+  VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial]"
+}
+
+function python_clusterloader() {
+  MY_CONFIG=../../config/node-affinity.yaml
+  python --version
+  python ../../cluster-loader.py -f $MY_CONFIG
+}
+
+function show_node_labels() {
+  oc get node --show-labels
+  oc get node -l cpu=4
+  oc get node -l cpu=6
+  oc get node -l beta.kubernetes.io/arch=intel
+}
+
+function check_no_error_pods()
+{
+  error=`oc get pods -n $1 | grep Error | wc -l`
+  if [ $error -ne 0 ]; then
+    echo "$error pods found, exiting"
+    #loop to find logs of error pods?
+    exit 1
+  fi
+}
+
+function wait_for_project_termination() {
+  COUNTER=0
+  terminating=$(oc get projects | grep $1 | grep Terminating | wc -l)
+  while [ $terminating -ne 0 ]; do
+    sleep 15
+    terminating=$(oc get projects | grep $1 | grep Terminating | wc -l)
+    echo "$terminating projects are still terminating"
+    COUNTER=$((COUNTER + 1))
+    if [ $COUNTER -ge 20 ]; then
+      echo "$terminating projects are still terminating after 5 minutes"
+      exit 1
+    fi
+  done
+  proj=$(oc get projects | grep $1 | wc -l)
+  if [ $proj -ne 0 ]; then
+    echo "$proj $1 projects are still there"
+    exit 1
+  fi
+  pods_in_proj=$(oc get pods -A | grep $1 | wc -l)
+  if [ $pods_in_proj -ne 0 ]; then
+    echo "$pods_in_proj $1 pods are still there"
+    exit 1
+  fi
+
+}
 
 date
 uname -a
@@ -16,7 +85,7 @@ declare -a node_array
 counter=1
 
 oc get nodes -l 'node-role.kubernetes.io/worker='
-oc describe nodes -l 'node-role.kubernetes.io/worker=' 
+oc describe nodes -l 'node-role.kubernetes.io/worker='
 
 initial_node_label="beta.kubernetes.io/arch=amd64"
 
@@ -31,7 +100,6 @@ for i in {1..2}; do
   echo "Array element node_array index $i has value : ${node_array[${i}]}"
 done
 
-
 # Configuration: label nodes  for Affinity and anti-affinity scheduling
 echo -e "\nLabeling node ${node_array[1]} with label 'cpu=4'"
 oc label nodes ${node_array[1]} cpu=4
@@ -42,64 +110,124 @@ oc label nodes ${node_array[2]} cpu=6
 echo -e "\nLabeling node ${node_array[1]} with label 'beta.kubernetes.io/arch=intel'"
 oc label nodes ${node_array[1]} --overwrite beta.kubernetes.io/arch=intel
 
-
-function show_node_labels() {
-  oc get node --show-labels
-  oc get node -l cpu=4
-  oc get node -l cpu=6
-  oc get node -l beta.kubernetes.io/arch=intel
-}
-
-function check_no_error_pods()
-{
-  error=`oc get pods --all-namespaces | grep Error | wc -l`
-  if [ $error -ne 0 ]; then
-    echo "$error pods found, exiting"
-    exit 1
-  fi
-}
-
 show_node_labels
 
 sleep 5
 
-
-# start GoLang cluster-loader
-export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
-
-cd /root/svt/openshift_scalability
-ls -ltr config/golang
-
-#### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
-## - Absolute path to config file needed
-## - .yaml extension is required now in config file name
-## - full path to the config file  must be under 70 characters total
-
-MY_CONFIG=/root/svt/openshift_scalability/config/golang/node-affinity.yaml
-echo -e "\nRunning GoLang cluster-loader from openshift-tests binary with config file: ${MY_CONFIG}"
-echo -e "\nContents of  config file: ${MY_CONFIG}"
-cat ${MY_CONFIG}
-
-VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"
+echo "Run tests"
+if [ "$TYPE" == "golang" ]; then
+  golang_clusterloader
+  pod_counts=$(python -c "import get_pod_total; get_pod_total.get_pod_counts_golang('$MY_CONFIG')")
+elif [ "$TYPE" == "python" ]; then
+  python_clusterloader
+  pod_counts=$(python -c "import get_pod_total; get_pod_total.get_pod_counts_python('$MY_CONFIG')")
+else
+  echo "$TYPE is not a valid option, available options: golang, python"
+  exit 1
+fi
 
 sleep 30
 
-check_no_error_pods
+check_no_error_pods node-affinity-0
 
-oc get pods --all-namespaces -o wide
+check_no_error_pods node-anti-affinity-0
 
-## TO DO:  check pod counts expecting 130 pods per namespace
-oc get pods -n node-affinity-0 -o wide | grep "pausepods" | grep ${node_array[2]} | grep Running | wc -l
-oc get pods -n node-anti-affinity-0 -o wide | grep "hellopods" | grep ${node_array[1]} | grep Running | wc -l
+## Check pod counts expecting <num from yaml> pods per namespace
+echo "nodes $node_array"
+affinity_pods=$(oc get pods -n node-affinity-0 -o wide | grep "pausepods" | grep ${node_array[2]} | grep Running | wc -l | xargs )
+anti_affinity_pods=$(oc get pods -n node-anti-affinity-0 -o wide | grep "hellopods" | grep -v ${node_array[2]} | grep Running | wc -l | xargs)
+
+#validate counts
+
+counts=$(echo $pod_counts | tr ' ' '\n')
+declare -a node_namespace
+node_affinity_total=0
+node_anti_affinity_total=0
+
+counter=0
+for n in ${counts}; do
+  if [ $((counter % 2)) == 0 ]; then
+    echo "counter $counter $n"
+    node_namespace=${n}
+  else
+    if [[ $node_namespace == "node-affinity"* ]]; then
+      echo "affinity"
+      node_affinity_total=${n}
+    elif [[ $node_namespace  == "node-anti-affinity"* ]]; then
+      node_anti_affinity_total=${n}
+    fi
+  fi
+  ((counter++))
+done
+
+## Pass/Fail
+pass_or_fail=0
+
+if [[ ${affinity_pods} == ${node_affinity_total} ]]; then
+  echo -e "\nActual ${affinity_pods} pods were sucessfully deployed. Node affinity test passed!"
+  ((pass_or_fail++))
+else
+  echo -e "\nActual ${affinity_pods} pods deployed does NOT match expected ${node_affinity_total} pods for node affinity test.  Node affinity test failed !"
+fi
+
+if [[ ${anti_affinity_pods} == ${node_anti_affinity_total} ]]; then
+  echo -e "\nActual ${anti_affinity_pods} pods were sucessfully deployed.  Node Anti-affinity test passed!"
+  ((pass_or_fail++))
+else
+  echo -e "\nActual ${anti_affinity_pods} pods deployed does NOT match expected ${node_anti_affinity_total} pods for node Anti-affinity test. Node Anti-affinity test failed !"
+fi
+
+counts=$(echo $pod_counts | tr ' ' '\n')
+declare -a node_namespace
+node_affinity_total=0
+node_anti_affinity_total=0
+
+counter=0
+for n in ${counts}; do
+  if [ $((counter % 2)) == 0 ]; then
+    echo "counter $counter $n"
+    node_namespace=${n}
+  else
+    if [[ $node_namespace == "node-affinity"* ]]; then
+      echo "affinity"
+      node_affinity_total=${n}
+    elif [[ $node_namespace  == "node-anti-affinity"* ]]; then
+      node_anti_affinity_total=${n}
+    fi
+  fi
+  ((counter++))
+done
+echo "node_affinity_total $node_affinity_total"
+echo "node_anti_affinity_total $node_anti_affinity_total"
+
+## Pass/Fail
+pass_or_fail=0
+
+if [[ ${affinity_pods} == ${node_affinity_total} ]]; then
+  echo -e "\nActual ${affinity_pods} pods were sucessfully deployed. Node affinity test passed!"
+  ((pass_or_fail++))
+else
+  echo -e "\nActual ${affinity_pods} pods deployed does NOT match expected ${node_affinity_total} pods for node affinity test.  Node affinity test failed !"
+fi
+
+if [[ ${anti_affinity_pods} == ${node_anti_affinity_total} ]]; then
+  echo -e "\nActual ${anti_affinity_pods} pods were sucessfully deployed.  Node Anti-affinity test passed!"
+  ((pass_or_fail++))
+else
+  echo -e "\nActual ${anti_affinity_pods} pods deployed does NOT match expected ${node_anti_affinity_total} pods for node Anti-affinity test. Node Anti-affinity test failed !"
+fi
+
+oc describe node/${node_array[2]}
 
 sleep 60
 
-# delete projects:  cleanup
+# delete projects:
+######### Clean up: delete projects and wait till all projects and pods are gone
 oc delete project node-affinity-0
-oc delete project node-anti-affinity-0
+wait_for_project_termination node-affinity-0
 
-######### TO DO:
-######### Need to clean up, delete projects and wait till all pods are gone
+oc delete project node-anti-affinity-0
+wait_for_project_termination node-anti-affinity-0
 
 sleep 30
 
@@ -111,4 +239,12 @@ oc label nodes ${node_array[1]} --overwrite ${initial_node_label}
 
 show_node_labels
 
+## Final Pass/Fail result
+if [[ ${pass_or_fail} == 2 ]]; then
+  echo -e "\nOverall Node Affinity and Anti-affinity Testcase result:  PASS"
+  exit 0
+else
+  echo -e "\nOverall Node Affinity and Anti-affinity Testcase result:  FAIL"
+  exit 1
+fi
 

--- a/openshift_scalability/ci/scripts/run-pod-affinity-anti-affinity.sh
+++ b/openshift_scalability/ci/scripts/run-pod-affinity-anti-affinity.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # set -x
 
+if [ "$#" -ne 1 ]; then
+  echo "syntax: $0 <TYPE>"
+  echo "<TYPE> should be either golang or python"
+  exit 1
+fi
+
+TYPE=$1
+
 date
 uname -a
 oc get clusterversion
@@ -14,39 +22,59 @@ echo "Date timestamp used for s1 pod spec filename: ${current_date}"
 total_pods=130
 echo "Expecting ${total_pods} pods to be deployed successfully for Pod Affinity and also for Pod Anti-Affinity tests"
 
+function golang_clusterloader() {
+
+  # start GoLang cluster-loader
+  export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
+  cur_loc=$(pwd)
+
+  #### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
+  ## - Absolute path to config file needed
+  ## - .yaml extension is required now in config file name
+  ## - full path to the config file  must be under 70 characters total
+
+  MY_CONFIG=$cur_loc/../../config/golang/pod-affinity.yaml
+  #  echo -e "\nRunning GoLang cluster-loader from openshift-tests binary with config file: ${MY_CONFIG}"
+  #  echo -e "\nContents of  config file: ${MY_CONFIG}"
+  #cat ${MY_CONFIG}
+
+  VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial]"
+
+}
+
+function python_clusterloader() {
+  MY_CONFIG=../../config/pod-affinity.yaml
+  python --version
+  python ../../cluster-loader.py -f $MY_CONFIG
+}
+
 # An error exit function
-function error_exit
-{
+function error_exit() {
   echo "$1" 1>&2
   exit 1
 }
 
-function wait_for_running
-{
+function wait_for_running() {
   counter=0
-  while true;
-  do
+  while true; do
     all_running=1
 
     oc get pods -n s1-proj -o wide
     RUNNING=$(oc get pods -n s1-proj)
     echo "Pod status in namespace s1-proj: ${RUNNING}"
-      if [[ $RUNNING =~ Running ]]
-      then
-        oc get pods -n s1-proj -o wide
-        echo "Pod s1 in namespace s1-proj is now Running"
-      else
-	all_running=0
-        echo "Pod s1 in namespace s1-proj is still not Running"
-      fi
+    if [[ $RUNNING =~ Running ]]; then
+      oc get pods -n s1-proj -o wide
+      echo "Pod s1 in namespace s1-proj is now Running"
+    else
+      all_running=0
+      echo "Pod s1 in namespace s1-proj is still not Running"
+    fi
 
-    if [ $all_running -eq 1 ]
-     then
+    if [ $all_running -eq 1 ]; then
       break
     fi
 
-    if [[ $counter == 10 ]]
-    then
+    if [[ $counter == 10 ]]; then
       echo "s1 pod failed to get into Running state"
       error_exit "s1 pod failed to get into Running state"
     fi
@@ -57,33 +85,42 @@ function wait_for_running
 
 }
 
-function wait_for_terminating 
-{
+function wait_for_project_termination() {
+  COUNTER=0
+  terminating=$(oc get projects | grep $1 | wc -l)
+  while [ $terminating -ne 0 ]; do
+    sleep 15
+    terminating=$(oc get projects | grep $1 | wc -l)
+    echo "$terminating projects are still there"
+    COUNTER=$((COUNTER + 1))
+    if [ $COUNTER -ge 20 ]; then
+      echo "$terminating projects are still there after 5 minutes"
+      exit 1
+    fi
+  done
+}
+
+function wait_for_terminating() {
   project_name=$1
   counter=0
-  while true;
-  do
+  while true; do
     still_terminating=0
 
-    oc get pods -n ${project_name} -o wide
     TERMINATING=$(oc get pods -n ${project_name})
     echo -e "\nPod status in namespace ${project_name} is: \n${TERMINATING}"
-      if [[ $TERMINATING =~ Terminating ]]
-      then
-        still_terminating=1
-        echo "Pods in namespace ${project_name} are still Terminating"
-      else
-        still_terminating=0
-        echo "No more Terminating pods in namespace ${project_name}"
-      fi
+    if [[ $TERMINATING =~ Terminating ]]; then
+      still_terminating=1
+      echo "Pods in namespace ${project_name} are still Terminating"
+    else
+      still_terminating=0
+      echo "No more Terminating pods in namespace ${project_name}"
+    fi
 
-    if [ $still_terminating -eq 0 ]
-     then
+    if [ $still_terminating -eq 0 ]; then
       break
     fi
 
-    if [[ $counter == 60 ]]
-    then
+    if [[ $counter == 60 ]]; then
       echo "We still have pods Terminating in namespace ${project_name}"
       error_exit "We still have pods Terminating in namespace ${project_name}"
     fi
@@ -94,11 +131,12 @@ function wait_for_terminating
 
 }
 
-
-function clean_up
-{ 
+function clean_up() {
   oc delete project s1-proj
-  rm -f /root/pod-s1-${current_date}.yaml 
+  rm -f pod-s1-${current_date}.yaml
+  wait_for_terminating s1-proj
+  wait_for_project_termination s1-proj
+
 }
 
 worker_nodes=$(oc get nodes -l 'node-role.kubernetes.io/worker=' | awk '{print $1}' | grep -v NAME | xargs)
@@ -106,8 +144,7 @@ worker_nodes=$(oc get nodes -l 'node-role.kubernetes.io/worker=' | awk '{print $
 echo -e "\nWorker  nodes are: $worker_nodes"
 
 oc get nodes -l 'node-role.kubernetes.io/worker='
-oc describe nodes -l 'node-role.kubernetes.io/worker=' 
-
+oc describe nodes -l 'node-role.kubernetes.io/worker='
 
 echo -e "apiVersion: v1
 kind: Pod
@@ -118,15 +155,15 @@ metadata:
 spec:
   containers:
   - name: ocp
-    image: docker.io/ocpqe/hello-pod" > /root/pod-s1-${current_date}.yaml
+    image: docker.io/ocpqe/hello-pod" > pod-s1-${current_date}.yaml
 
-ls -ltr /root/pod-s1-${current_date}.yaml
-cat /root/pod-s1-${current_date}.yaml
+ls -ltr pod-s1-${current_date}.yaml
+cat pod-s1-${current_date}.yaml
 
-# create a new project
+#create a new project
 oc new-project s1-proj
 
-oc create -f /root/pod-s1-${current_date}.yaml
+oc create -f pod-s1-${current_date}.yaml
 
 oc get pods -n s1-proj -o wide
 
@@ -141,24 +178,41 @@ sleep 30
 
 oc project default
 
-# start GoLang cluster-loader
-export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
+echo "Run tests"
+if [ "$TYPE" == "golang" ]; then
+  golang_clusterloader
+  pod_counts=$(python -c "import get_pod_total; get_pod_total.get_pod_counts_golang('$MY_CONFIG')")
+elif [ "$TYPE" == "python" ]; then
+  python_clusterloader
+  pod_counts=$(python -c "import get_pod_total; get_pod_total.get_pod_counts_python('$MY_CONFIG')")
+else
+  echo "$TYPE is not a valid option, available options: golang, python"
+  exit 1
+fi
 
-cd /root/svt/openshift_scalability
-ls -ltr config/golang
+counts=$(echo $pod_counts | tr ' ' '\n')
+declare -a pod_namespace
+declare -a pod_counts
+pod_affinity_total=0
+pod_anti_affinity_total=0
 
-#### OCP 4.2: new requirements to run golang cluster-loader from openshift-tests binary:
-## - Absolute path to config file needed
-## - .yaml extension is required now in config file name
-## - full path to the config file  must be under 70 characters total
-
-MY_CONFIG=/root/svt/openshift_scalability/config/golang/pod-affinity.yaml
-echo -e "\nRunning GoLang cluster-loader from openshift-tests binary with config file: ${MY_CONFIG}"
-echo -e "\nContents of  config file: ${MY_CONFIG}"
-cat ${MY_CONFIG}
-
-VIPERCONFIG=$MY_CONFIG openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"
-
+counter=0
+for n in ${counts}; do
+  if [ $((counter % 2)) == 0 ]; then
+    echo "counter $counter $n"
+    pod_namespace=${n}
+  else
+    if [[ $pod_namespace == "pod-affinity"* ]]; then
+      echo "affinity"
+      pod_affinity_total=${n}
+    elif [[ $pod_namespace  == "pod-anti-affinity"* ]]; then
+      pod_anti_affinity_total=${n}
+    fi
+  fi
+  ((counter++))
+done
+echo "pod_affinity_total $pod_affinity_total"
+echo "pod_anti_affinity_total $pod_anti_affinity_total"
 cluster_loader_result=$?
 echo -e "\nClusterLoader return status: ${cluster_loader_result}"
 
@@ -167,34 +221,34 @@ sleep 30
 oc get pods --all-namespaces -o wide
 
 echo -e "\n============= Summary of pod count with affinity to s1 pod: =================="
-oc get pods -n pod-affinity-s1-0 -o wide | grep "pod-affinity-security-in-s1-pod" | grep ${s1pod_node} 
+oc get pods -n pod-affinity-s1-0 -o wide | grep "pod-affinity-security-in-s1" | grep ${s1pod_node}
 
-s1_affinity_pod_count=$(oc get pods -n pod-affinity-s1-0 -o wide | grep "pod-affinity-security-in-s1-pod" | grep ${s1pod_node} | grep Running | wc -l)
-echo -e "\nNumber of hellopods deployed with pod affinity to pod s1:  ${s1_affinity_pod_count} , expecting ${total_pods} pods"
+s1_affinity_pod_count=$(oc get pods -n pod-affinity-s1-0 -o wide | grep "pod-affinity-security-in-s1" | grep ${s1pod_node} | grep Running | wc -l | xargs)
+echo -e "\nNumber of hellopods deployed with pod affinity to pod s1:  ${s1_affinity_pod_count} , expecting ${pod_affinity_total} pods"
 
 echo -e "\n============= Summary of pod count with anit-affinity to s1 pod: =================="
-oc get pods -n pod-anti-affinity-s1-0 -o wide | grep "pod-anti-affinity-security-in-s1-pod" | grep -v ${s1pod_node} 
+oc get pods -n pod-anti-affinity-s1-0 -o wide | grep "pod-anti-affinity-security-in-s1" | grep -v ${s1pod_node}
 
-s1_anti_affinity_pod_count=$(oc get pods -n pod-anti-affinity-s1-0 -o wide | grep "pod-anti-affinity-security-in-s1-pod" | grep -v ${s1pod_node} | grep Running | wc -l)
-echo -e "\nNumber of hellopods deployed with pod anti-affinity to pod s1 on nodes other than ${s1pod_node} is : ${s1_anti_affinity_pod_count} , expecting ${total_pods} pods"
+s1_anti_affinity_pod_count=$(oc get pods -n pod-anti-affinity-s1-0 -o wide | grep "pod-anti-affinity-security-in-s1" | grep -v ${s1pod_node} | grep Running | wc -l | xargs)
+echo -e "\nNumber of hellopods deployed with pod anti-affinity to pod s1 on nodes other than ${s1pod_node} is : ${s1_anti_affinity_pod_count} , expecting ${pod_anti_affinity_total} pods"
+
+oc describe node/${s1pod_node}
 
 ## Pass/Fail
 pass_or_fail=0
 
-if [[ ${s1_affinity_pod_count} == ${total_pods} ]]
-then
-  echo -e "\nActual ${s1_affinity_pod_count} pods were sucessfully deployed.  Pod affinity test passed!"
+if [[ ${s1_affinity_pod_count} == ${pod_affinity_total} ]]; then
+  echo -e "\nActual ${s1_affinity_pod_count} pods were sucessfully deployed. Pod affinity test passed!"
   ((pass_or_fail++))
 else
-  echo -e "\nActual ${s1_affinity_pod_count} pods deployed does NOT match expected ${total_pods} pods for pod affinity test.  Pod affinity test failed !"
+  echo -e "\nActual ${s1_affinity_pod_count} pods deployed does NOT match expected ${pod_affinity_total} pods for pod affinity test.  Pod affinity test failed !"
 fi
 
-if [[ ${s1_anti_affinity_pod_count} == ${total_pods} ]]
-then
+if [[ ${s1_anti_affinity_pod_count} == ${pod_anti_affinity_total} ]]; then
   echo -e "\nActual ${s1_anti_affinity_pod_count} pods were sucessfully deployed.  Pod Anti-affinity test passed!"
   ((pass_or_fail++))
 else
-  echo -e "\nActual ${s1_anti_affinity_pod_count} pods deployed does NOT match expected ${total_pods} pods for pod Anti-affinity test.  Pod Anti-affinity test failed !"
+  echo -e "\nActual ${s1_anti_affinity_pod_count} pods deployed does NOT match expected ${pod_anti_affinity_total} pods for pod Anti-affinity test.  Pod Anti-affinity test failed !"
 fi
 
 sleep 60
@@ -208,18 +262,18 @@ sleep 30
 echo -e "\nWaiting for pods to terminate ..."
 wait_for_terminating pod-affinity-s1-0
 wait_for_terminating pod-anti-affinity-s1-0
+wait_for_project_termination pod-affinity-s1-0
+wait_for_project_termination pod-anti-affinity-s1-0
 
-## Allow for more time to termiante all resources in deleted projects
-## This helps if running back-toback tests or CI jenkins job
+# Allow for more time to termiante all resources in deleted projects
+# This helps if running back-toback tests or CI jenkins job
 sleep 60
 
 ## Final Pass/Fail result
-if [[ ${pass_or_fail} == 2 ]]
-then
+if [[ ${pass_or_fail} == 2 ]]; then
   echo -e "\nOverall Affinity and Anti-affinity Testcase result:  PASS"
   exit 0
 else
   echo -e "\nOverall Affinity and Anti-affinity Testcase result:  FAIL"
   exit 1
 fi
-

--- a/openshift_scalability/config/golang/node-affinity.yaml
+++ b/openshift_scalability/config/golang/node-affinity.yaml
@@ -10,7 +10,7 @@ ClusterLoader:
         - num: 200
           image: gcr.io/google_containers/pause-amd64:3.0
           basename: pausepods
-          file: ./content/pod-pause-node-affinity.json
+          file: ../../content/pod-pause-node-affinity.json
 
     - num: 1
       basename: node-anti-affinity-
@@ -20,7 +20,7 @@ ClusterLoader:
         - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: hellopods
-          file: ./content/pod-hello-node-anti-affinity.json
+          file: ../../content/pod-hello-node-anti-affinity.json
 
   tuningsets:
     - name: default

--- a/openshift_scalability/config/golang/pod-affinity.yaml
+++ b/openshift_scalability/config/golang/pod-affinity.yaml
@@ -10,7 +10,7 @@ ClusterLoader:
         - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: pod-affinity-security-in-s1
-          file: /root/svt/openshift_scalability/content/pod-pod-affinity.json
+          file: ../../content/pod-pod-affinity.json
 
     - num: 1
       basename: pod-anti-affinity-s1-
@@ -20,7 +20,7 @@ ClusterLoader:
         - num: 130
           image: docker.io/ocpqe/hello-pod
           basename: pod-anti-affinity-security-in-s1
-          file: /root/svt/openshift_scalability/content/pod-pod-anti-affinity.json
+          file: ../../content/pod-pod-anti-affinity.json
 
 
   tuningsets:

--- a/openshift_scalability/config/node-affinity.yaml
+++ b/openshift_scalability/config/node-affinity.yaml
@@ -1,0 +1,40 @@
+projects:
+  - num: 1
+    basename: node-affinity-
+    tuning: default
+    ifexists: delete
+    pods:
+      - total: 200
+      - num: 100
+        image: gcr.io/google_containers/pause-amd64:3.0
+        basename: pausepods
+        file: ../../content/pod-pause-node-affinity.json
+        storage:
+          - type: none
+
+  - num: 1
+    basename: node-anti-affinity-
+    tuning: default
+    ifexists: delete
+    pods:
+      - total: 130
+      - num: 100
+        image: docker.io/ocpqe/hello-pod
+        basename: hellopods
+        file: ../../content/pod-hello-node-anti-affinity.json
+        storage:
+          - type: none
+
+quotas:
+  - name: default
+    file: default
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 40
+        pause: 10 s
+      ratelimit:
+        delay: 0
+

--- a/openshift_scalability/config/pod-affinity.yaml
+++ b/openshift_scalability/config/pod-affinity.yaml
@@ -1,0 +1,36 @@
+provider: local
+projects:
+  - num: 1
+    basename: pod-affinity-s1-
+    tuning: default
+    ifexists: delete
+    pods:
+      - total: 130
+      - num: 100
+        image: docker.io/ocpqe/hello-pod
+        basename: pod-affinity-security-in-s1
+        file: ../../content/pod-pod-affinity.json
+        storage:
+          - type: none
+  - num: 1
+    basename: pod-anti-affinity-s1-
+    tuning: default
+    ifexists: delete
+    pods:
+      - total: 130
+      - num: 100
+        image: docker.io/ocpqe/hello-pod
+        basename: pod-anti-affinity-security-in-s1
+        file: ../../content/pod-pod-anti-affinity.json
+        storage:
+          - type: none
+
+tuningsets:
+  - name: default
+    pods:
+      stepping:
+        stepsize: 50
+        pause: 120 s
+      ratelimit:
+        delay: 0
+

--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -15,17 +15,23 @@ logger.setLevel(logging.INFO)
 logger.addHandler(screen_handler)
 
 def calc_time(timestr):
-    tlist = timestr.split()
-    if tlist[1] == "s":
-        return int(tlist[0])
-    elif tlist[1] == "min":
-        return int(tlist[0]) * 60
-    elif tlist[1] == "ms":
-        return int(tlist[0]) / 1000
-    elif tlist[1] == "hr":
-        return int(tlist[0]) * 3600
-    else:
-        logger.error("Invalid delay in rate_limit Exiting ........")
+
+    try:
+        tlist = str(timestr).split()
+        if tlist[1] == "s":
+            return int(tlist[0])
+        elif tlist[1] == "min":
+            return int(tlist[0]) * 60
+        elif tlist[1] == "ms":
+            return int(tlist[0]) / 1000
+        elif tlist[1] == "hr":
+            return int(tlist[0]) * 3600
+        else:
+            logger.error("Invalid delay in rate_limit Exiting ........")
+            sys.exit()
+    except Exception as e:
+        logger.error("Error setting pause time: " + str(e))
+        logger.error("Exiting ........")
         sys.exit()
 
 def oc_command(args, globalvars):
@@ -305,6 +311,7 @@ def create_pods(podcfg, num, storagetype, globalvars):
                 total_pods_created = int(globalvars["totalpods"])
                 if total_pods_created % stepsize == 0 and globalvars["tolerate"] is False:
                     pod_data(globalvars)
+                    logger.info("Pausing for " + str(pause))
                     time.sleep(calc_time(pause))
             if "rate_limit" in globalvars["tuningset"]:
                 delay = globalvars["tuningset"]["rate_limit"]["delay"]
@@ -324,8 +331,7 @@ def pod_data(globalvars):
             getpods = oc_command("kubectl get pods --namespace " + namespace, globalvars)
         else:
             getpods = oc_command("oc get pods -n " + namespace, globalvars)
-        all_status = str(getpods[0], 'utf-8').split("\n")
-
+        all_status = str(getpods[0]).decode('utf-8').split("\n")
         size = len(all_status)
         all_status = all_status[1:size - 1]
         for status in all_status:
@@ -553,7 +559,6 @@ def project_handler(testconfig, globalvars):
         for k, child in enumerate(children):
             os.waitpid(child, 0)
 
-
 def quota_handler(inputquota, globalvars):
     logger.debug("Function :: quota_handler")
 
@@ -574,7 +579,6 @@ def quota_handler(inputquota, globalvars):
     else:
         oc_command("oc create -f " + tmpfile.name, globalvars)
     tmpfile.close()
-
 
 def template_handler(templates, globalvars):
     logger.debug("template_handler function called")
@@ -620,7 +624,6 @@ def service_handler(inputservs, globalvars):
         service_config["metadata"]["name"] = basename
 
         create_service(service_config, num, globalvars)
-
 
 def ebs_create(globalvars):
     # just calling this function to create EBS, pv and pvc, EBS volume id == pv name == pvc name


### PR DESCRIPTION
These changes are adding both pod and node affinity test scripts.

- Added python and golang versions of cluster loader
- Making relative imports in yaml files 
- Adding python yaml files for python cluster loader 
- Add validation of expected number of pods in both pods and nodes based on nums set in yaml files not hard coded 
- This also includes using the 4.6 version of openshift-tests 

Also adding a script that helps install the openshift-tests binary (get_openshift_tests.sh )