### PR TITLE
Node vertical updates

### DIFF
--- a/openshift_scalability/config/golang/nodeVertical-labeled-nodes.yaml
+++ b/openshift_scalability/config/golang/nodeVertical-labeled-nodes.yaml
@@ -7,10 +7,9 @@ ClusterLoader:
       tuning: default
       ifexists: delete
       pods:
-        - num: 1000
-          image: gcr.io/google_containers/pause-amd64:3.0
-          basename: pausepods
-          file: pod-pause-labeled-nodes.json
+        - num: 660
+          basename: hello
+          file: ../../content/pod-pause-labeled-nodes.json
   tuningsets:
     - name: default
       pods:

--- a/openshift_scalability/config/nodeVertical.yaml
+++ b/openshift_scalability/config/nodeVertical.yaml
@@ -4,14 +4,13 @@ projects:
     ifexists: delete
     tuning: default
     pods:
-      - total: 1000
-      - num: 100
-        image: gcr.io/google_containers/pause-amd64:3.0
-        basename: pausepods
+      - total: 100
+      - num: 660
         file: content/pod-pause.json
+        basename: hello
         storage:
           - type: none
-          
+
 quotas:
   - name: default
     file: default
@@ -20,7 +19,7 @@ tuningsets:
   - name: default
     pods:
       stepping:
-        stepsize: 50
-        pause: 60 s
+        stepsize: 100
+        pause: 10 s
       rate_limit:
         delay: 0 ms


### PR DESCRIPTION
Updating the node vertical test to have non hard coded paths and updated to work with the golang cluster loader version 4.7