### PR TITLE
Bulk delete

### DIFF
--- a/openshift_performance/ci/content/conc_proj.yaml
+++ b/openshift_performance/ci/content/conc_proj.yaml
@@ -1,14 +1,13 @@
 projects:
-  - num: 1
-    basename: clusterproject
+  - basename: clusterproject
     ifexists: default
+    num: 1000
     tuning: default
-
 tuningsets:
   - name: default
     pods:
-      stepping:
-        stepsize: 5
-        pause: 10 s
       rate_limit:
         delay: 250 ms
+      stepping:
+        pause: 10 s
+        stepsize: 5

--- a/openshift_performance/ci/content/pyconfigLoadedProject.yaml
+++ b/openshift_performance/ci/content/pyconfigLoadedProject.yaml
@@ -1,0 +1,26 @@
+projects:
+  - basename: clusterproject
+    ifexists: delete
+    num: 10
+    tuning: default
+    templates:
+      - file: ../../../openshift_scalability/content/build-config-template.json
+        num: 10
+      - file: ../../../openshift_scalability/content/build-template.json
+        num: 10
+      - file: ../../../openshift_scalability/content/image-stream-all-template.json
+        num: 20
+      - file: ../../../openshift_scalability/content/ssh-secret-template.json
+        num: 200
+      - file: ../../../openshift_scalability/content/route-template.json
+        num: 10
+quotas:
+  - name: default
+tuningsets:
+  - name: default
+    pods:
+      rate_limit:
+        delay: 250 ms
+      stepping:
+        pause: 5 s
+        stepsize: 20

--- a/openshift_performance/ci/scripts/bulk_delete.sh
+++ b/openshift_performance/ci/scripts/bulk_delete.sh
@@ -1,0 +1,65 @@
+#/!/bin/bash
+#set -x
+################################################
+## Auth=prubenda@redhat.com
+## Desription: Script for running bulk delete
+## of empty and loaded projects and comparing times
+################################################
+file_1="../content/conc_proj.yaml"
+file_2="../content/pyconfigLoadedProject.yaml"
+delete_output=bulk_delete.out
+function create_projects()
+{
+  python ../../../openshift_scalability/cluster-loader.py -f $1
+}
+
+function delete_projects() {
+  ./delete_projects.sh
+}
+
+function rewrite_yaml() {
+  python3 -c "import increase_pods; increase_pods.print_new_yaml($1,'$2')"
+}
+
+python3 -m pip install ruamel.yaml
+
+rm -if $delete_output
+
+oc version >> $delete_output
+
+oc get machinesets -A >> $delete_output
+echo "=====Empty projects======"  >> $delete_output
+rewrite_yaml 500 $file_1
+create_projects $file_1
+
+echo "Deleting 500 empty projects\n" >> $delete_output
+delete_projects >> $delete_output
+
+rewrite_yaml 1000 $file_1
+create_projects $file_1
+
+echo "Deleting 1000 empty projects\n" >> $delete_output
+delete_projects >> $delete_output
+
+#edit conc_proj to have 5000 projects
+rewrite_yaml 5000 $file_1
+create_projects $file_1
+
+echo "Deleting 5000 empty projects\n" >> $delete_output
+delete_projects >> $delete_output
+#
+echo "=====Loaded projects======"
+rewrite_yaml 500 $file_2
+create_projects $file_2
+
+echo "Deleting 500 loaded projects" >> $delete_output
+delete_projects >> $delete_output
+
+#edit pyconfigLoadedProject.yaml  to have 1000 projects
+rewrite_yaml 1000 $file_2
+create_projects $file_2
+
+echo "Deleting 1000 loaded projects" >> $delete_output
+delete_projects >> $delete_output
+
+cat $delete_output

--- a/openshift_performance/ci/scripts/compare_bulk_delete.py
+++ b/openshift_performance/ci/scripts/compare_bulk_delete.py
@@ -1,0 +1,83 @@
+import re
+import sys
+
+def percent_difference(new, old):
+
+    response = (new - old)/old*100
+    return response
+
+def compare_delete_timing(json_1, json_2):
+    for k1, v1 in json_1.items():
+        for k2, v2 in json_2.items():
+            if k1 == k2:
+                print('\tnumber of projects ' + str(k1))
+                delete_compare = percent_difference(v1, v2)
+                print('\t\tdeletion compare: ' + str(delete_compare) + "%")
+
+
+def read_file(file):
+    all_file = []
+
+    delete_split = file.split('\n')
+    i = 0
+    proj_dict = {'empty': {}, 'loaded': {}}
+    empty = True
+    for delete_line in delete_split:
+        # each set of info is 2 lines:
+        # 1 line number and type of projects
+        # line 2 is deletion time
+        if "delet" not in delete_line.lower():
+            i = 0
+            continue
+        elif delete_line in ["", "\n"]:
+            i = 0
+            continue
+        elif i == 0:
+            delete_num = int(delete_line.split(' ')[-3])
+            i += 1
+            if "empty" in delete_line:
+                empty = True
+            else:
+                empty = False
+
+        else:
+            #might just have to ignore first and last items in last
+            delete_time = delete_line.split(" - ")[-1]
+            if empty:
+                proj_dict['empty'][delete_num] = int(delete_time)
+            else:
+                proj_dict['loaded'][delete_num] = int(delete_time)
+            i = 0
+    return proj_dict
+
+if len(sys.argv) > 3 or len(sys.argv) <= 2:
+    print("Need 2 delete output files to compare")
+    sys.exit(1)
+
+#get command line parameters
+file_1 = sys.argv[1]
+file_2 = sys.argv[2]
+
+with open(file_1, "r") as f1:
+    f1_content = f1.read()
+
+f1_list = read_file(f1_content)
+
+with open(file_2, "r") as f2:
+    f2_content = f2.read()
+
+f2_list = read_file(f2_content)
+
+for k1, v1 in f1_list.items():
+    for k2, v2 in f2_list.items():
+        if k1 == k2:
+            print('Comparing deletion time of ' + str(k1) + ' projects')
+            compare_delete_timing(v1, v2)
+
+
+
+
+
+
+
+

--- a/openshift_performance/ci/scripts/delete_projects.sh
+++ b/openshift_performance/ci/scripts/delete_projects.sh
@@ -1,7 +1,7 @@
 function delete_projects()
 {
-  echo "deleting projects"
-  oc delete project -l purpose=test
+  echo "deleting projects" >> delete.out
+  oc delete project -l purpose=test >> delete.out
 }
 
 function wait_for_project_termination()
@@ -10,7 +10,7 @@ function wait_for_project_termination()
   while [ $terminating -ne 0 ]; do
   sleep 5
   terminating=`oc get projects | grep Terminating | wc -l`
-  echo "$terminating projects are still terminating"
+  echo "$terminating projects are still terminating" >> delete.out
   done
 }
 

--- a/openshift_performance/ci/scripts/increase_pods.py
+++ b/openshift_performance/ci/scripts/increase_pods.py
@@ -1,0 +1,38 @@
+import subprocess
+#pip install ruamel.yaml
+from ruamel.yaml import YAML
+
+
+def run(command):
+    try:
+        output = subprocess.Popen(command, shell=True,
+                                  universal_newlines=True, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+        (out, err) = output.communicate()
+        print("Out " + str(out))
+    except Exception as e:
+        print("Failed to run %s, error: %s" % (command, e))
+    return out
+
+
+def print_new_yaml(num, fileName):
+    # append to file
+    yaml = YAML()
+    with open(fileName, "r") as f:
+        yaml_file = yaml.load(f)
+        yaml_file['projects'][0]['num'] = num
+    with open(fileName, "w+") as f:
+        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.dump(yaml_file, f)
+
+
+def print_new_yaml_temp(num, fileName):
+    # append to file
+    yaml = YAML()
+    with open(fileName, "r") as f:
+        yaml_file = yaml.load(f)
+        yaml_file['projects'][0]['templates'][0]['num'] = num
+    with open(fileName, "w+") as f:
+        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.dump(yaml_file, f)
+


### PR DESCRIPTION
Full script for [TC](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-14475)

This test case takes a very very long time to run. For testing might be easier to reduce numbers. 

I edited the delete_projects script so that the output of deleting each of the projects goes to a file and the timing will be put to stdout, let me know if I should change this. 

For the correct spacing when rewriting I had to use a python3 pip package but cluster loader needs python2 currently. So had to specify the python version when running the rewrite script. Let me know if you don't think this will work or if there's a better way 