### PR TITLE
add personas and kuebconfig with context for multiple users

### DIFF
--- a/reliability/config/enhance_reliability.yaml
+++ b/reliability/config/enhance_reliability.yaml
@@ -1,0 +1,40 @@
+reliability:
+  kubeconfig: ~/Downloads/kubeconfig
+  timeSubstitutions:
+    minute: 10s
+    hour: 30s
+    day: 2m
+    week: 3m
+    month: 4m
+  limits:
+    maxProjects: 20
+    # sleepTime should be <= mix of timeSubstitutions in the current design,
+    # or else, tasks with timeSubstitutions < sleepTime will be executed with the interval of sleepTime.
+    sleepTime: 10
+
+  appTemplates:
+    - template: cakephp-mysql-persistent
+    - template: nodejs-postgresql-persistent
+    - template: django-psql-persistent
+    - template: rails-pgsql-persistent
+    - template: dancer-mysql-persistent
+
+  users:
+    - admin_user: kubeadmin
+    - admin_password: R3xrm-uIABR-BB4Za-xaWWF
+    - user_file: /Users/qili/Downloads/users.spec
+  tasks:
+    minute:
+      # - action: login
+      #   resource: session
+      #   persona: admin
+      #   concurrency: 1
+      - action: login
+        resource: session
+        persona: developer
+        concurrency: 3
+      # - action: create
+      #   resource: projects
+      #   quantity: 1
+      #   persona: developer
+      #   concurrency: 2

--- a/reliability/config/simple_reliability.yaml
+++ b/reliability/config/simple_reliability.yaml
@@ -1,4 +1,5 @@
 reliability:
+  kubeconfig: ~/Downloads/kubeconfig
   timeSubstitutions:
     minute: 10s
     hour: 30s
@@ -18,8 +19,8 @@ reliability:
 
   users:
     - admin_user: kubeadmin
-    - admin_password: Pn38G-UyeHS-3uKvF-6zJyU
-    - user_file: /home/mifiedle/mffiedler_git/svt/reliability/config/users.spec  
+    - admin_password: R3xrm-uIABR-BB4Za-xaWWF
+    - user_file: /Users/qili/Downloads/users.spec
   tasks:
     minute:
       - action: check

--- a/reliability/tasks/Contexts.py
+++ b/reliability/tasks/Contexts.py
@@ -1,0 +1,73 @@
+from tasks.utils.oc import oc
+import logging
+import os
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from time import perf_counter
+
+class Contexts:
+    def __init__(self):
+        self.kubeconfigs = {}
+        self.logger = logging.getLogger('reliability')
+        self.cwd = os.getcwd()
+
+    # Create kubeconfig file and add context by login for each user
+    def create_kubeconfigs(self, kubeconfig, users):
+        self.logger.info('Creating kubeconfig files for users...')
+        # clear kubeconfigs folder if already exist and create
+        if os.path.exists(self.cwd + '/kubeconfigs'):
+            shutil.rmtree(self.cwd + '/kubeconfigs')
+        os.mkdir(self.cwd + '/kubeconfigs')
+
+        login_args = []
+        # make a copy of kubeconfig file for each user
+        for name in users:
+            kubeconfig_path = self.cwd + '/kubeconfigs/kubeconfig_' + name
+            if os.path.isfile(kubeconfig_path):
+                os.remove(kubeconfig_path)
+            os.system('cp ' + kubeconfig + ' ' +  kubeconfig_path)
+            self.kubeconfigs[name] = kubeconfig_path
+            login_args.append((users[name].name, users[name].password, kubeconfig_path))
+        self.logger.info('Creating kubeconfig files for users is done.')
+
+        # create context in each kubeconfig files by logging in with each user
+        # run in parallel
+        self.logger.info('Creating context for users...')
+        #start = perf_counter()
+        workers = 51
+        # if max_workers=None, default is 5 * cpu cores
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            results = executor.map(lambda t: self.login(*t), login_args)
+            for result in results:
+                print(result)
+        #end = perf_counter()
+        #print('perf of {} workers is: {} second'.format(workers, end - start))
+        self.logger.info('Creating context for users is done.')
+
+    def login(self, username, password, kubeconfig):
+        result, rc = oc('login -u ' + username + ' -p ' + password, kubeconfig)
+        if rc !=0:
+            self.logger.error('Login with user "{}" failed'.format(username))
+            print(result)
+            return 'Login with user "{}" failed.'.format(username)
+        else:
+            return 'Login with user "{}" successfully.'.format(username)
+
+    def get_kubeconfigs(self):
+        return self.kubeconfigs
+    
+    def init(self):
+        pass
+
+all_contexts = Contexts()
+
+if __name__ == '__main__':
+    class TestUser:
+        def __init__(self):
+            self.name = 'kubeadmin'
+            self.password = 'R3xrm-uIABR-BB4Za-xaWWF'
+    user = TestUser()
+    users = {'kubeadmin': user}
+    all_contexts.create_kubeconfigs('~/Downloads/kubeconfig', users)
+    with open(os.getcwd() + '/kubeconfigs/kubeconfig_kubeadmin') as f:
+        print(f.read())

--- a/reliability/tasks/GlobalData.py
+++ b/reliability/tasks/GlobalData.py
@@ -1,0 +1,44 @@
+from ReliabilityConfig import ReliabilityConfig
+from tasks.Users import all_users, User
+from tasks.Contexts import all_contexts
+import logging
+
+# a class to hold shared data, config, users, kubeconfigs
+class GlobalData:
+
+    def __init__(self):
+        self.config = None
+        self.users = {}
+        self.kubeconfigs = {}
+        self.logger = logging.getLogger('reliability')
+    
+    def load_data(self, config_file):
+        # load config
+        rc = ReliabilityConfig(config_file)
+        rc.load_config()
+        self.config = rc.config['reliability']
+        
+        # load all developer users
+        all_users.init()
+        all_users.load_users(self.config['users'][2]["user_file"])
+        self.users = all_users.get_users()
+        
+        # add admin user
+        admin = User(self.config["users"][0]["admin_user"]
+            ,self.config["users"][1]["admin_password"])
+        self.users[self.config["users"][0]["admin_user"]] = admin
+        
+        # create kubeconfig with contexts for all users
+        all_contexts.init()
+        all_contexts.create_kubeconfigs(self.config['kubeconfig'],self.users)
+        self.kubeconfigs = all_contexts.get_kubeconfigs()
+    
+    def init(self):
+        pass
+
+# make it singleton
+global_data = GlobalData()
+
+if __name__ == "__main__":
+    global_data.load_data('/Users/qili/git/svt/reliability/config/enhance_reliability.yaml')
+    print(global_data.config)

--- a/reliability/tasks/Users.py
+++ b/reliability/tasks/Users.py
@@ -27,8 +27,10 @@ class Users:
         
         if len(self.users) == 0:
             self.logger.warning("load_users: " + user_file + " contained no users")
-        return
     
+    def get_users(self):
+        return self.users
+
     def init(self):
         pass
 

--- a/reliability/tasks/utils/oc.py
+++ b/reliability/tasks/utils/oc.py
@@ -17,11 +17,12 @@ def shell(cmd):
     return string_result, rc
 
 def oc(cmd, config=""):
-    cmd = "oc " + cmd
     rc = 0
     result = ""
     if config:
-        cmd = "KUBECONFIG=" + config + " " + cmd
+        cmd = "oc --kubeconfig " + config + ' ' + cmd
+    else:
+        cmd = "oc " + cmd
     result,rc = shell(cmd)
     return result,rc
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-4095
[Reliability Test Tool Enhancement Plan ](https://docs.google.com/document/d/12n_yOXxZcsaokEE4rt04qpj3z7p9eWiSk4m5UqTEY7U/edit#heading=h.n4ceby94lm77)
1. Add 'persona' and 'concurrency' entries to the config file, in task section, to specify which kind of user this task will be executed by, and how many of users will do this task concurrently.
config file:
```
  tasks:
    minute:
      - action: create
        resource: projects
        quantity: 1
        persona: developer
        concurrency: 2
```
3. To make multiple user to run oc command concurrently, make a copy of kubeconfig file provided by installer for each user, and addd context for each user in each kubeconfig file by doing a login with that user.
Add 'kubeconfig' in config file pointing to the kubeconfig get from the cluster install.
config file:
```
reliability:
  kubeconfig: ~/Downloads/kubeconfig
```

Add a module 'Context' to create the kubeconfig files (copy from the kubeconfig in config file as above) and add contexts.

example context in 'kubeconfig_testuser-0' after login with 'testuser-0'
```
contexts:
- context:
    cluster: api-qili-qe-devcluster-openshift-com:6443
    user: testuser-0/api-qili-qe-devcluster-openshift-com:6443
  name: /api-qili-qe-devcluster-openshift-com:6443/testuser-0
current-context: /api-qili-qe-devcluster-openshift-com:6443/testuser-0
```
The creation of kubeconfig and context will be initiated once before test start. Installer (Flexy install) provides 1 admin users kubeadmin and 50 developer users, testuser-0 to testuser-49. Create kubeadmin user's context directly. Create the 50 developer uesrs' context with multi thread to speed up the initiation work.

3. As the kubeconfigs (and sometimes users) data will not be changed after init and need to be used by all tasks, for convenience, create a singleton  module 'GlobalData' to hold those data. To be consistent, put the config data into this instance too. Modify related modules as needed to adapt to this config data change.

Exit Criteria
1. Reliability test creates 1 admin and 50 developer users' kubeconfig file with context right after test started and before executing tasks. The kubeconfig files are put under a 'kubeconfigs' folder in the same location of the reliability.py. 
2. Edit any previous config files to add 'kubeconfig' and run with it, test should pass.
Add 'kubeconfig' in your config file and point it to the kubeconfig file downloaded from installer.
example:
```
reliability:
  kubeconfig: ~/Downloads/kubeconfig
```
3. Run test with 'enhance_reliability.yaml' to test the multiple users login with kubeconfig files, should pass.