### PR TITLE
Error cases and logs for concurrent builds 

### DIFF
--- a/openshift_performance/ci/scripts/README.md
+++ b/openshift_performance/ci/scripts/README.md
@@ -1,3 +1,15 @@
+## Concurrent builds README
+
+### Purpose
+The conc_builds.sh scripts is a flexible tool for driving builds in OpenShift.  This test is intended to reocrd the times of concurrent builds of a specific application and the time it takes to push the image to a registry.
+
+It combines many different tools including cluster-loader and build_test 
+
+### Install python packages
+
+```
+$ pip install pytimeparse logging pyyaml rbd rados
+
 ## conc_builds README
 
 ### Purpose 
@@ -35,11 +47,12 @@ $ pip install -r ../../../openshift_scalability/cluster_loader_requirements.txt
 
 ### Setup
 
-**Projects and applicatons:**  It is recommended that [cluster-loader](https://github.com/openshift/svt/blob/master/openshift_scalability/README.md) be used to create projects, deployments, build configurations, etc.   **pod_density** is a complimentary tool that can run the pod creation by **cluster_loader**.
+**Projects and applicatons:**  It is recommended that [cluster-loader](https://github.com/openshift/svt/blob/master/openshift_scalability/README.md) be used to create projects, deployments, build configurations, etc.   **build_test** is a complimentary tool that can run the builds created by **cluster_loader**.
 
 An example cluster-loader config that works with build_test.py is [master-vert.yaml](https://github.com/openshift/svt/blob/master/openshift_scalability/config/master-vert-pv.yaml)
 
 This will create namespaces as below.  These projects will be specified in the build_test json config.
+svt-<app_name>-<number>
 
 ```
 # oc get ns
@@ -82,3 +95,35 @@ You'll need to edit the version of the imagestream to latest or a specific versi
 
 You can find the latest version by the following: 
 ```oc get imagestreamtag -A | grep <image_stream> ```
+
+If you want to change the number of projects you have to edit the number of projects in conc_builds.sh as well as the num field at the top of the [yaml files](https://github.com/openshift/svt/tree/master/openshift_performance/ci/content) specific for the application.  By default conc_builds and the content yaml files create 75 projects
+
+
+
+
+### Usage
+
+```./conc_builds.sh ```
+
+
+### Debugging steps
+
+```oc get builds -A``` (--all-namespaces if before 4.0)
+
+```oc describe build/<buildName> -n <namespace>```
+ 
+```oc get pods -A ```
+
+```oc describe pod/<podName> -n <namespace> ```
+  
+```oc logs <podName> -n <namespace> | grep error```
+
+
+
+
+### Solutions to issues
+
+
+https://access.redhat.com/solutions/3467561
+
+https://docs.openshift.com/container-platform/3.10/install_config/registry/registry_known_issues.html

--- a/openshift_performance/ci/scripts/get_conc_build_info.py
+++ b/openshift_performance/ci/scripts/get_conc_build_info.py
@@ -1,0 +1,132 @@
+import subprocess
+from optparse import OptionParser
+import re
+import time
+
+
+def run(command):
+    try:
+        output = subprocess.Popen(command, shell=True,
+                                  universal_newlines=True, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+        (out, err) = output.communicate()
+    except Exception as e:
+        print("Failed to run %s, error: %s" % (command, e))
+    return out
+
+def pods_in_nodes():
+    nodes =run("oc get pods -A -o wide | grep svt | awk '{print $8}'")
+    node_list = nodes.split('\n')
+    node_json= {}
+    for node in node_list:
+        if node in node_json.keys():
+            continue
+        node_json[node] = node_list.count(node)
+
+    print(node_json)
+
+
+def see_if_error_builds(output_file):
+    print('here')
+    errorbuilds=run('oc get builds --all-namespaces | grep svt | egrep -v "Running|Complete|Creating|Pending"')
+    with open(output_file, "a") as f:
+        f.write(str(errorbuilds))
+    print ("error builds" + str(errorbuilds))
+    COUNTER=0
+    error_builds_list = errorbuilds.split("\n")
+    builds = []
+
+    for val in error_builds_list:
+        COUNTER = 0
+        error_builds = []
+        line = re.split(r'\s{2,}', val)
+        for word in line:
+            if ((COUNTER % 6 ) == 0 ):
+                error_builds.append(word)
+            elif ((COUNTER % 6 ) == 1):
+
+                error_builds.append(word)
+                builds.append(error_builds)
+            else:
+                break
+
+            COUNTER += 1
+
+    return builds
+
+
+def get_error_builds(build_item):
+    namespace = build_item[0]
+    name = build_item[1]
+    #append to file
+    with open("build/" +name + namespace +".out", "w+") as f:
+        f.write("Log info for " + name + " build in namespace "+ namespace + '\n')
+        #logs = run("oc describe pod/" + str(name) + " -n " + namespace)
+        #f.write("Describe pod " + str(logs) + '\n')
+        logs = run("oc logs -f build/" + str(name) + " -n " + namespace)
+        f.write("Logs build " + str(logs) + '\n')
+
+
+def check_error_build(global_output_file):
+    builds_list = see_if_error_builds(global_output_file)
+    skip_first = True
+    run("mkdir build")
+    for build_item in builds_list:
+        if skip_first:
+            skip_first = False
+        else:
+            get_error_builds(build_item)
+
+def see_if_error(output_file):
+    print('here')
+    errorpods=run('oc get pods --all-namespaces | grep svt | egrep -v "Running|Complete|Creating|Pending"')
+    with open(output_file, "a") as f:
+        f.write(str(errorpods))
+    print ("errorpods" + str(errorpods) + str(type(errorpods)))
+    COUNTER=0
+    error_pods_list = errorpods.split("\n")
+    pods = []
+
+    for val in error_pods_list:
+        COUNTER = 0
+        error_pods = []
+        line = re.split(r'\s{2,}', val)
+        for word in line:
+            if ((COUNTER % 6 ) == 0 ):
+                error_pods.append(word)
+            elif ((COUNTER % 6 ) == 1):
+
+                error_pods.append(word)
+                pods.append(error_pods)
+            else:
+                break
+
+            COUNTER += 1
+
+    return pods
+
+
+def get_error_logs(pod_item, output_file):
+    namespace = pod_item[0]
+    name = pod_item[1]
+    #append to file
+    with open("pod/" + name + namespace +".out", "w+") as f:
+        f.write("Debugging info for " + name + " in namespace "+ namespace + '\n')
+        logs = run("oc logs " + str(name) + " -n " + namespace)
+        f.write("Logs " + str(logs) + '\n')
+
+
+
+def check_error(global_output_file):
+    pods_list = see_if_error(global_output_file)
+    skip_first = True
+    run("mkdir pod")
+    for pod_item in pods_list:
+        if skip_first:
+            skip_first = False
+        else:
+            get_error_logs(pod_item, global_output_file)
+
+pods_in_nodes()
+check_error("pod_error.out")
+check_error_build("build_error.out")


### PR DESCRIPTION
This PR adds in more details to the readme for the concurrent builds script. Adding in possible debugging steps and 2 helpful solutions to common issues I've found.

It adds in a script that gets all the logs of failed builds and pods that are not in a "Running|Complete|Creating|Pending" state. I have found this super helpful when there are more than a few failed builds for opening bugs. 