### PR TITLE
add concurrency to reliability test

### DIFF
--- a/reliability/ReliabilityConfig.py
+++ b/reliability/ReliabilityConfig.py
@@ -9,8 +9,8 @@ class ReliabilityConfig:
         self.config = []
 
     def load_config(self):
-        f = open(self.config_file)
-        self.config = yaml.load(f)
+        with open(self.config_file) as f:
+            self.config = yaml.safe_load(f)
 
 if __name__ == "__main__":
     rc = ReliabilityConfig("/home/mifiedle/mffiedler_git/svt/reliability/nextgen/config/simple_reliability.yaml")

--- a/reliability/config/enhance_reliability.yaml
+++ b/reliability/config/enhance_reliability.yaml
@@ -1,15 +1,16 @@
 reliability:
-  kubeconfig: ~/Downloads/kubeconfig
+  kubeconfig: <path_to_kubeconfig>
   timeSubstitutions:
-    minute: 10s
-    hour: 30s
+    minute: 30s
+    hour: 1m
     day: 2m
-    week: 3m
-    month: 4m
+    week: 6m
+    month: 6m
   limits:
-    maxProjects: 20
-    # sleepTime should be <= mix of timeSubstitutions in the current design,
-    # or else, tasks with timeSubstitutions < sleepTime will be executed with the interval of sleepTime.
+    # total number of projects to create
+    # for 3 nodes m5.xlarge cluster, 30 is recomended
+    # for 5 nodes m5.xlarge cluster, 60 is recomended
+    maxProjects: 25
     sleepTime: 10
 
   appTemplates:
@@ -18,23 +19,63 @@ reliability:
     - template: django-psql-persistent
     - template: rails-pgsql-persistent
     - template: dancer-mysql-persistent
-
   users:
-    - admin_user: kubeadmin
-    - admin_password: <password>
-    - user_file: /Users/qili/Downloads/users.spec
+    - kubeadmin_file: <path_to_kubeadmin-password>
+    - user_file: <path_to_users.spec>
   tasks:
     minute:
-      # - action: login
-      #   resource: session
-      #   persona: admin
-      #   concurrency: 1
+      - action: check
+        resource: pods
+        persona: admin
+        concurrency: 1
+      - action: check
+        resource: projects
+        persona: developer
+        concurrency: 5
+    hour:
+      - action: check
+        resource: projects
+        persona: developer
+        concurrency: 5
+      - action: create
+        resource: projects
+        quantity: 2
+        persona: developer
+        concurrency: 5
+      - action: visit
+        resource: apps
+        applyPercent: 100
+        persona: user
+        concurrency: 10
+      - action: scaleUp
+        resource: apps
+        applyPercent: 50
+        persona: developer
+        concurrency: 3
+      - action: scaleDown
+        resource: apps
+        applyPercent: 50
+        persona: developer
+        concurrency: 1
+      - action: build
+        resource: apps
+        applyPercent: 33
+        persona: developer
+        concurrency: 2
+      - action: modify
+        resource: projects
+        applyPercent: 25
+        persona: developer
+        concurrency: 2
+      - action: clusteroperators
+        resource: monitor
+    week:
+      - action: delete
+        resource: projects
+        applyPercent: 33
+        persona: developer
+        concurrency: 5
       - action: login
         resource: session
         persona: developer
-        concurrency: 3
-      # - action: create
-      #   resource: projects
-      #   quantity: 1
-      #   persona: developer
-      #   concurrency: 2
+        concurrency: 5

--- a/reliability/config/simple_reliability.yaml
+++ b/reliability/config/simple_reliability.yaml
@@ -1,5 +1,5 @@
 reliability:
-  kubeconfig: ~/Downloads/kubeconfig
+  kubeconfig: <path_to_kubeconfig>
   timeSubstitutions:
     minute: 10s
     hour: 30s
@@ -7,6 +7,9 @@ reliability:
     week: 3m
     month: 4m
   limits:
+    # total number of projects to create
+    # for 3 nodes m5.xlarge cluster, 30 is recomended
+    # for 5 nodes m5.xlarge cluster, 60 is recomended
     maxProjects: 20
     sleepTime: 10
 
@@ -18,45 +21,66 @@ reliability:
     - template: dancer-mysql-persistent
 
   users:
-    - admin_user: kubeadmin
-    - admin_password: <password>
-    - user_file: /Users/qili/Downloads/users.spec
+    - kubeadmin_file: <path_to_kubeadmin-password>
+    - user_file: <path_to_users.spec>
   tasks:
     minute:
       - action: check
         resource: pods
+        persona: admin
+        concurrency: 1
       - action: check
         resource: projects
+        persona: developer
+        concurrency: 2
       - action: create
         resource: projects
         quantity: 1
+        persona: developer
+        concurrency: 2
     hour:
       - action: check
         resource: projects
+        persona: developer
+        concurrency: 2
       - action: visit
         resource: apps
         applyPercent: 100
+        persona: user
+        concurrency: 10
       - action: create
         resource: projects
         quantity: 1
+        persona: developer
+        concurrency: 2
       - action: scaleUp
         resource: apps
         applyPercent: 50
+        persona: developer
+        concurrency: 2
       - action: scaleDown
         resource: apps
         applyPercent: 50
+        persona: developer
+        concurrency: 2
       - action: build
         resource: apps
         applyPercent: 33
+        persona: developer
+        concurrency: 2
       - action: modify
         resource: projects
         applyPercent: 25
+        persona: developer
+        concurrency: 2
     week:
       - action: delete
         resource: projects
         applyPercent: 25
+        persona: developer
+        concurrency: 2
       - action: login
         resource: session
-        user: testuser-47
-        password: LNrHdFaoJh9X
+        persona: developer
+        concurrency: 5
 

--- a/reliability/tasks/GlobalData.py
+++ b/reliability/tasks/GlobalData.py
@@ -1,7 +1,9 @@
 from ReliabilityConfig import ReliabilityConfig
 from tasks.Users import all_users, User
 from tasks.Contexts import all_contexts
+from threading import Lock
 import logging
+import time
 
 # a class to hold shared data, config, users, kubeconfigs
 class GlobalData:
@@ -10,6 +12,14 @@ class GlobalData:
         self.config = None
         self.users = {}
         self.kubeconfigs = {}
+        self.project_id_lock = Lock()
+        self.projects_lock = Lock()
+        self.apps_lock = Lock()
+        self.builds_lock = Lock()
+        self.total_build_count = 0
+        self.app_visit_succeeded = 0
+        self.app_visit_failed = 0
+        self.last_login_time = time.time()
         self.logger = logging.getLogger('reliability')
     
     def load_data(self, config_file):
@@ -18,20 +28,20 @@ class GlobalData:
         rc.load_config()
         self.config = rc.config['reliability']
         
-        # load all developer users
         all_users.init()
-        all_users.load_users(self.config['users'][2]["user_file"])
+        # load all developer users
+        all_users.load_users(self.config['users'][1]["user_file"])
+              
+        # load admin user
+        all_users.load_admin(self.config['users'][0]["kubeadmin_file"])
+
         self.users = all_users.get_users()
-        
-        # add admin user
-        admin = User(self.config["users"][0]["admin_user"]
-            ,self.config["users"][1]["admin_password"])
-        self.users[self.config["users"][0]["admin_user"]] = admin
         
         # create kubeconfig with contexts for all users
         all_contexts.init()
         all_contexts.create_kubeconfigs(self.config['kubeconfig'],self.users)
-        self.kubeconfigs = all_contexts.get_kubeconfigs()
+        self.last_login_time = time.time()
+        self.kubeconfigs = all_contexts.kubeconfigs
     
     def init(self):
         pass

--- a/reliability/tasks/Monitor.py
+++ b/reliability/tasks/Monitor.py
@@ -1,3 +1,4 @@
+from .GlobalData import global_data
 from .utils.oc import oc
 import logging
 import yaml
@@ -7,7 +8,9 @@ class Monitor:
         self.logger = logging.getLogger('reliability')
 
     def check_operators(self):
-        (result, rc) = oc("get clusteroperators -o yaml")
+        # This operation can only be done by admin user
+        kubeconfig = global_data.kubeconfigs["kubeadmin"]
+        (result, rc) = oc("get clusteroperators --kubeconfig " + kubeconfig + " -o yaml")
         if rc != 0:
             self.logger.error("get clusteroperators: failed")
         else:

--- a/reliability/tasks/Pods.py
+++ b/reliability/tasks/Pods.py
@@ -6,10 +6,11 @@ class Pods:
     def __init__(self):
         self.logger = logging.getLogger('reliability')
 
-    def check(self):
-        (result, rc) = shell('oc get pods --all-namespaces| egrep -v "Running|Complete"')
-        if rc != 0:
-           self.logger.error("get pods: failed")
+    def check(self, namespace, kubeconfig):
+        if namespace.startswith("all-namespaces"):
+            (result, rc) = shell('oc get pods -A --kubeconfig ' + kubeconfig + '| egrep -v "Running|Complete"')
+        else:
+            (result, rc) = shell('oc get pods --kubeconfig ' + kubeconfig + ' -n ' + namespace + '| egrep -v "Running|Complete"')
 
     def init(self):
         pass

--- a/reliability/tasks/Projects.py
+++ b/reliability/tasks/Projects.py
@@ -1,72 +1,91 @@
+from .GlobalData import global_data
 from .utils.oc import oc
 from .utils.utils import random_string
 from .Apps import App, all_apps
 import logging
+import random
 
 
 class Project:
-    def __init__(self, name):
+    def __init__(self, name, user):
         self.name = name
+        self.user = user
         self.app = None
         self.logger = logging.getLogger('reliability')
 
-    def modify(self):
+    def modify(self, kubeconfig):
         key = random_string(8)
         value = random_string(256)
-        (result, rc) = oc("create secret generic -n " + self.name + " " + key + " --from-literal=" + key + "=" + value)
+        (result, rc) = oc("create secret generic -n " + self.name + " " + key + " --from-literal=" + key + "=" + value, kubeconfig)
         if rc !=0 :
             self.logger.error("modify project: Secret creation failed")
-
-
-
+            return "Project modify failed : " + self.name
+        else :
+            return "Project modify succeeded : " + self.name
 
 class Projects:
     def __init__(self):
         self.projects = {}
-        self.next_id = 0
+        self.next_ids = {}
         self.max_projects = 10
         self.current_projects = 0
         self.total_projects = 0
         self.logger = logging.getLogger('reliability')
 
-    def add(self, name):
-        name = name + "-" + str(self.next_id)
-
-        if self.current_projects == self.max_projects:
-            self.logger.warning("create_project: project " + name + ". " + str(self.max_projects) + " already exist.")
+    def add(self, user, kubeconfig):    
+        # use project_id_lock to protect shared mutable counter next_ids
+        with global_data.project_id_lock:
+            if user not in self.next_ids:
+                self.next_ids[user] = 1
+            else:
+                self.next_ids[user] += 1
+        name = user + "-" + str(self.next_ids[user])
+        self.logger.debug("current projects: "+ str(self.current_projects))
+        self.logger.debug("max projects: "+ str(self.max_projects))
+        if self.current_projects >= self.max_projects:
+            self.logger.warning("create_project: project " + name + " aborted. " + str(self.max_projects) + " projects already exist.")
             return None
         if name in self.projects:
             self.logger.error("create_project: project " + name + " already exists.")
             return None
 
-        new_project = Project(name)
-        (result, rc) = oc("new-project --skip-config-write " + name)
-        self.next_id += 1
-        self.current_projects += 1
-        self.total_projects += 1
+        new_project = Project(name, user)
+        (result, rc) = oc("new-project --skip-config-write " + name, kubeconfig)
 
         if rc == 0:
             self.projects[name] = new_project
-            oc("label namespace " + name + " purpose=reliability")
+            # developer is forbidden to patch resource "namespaces"
+            kubeconfig_admin = global_data.kubeconfigs["kubeadmin"]
+            oc("label namespace " + name + " purpose=reliability", kubeconfig_admin)
+            # use projects_lock to protect shared mutable counters current_projects and total_projects
+            with global_data.projects_lock:
+                self.current_projects += 1
+                self.total_projects += 1
+            self.logger.debug("total projects: "+ str(self.total_projects))
+        # in case project already exists before test start
+        else:
+            return None
 
         return new_project
 
-    def delete(self, name):
+    def delete(self, name, kubeconfig):
         if not (name in self.projects): 
             self.logger.error("delete_project: project " + name + " does not exist" )
-        oc("delete project --wait=false " + name)
+        oc("delete project --wait=false " + name, kubeconfig)
         all_apps.init()
         app_to_remove = self.projects[name].app        
         all_apps.remove(app_to_remove)
 
-        self.current_projects -= 1
+        with global_data.projects_lock:
+            self.current_projects -= 1
 
         # remove project from projects even if fails - suspect and should not be used
         self.projects.pop(name)
 
-    def check_projects(self):
-        oc("get projects -o wide -l purpose=reliability")
+        return "Project deleted : " + name
 
+    def check_projects(self, kubeconfig):
+        oc("get projects -o wide -l purpose=reliability", kubeconfig)
 
     def get_project(self, name) :
         project = None
@@ -76,9 +95,8 @@ class Projects:
             project = self.projects[name]
         return project
 
-   
-    def reconcile(self):
-        (result,rc) = oc("get projects -l purpose=reliability --no-headers | cut -f1 -d\" \"")
+    def reconcile(self, kubeconfig):
+        (result,rc) = oc("get projects -l purpose=reliability --no-headers | cut -f1 -d\" \"", kubeconfig)
         if rc == 0:
             actual_project_list = result.split('\n')
             for this_project in actual_project_list:

--- a/reliability/tasks/Session.py
+++ b/reliability/tasks/Session.py
@@ -1,0 +1,18 @@
+from  .utils.oc import oc
+import logging
+
+class Session:
+    def __init__(self):
+        self.logger = logging.getLogger('reliability')
+
+    def login(self, username, password, kubeconfig):
+        result, rc = oc('login -u ' + username + ' -p ' + password, kubeconfig)
+        if rc !=0:
+            self.logger.error(f"Login with user {username} failed")
+            self.logger.info(result)
+            return f"Login with user {username} failed"
+        else:
+            return f"Login with user {username} successfully."
+
+    def init(self):
+        pass

--- a/reliability/tasks/Task.py
+++ b/reliability/tasks/Task.py
@@ -4,20 +4,20 @@ from .Projects import all_projects
 from .Projects import Projects
 from .Pods import all_pods
 from .Monitor import monitor
+from .Session import Session
 from .utils.oc import oc
+from .utils.LoadApp import LoadApp
 import random
 import logging
-import os
 import time
 from concurrent.futures import ThreadPoolExecutor
-
+import asyncio
 
 class Task:
     def __init__(self, task):
         self.task = task
         self.templates = global_data.config["appTemplates"]
         self.logger = logging.getLogger('reliability')
-        self.cwd = os.getcwd()
         random.seed()
 
     def get_targets(self, candidates, percent):
@@ -50,49 +50,100 @@ class Task:
         persona = self.task.setdefault("persona","admin")
         concurrency = self.task.setdefault("concurrency",1)
 
-        # prepare concurrency number of kubeconfigs
-        kubeconfigs = []
+        # prepare concurrency number of users
+        users = []
+        # ThreadPoolExecutor workers
+        workers = 0
 
         if persona == "admin":
-                kubeconfigs.append(global_data.kubeconfigs["kubeadmin"])
+                users.append("kubeadmin")
+                workers = 1
         elif persona == "developer":
             for i in range(0, concurrency):
-                name = "testuser-" + str(i)
-                kubeconfigs.append(global_data.kubeconfigs[name])
+                users.append("testuser-" + str(i))
+                workers += 1
 
         # Project actions
         if resource == "projects":
             if action == "create":
                 self.logger.debug("create projects")
                 quantity = self.task["quantity"]
+                template = random.choice(global_data.config["appTemplates"])["template"]
                 for i in range(0, quantity):
-                    project_base_name = random.choice(self.templates)["template"]
-                    new_project = all_projects.add(project_base_name)
-                    if new_project != None:
-                        if new_project.name.startswith("eap"):
-                            app = App("eap-app", new_project.name, project_base_name, "eap-app")
-                        else:
-                            app = App(project_base_name, new_project.name, project_base_name, project_base_name)
-                        new_project.app = app
-                        all_apps.add(app) 
-                    # with ThreadPoolExecutor() as pool:
-                    #     results = pool.map(all_projects.add, kubeconfigs)
-                    #     for result in results:
-                    #         print(result)          
+                    projects = []
+                    # prepare parameters list - user and kubeconfig - for all_projects.add
+                    project_create_args = []
+                    for user in users:
+                        kubeconfig = global_data.kubeconfigs[user]
+                        project_create_args.append((user, kubeconfig))
+                    # create project concurrently
+                    with ThreadPoolExecutor(max_workers=workers) as executor:
+                        results =  executor.map(lambda t: all_projects.add(*t), project_create_args)
+                        for result in results:
+                            if result != None:
+                                projects.append(result)
+                                self.logger.info(f"Project added is: {result.name}")
+                    if len(projects) > 0:
+                        # prepare parameters list - app name and kubeconfig - for all_apps.add
+                        app_add_args = []
+                        for project in projects:             
+                            if template.startswith("eap"):
+                                app = App("eap-app", project.name, template, "eap-app")
+                            else:
+                                app = App(template, project.name, template, template)
+                            kubeconfig = global_data.kubeconfigs[project.user]
+                            app_add_args.append((app, kubeconfig))
+                        # add app for all projects created concurrently
+                        with ThreadPoolExecutor(max_workers=workers) as executor:
+                            results =  executor.map(lambda t: all_apps.add(*t), app_add_args)
+                            for result in results:
+                                if result != None:
+                                    all_projects.projects[result.project].app = result
+                                    self.logger.info(f"App added to project: {result.project}.")
+                                
             elif action == "delete":
                 self.logger.debug("delete projects")
                 projects = list(all_projects.projects.keys())
                 projects_to_delete = self.get_targets(projects,self.get_percent())
+                # prepare parameters list - project name and kubeconfig - for all_projects.delete
+                project_delete_args = []
                 for project_to_delete in projects_to_delete:
-                    all_projects.delete(project_to_delete)
+                    user = all_projects.projects[project_to_delete].user
+                    kubeconfig = global_data.kubeconfigs[user]
+                    project_delete_args.append((project_to_delete,kubeconfig))
+                # delete projects concurrently
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results = executor.map(lambda t: all_projects.delete(*t), project_delete_args)
+                    for result in results:
+                        self.logger.info(result)
+
             elif action == "check":
                 self.logger.debug("check projects")
-                all_projects.check_projects()
+                # check projects concurrently
+                kubeconfigs = []
+                for user in users:
+                    kubeconfigs.append(global_data.kubeconfigs[user])
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results =  executor.map(all_projects.check_projects, kubeconfigs)
+
             elif action == "modify":
                 projects = list(all_projects.projects.keys())
                 projects_to_modify = self.get_targets(projects, self.get_percent())
+                # prepare parameters list - project name and kubeconfig - for project.modify
+                project_modify_args = []
                 for project_to_modify in projects_to_modify:
-                    all_projects.projects[project_to_modify].modify()
+                    # to avoid the project being deleted -async after getting the list.
+                    try: 
+                        user = all_projects.projects[project_to_modify].user
+                        kubeconfig = global_data.kubeconfigs[user]
+                        project_modify_args.append((project_to_modify, kubeconfig))
+                    except KeyError:
+                        self.logger.info(f"Projet {project_to_modify} no longer exists in projects list.")
+                # modify projects concurrently
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results = executor.map(lambda t: all_projects.projects[t[0]].modify(t[1]), project_modify_args)
+                    for result in results:
+                        self.logger.info(result)
 
         # Application actions
         elif resource == "apps":
@@ -101,45 +152,113 @@ class Task:
                 if len(all_apps.apps) > 0:
                     apps = list(all_apps.apps.keys())
                     apps_to_build = self.get_targets(apps, self.get_percent())
+                    # prepare parameters list - app name and kubeconfig - for app.build
+                    app_build_args = []
                     for app_to_build in apps_to_build:
-                        all_apps.apps[app_to_build].build()
+                        try:
+                            project = all_apps.apps[app_to_build].project
+                            user = all_projects.projects[project].user
+                            kubeconfig = global_data.kubeconfigs[user]
+                            app_build_args.append((app_to_build, kubeconfig))
+                        except KeyError:
+                            self.logger.info(f"Application {app_to_build} no longer exists in apps list.")
+                    # add apps concurrently
+                    with ThreadPoolExecutor(max_workers=workers) as executor:
+                        results = executor.map(lambda t: all_apps.apps[t[0]].build(t[1]), app_build_args)
+                        for result in results:
+                            self.logger.info(result)
+
             elif action == "scaleUp":
                 self.logger.debug("ScaleUp apps")
-                apps = list(all_apps.apps.keys())
-                apps_to_scale = self.get_targets(apps, self.get_percent())
-                for app_to_scale in apps_to_scale:
-                    all_apps.apps[app_to_scale].scale_up()
+                if len(all_apps.apps) > 0:
+                    apps = list(all_apps.apps.keys())
+                    apps_to_scale = self.get_targets(apps, self.get_percent())
+                    # prepare parameters list - app name and kubeconfig - for app.scale_up
+                    app_scale_args = []
+                    for app_to_scale in apps_to_scale:
+                        try:
+                            project = all_apps.apps[app_to_scale].project
+                            user = all_projects.projects[project].user
+                            kubeconfig = global_data.kubeconfigs[user]
+                            app_scale_args.append((app_to_scale, kubeconfig))
+                        except KeyError:
+                            self.logger.info(f"Application {app_to_scale} no longer exists in apps list.")
+                    # scale up apps concurrently
+                    with ThreadPoolExecutor(max_workers=workers) as executor:
+                        results = executor.map(lambda t: all_apps.apps[t[0]].scale_up(t[1]), app_scale_args)
+                        for result in results:
+                            self.logger.info(result)
+
             elif action =="scaleDown":
                 self.logger.debug("ScaleDown apps")
-                apps = list(all_apps.apps.keys())
-                apps_to_scale = self.get_targets(apps, self.get_percent())
-                for app_to_scale in apps_to_scale:
-                    all_apps.apps[app_to_scale].scale_down()
+                if len(all_apps.apps) > 0:
+                    apps = list(all_apps.apps.keys())
+                    apps_to_scale = self.get_targets(apps, self.get_percent())
+                    # prepare parameters list - app name and kubeconfig - for app.scale_down
+                    app_scale_args = []
+                    for app_to_scale in apps_to_scale:
+                        try:
+                            project = all_apps.apps[app_to_scale].project
+                            user = all_projects.projects[project].user
+                            kubeconfig = global_data.kubeconfigs[user]
+                            app_scale_args.append((app_to_scale, kubeconfig))
+                        except KeyError:
+                            self.logger.info(f"Application {app_to_scale} no longer exists in apps list.")
+                    # add down apps concurrently
+                    with ThreadPoolExecutor(max_workers=workers) as executor:
+                        results = executor.map(lambda t: all_apps.apps[t[0]].scale_down(t[1]), app_scale_args)
+                        for result in results:
+                            self.logger.info(result)
                 #time.sleep(30)
+
+            # using coroutines for concurrent app visit
             elif action == "visit":
                 self.logger.debug("Visit Apps")
-                apps = list(all_apps.apps.keys())
-                apps_to_scale = self.get_targets(apps, self.get_percent())
-                for app_to_scale in apps_to_scale:
-                    all_apps.apps[app_to_scale].visit()
+                if len(all_apps.apps) > 0:
+                    loadApp = LoadApp()
+                    urls = []
+                    apps = list(all_apps.apps.keys())
+                    apps_to_visit = self.get_targets(apps, self.get_percent())
+                    for app_to_visit in apps_to_visit:
+                        urls.append("http://" + all_apps.apps[app_to_visit].route + "/")
+                    loadApp.set_tasks(urls, concurrency)
+                    loop = asyncio.get_event_loop()
+                    loop.run_until_complete(asyncio.wait(loadApp.tasks))
+                    global_data.app_visit_succeeded += loadApp.app_visit_succeeded
+                    global_data.app_visit_failed += loadApp.app_visit_failed
+                    self.logger.info(f"Succeeded visit: {str(loadApp.app_visit_succeeded)}. Failed visit: {str(loadApp.app_visit_failed)}")
+
         elif resource == "pods":
             if action == "check":
                 self.logger.debug("Check pods")
-                all_pods.check()
+                # prepare parameters list - project name and kubeconfig - for all_pods.check
+                pod_check_args = []
+                for user in users:
+                    kubeconfig = global_data.kubeconfigs[user]
+                    if user == "kubeadmin":
+                        pod_check_args.append(("all-namespaces", kubeconfig))
+                    else:
+                        for project in all_projects.projects.values():
+                            if project.user == user:
+                                pod_check_args.append((project.name, kubeconfig))
+                # check pods concurrently
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results = executor.map(lambda t: all_pods.check(*t), pod_check_args)
 
         # Session actions
         elif resource == "session" :
             if action == "login":
-                for i in range (0, concurrency):
-                    if persona == "admin":
-                        name = "kubeadmin"
-                    elif persona == "developer":
-                        name = "testuser-" + str(i)
-                    password = global_data.users[name].password
-                    kubeconfig = global_data.kubeconfigs[name]
-                    result, rc = oc("login -u " + name + " -p " + password + " --kubeconfig " + kubeconfig)
-                    if rc !=0 :
-                        self.logger.error("Login failed")
+                login_args = []
+                for user in users:
+                    password = global_data.users[user].password
+                    kubeconfig = global_data.kubeconfigs[user]
+                    login_args.append((user, password, kubeconfig))
+                # login concurrently
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results = executor.map(lambda t: Session().login(*t), login_args)
+                    for result in results:
+                        self.logger.info(result)
+
         elif resource == "monitor" :
             if action == "clusteroperators":
                 self.logger.debug("Monitor clusteroperators")

--- a/reliability/tasks/Users.py
+++ b/reliability/tasks/Users.py
@@ -15,12 +15,12 @@ class Users:
 
     def load_users(self,user_file):
         try:
-            f = open(user_file)
-            reader = csv.reader(f)
-            user_list = list(reader)
-            for user_entry in user_list[0]:
-                name,password = user_entry.split(':')
-                self.users[name] = User(name,password)
+            with open(user_file) as f:
+                reader = csv.reader(f)
+                user_list = list(reader)
+                for user_entry in user_list[0]:
+                    name,password = user_entry.split(':')
+                    self.users[name] = User(name,password)
 
         except Exception as e:
             self.logger.warning("load_users: " + user_file + " failed to load or does not exist: " + str(e))
@@ -28,6 +28,14 @@ class Users:
         if len(self.users) == 0:
             self.logger.warning("load_users: " + user_file + " contained no users")
     
+    def load_admin(self, kubeadmin_file):
+        try:
+            with open(kubeadmin_file) as f:
+                password = f.read()
+                self.users["kubeadmin"] = User("kubeadmin", password)
+        except Exception as e:
+            self.logger.warning("load_admin: " + kubeadmin_file + " failed to load or does not exist: " + str(e))
+
     def get_users(self):
         return self.users
 

--- a/reliability/tasks/utils/LoadApp.py
+++ b/reliability/tasks/utils/LoadApp.py
@@ -1,0 +1,42 @@
+import logging
+from aiohttp import ClientSession
+import asyncio
+from time import perf_counter
+
+
+class LoadApp():
+    def __init__(self):
+        self.logger = logging.getLogger('reliability')
+        self.app_visit_succeeded = 0
+        self.app_visit_failed = 0
+        self.tasks = []
+
+    async def get(self, url):
+        # To simulate differnt users accessing same app, do not reuse session
+        async with ClientSession() as session:
+            async with session.get(url) as response:
+                code = response.status
+                result = await response.text()
+                self.logger.info(f"{str(code)} : load: {url}")
+                #print (f"{str(code)} : load: {url}")
+                if code == 200:
+                    self.app_visit_succeeded += 1
+                else:
+                    self.app_visit_failed += 1
+
+    def set_tasks(self, urls, num):
+        for url in urls:
+            for i in range(num):
+                task = asyncio.ensure_future(self.get(url))
+                self.tasks.append(task)
+
+if __name__ == "__main__":
+    loadApp = LoadApp()
+    urls = ["https://www.google.com",]
+    concurrency = 10
+    loadApp.set_tasks(urls, concurrency)
+    loop = asyncio.get_event_loop()
+    start = perf_counter()
+    loop.run_until_complete(asyncio.wait(loadApp.tasks))
+    end = perf_counter()
+    print(f"Perf of {concurrency} visits is: {end - start} second.")


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-4221
[Reliability Test Tool Enhancement Plan ](https://docs.google.com/document/d/12n_yOXxZcsaokEE4rt04qpj3z7p9eWiSk4m5UqTEY7U/edit#heading=h.n4ceby94lm77)

### Concurrent task run with multiple users - priority 0-1
**What**
Today the test execution is sequentially with default user system:admin and then as the user specified in the "login" action.
This task is to add concurrency for each type of user added in [phase 1](https://issues.redhat.com/browse/OCPQE-4095).
X admin/developer users can run m tasks(oc commands) concurrently. (currently only one admin user in config yaml structure, can restructure in the future)
Y end users can visit n applications concurrently

**Why**
1. Simulate concurrent operations from different users like the real world.
2. Shorten the time of test execution.
For example, for 51 users doing the login operation:
sequentially: 243.6s
concurrently(51 threads): 13.0s

**How**
1. According to the setting of task in config file, choose 'concurrency' number of users for each 'persona' (admin, developer, user). With the config below, 'testuser-0' and 'testuser-1' will execute the project create operation concurrently, while 10 end users will visit all (100%) applications - every application will be visited by 10 users concurrently.
```
      - action: create
        resource: projects
        quantity: 2
        persona: developer
        concurrency: 2
      - action: visit
        resource: apps
        applyPercent: 100
        persona: user
        concurrency: 10
```
2. Modify Task.py, for each type of action, use multiple threads to run the tasks with oc or shell commands.

3. Modify functions Projects.py, Apps.py, and Pods.py to accept 'kubeconfig' parameter. 
Add -n namespace to a command if needed, such as getting pod - a dev user can only list pods under its own namespace.
For operations that can only be run by admin, such as labeling namespace, using admin user's kubeconfig.

4. Add global locks to protect the shared mutable counters, like the project id, total project number, app number, build number.
5. The '+=' operations are not thread safe. 
Is adding and poping a dict's entry in a shared map with multiple thread thread safe? - I think, yes. https://docs.python.org/3/glossary.html#term-global-interpreter-lock
https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe

5. Handle the situation caused by ansync operations. For example, an app is chosen to be upgraded, while the project deletion (--wait=false is async) actually done after that.

6. For app visit, the current solution is visiting sequentially. Implement concurrency with corutines (asyncio|https://github.com/timofurrer/awesome-asyncio/blob/master/README.md + aiohttp.
Corutines can support high concurrency for persona user. Concurrency is better than multi threading as it is single-threaded, multiplexing I/O access, thus cost is lower.
Add a new LoadApp module to load apps, use this module to count the application visit succeeded and failed numbers. 
The visit function is Apps module is kept for verify application route availability after app creation. 
In this way, the app visit succeeded and failed numbers only count the visits after route is available, 503 before available will not be counted. This can better reflect the user persona's concern - app visiting after it is ready.
example of an app visit task config. This config means 10 persona user will visit all applications concurrently.
```
      - action: visit
        resource: apps
        applyPercent: 100
        persona: user # actually not used
        concurrency: 10
```

**Exit Criteria**
Config with all kinds of tasks can be run with multiple users in parallel.
`python reliability.py -f config/enhance_reliability.yaml`