### PR TITLE
[reliability][enhance]add customized task

### DIFF
--- a/reliability/config/enhance_reliability.yaml
+++ b/reliability/config/enhance_reliability.yaml
@@ -24,6 +24,19 @@ reliability:
     - user_file: <path_to_users.spec>
   tasks:
     minute:
+      # Specify an oc command to execute as 'action'.
+      # Don't use command that could return '1' as expected, e.g. oc get pods -A | egrep -v "Running|Completed".
+      # Use oc get pods -A | awk '$4!="Running" && $4!="Completed"' instead.
+      - action: oc whoami
+        resource: customize
+        persona: developer
+        concurrency: 5
+      # Specify a file to execute as 'action'.
+      # File contains lines of oc command to execute. Don't use command that could return '1' as expected.
+      - action: <path to file>
+        resource: customize
+        persona: admin
+        concurrency: 1
       - action: check
         resource: pods
         persona: admin

--- a/reliability/tasks/Contexts.py
+++ b/reliability/tasks/Contexts.py
@@ -58,6 +58,6 @@ if __name__ == '__main__':
             self.password = '<password>'
     user = TestUser()
     users = {'kubeadmin': user}
-    all_contexts.create_kubeconfigs('~/Downloads/kubeconfig', users)
+    all_contexts.create_kubeconfigs('<path to kubeconfig of the cluster>"', users)
     with open(os.getcwd() + '/kubeconfigs/kubeconfig_kubeadmin') as f:
         print(f.read())

--- a/reliability/tasks/CustomizedTask.py
+++ b/reliability/tasks/CustomizedTask.py
@@ -1,0 +1,66 @@
+from .GlobalData import global_data
+from tasks.utils.oc import oc
+import os
+import logging
+
+class OCTask():
+    def __init__(self, command, kubeconfig):
+        self.command = command
+        self.kubeconfig = kubeconfig
+        
+    def execute(self):
+        return oc(self.command.lstrip("oc "), self.kubeconfig)
+
+class FileTask():
+    def __init__(self, file, kubeconfig):
+        self.file =file
+        self.kubeconfig = kubeconfig
+        self.output = []
+        self.rc = 0
+    def execute(self):
+        with open (self.file) as f:
+            for l in f.readlines():
+                task = OCTask(l, self.kubeconfig)
+                output, rc = task.execute()
+                self.output.append(output)
+                if rc != 0:
+                    break
+        return self.output, rc
+
+class CustomizedTask():
+    def __init__(self):
+        self.output = None
+        self.code = 0
+        self.customized_task_succeeded = 0
+        self.customized_task_failed = 0
+        self.logger = logging.getLogger('reliability')
+
+    def execute_task(self, action, kubeconfig):
+        if action.startswith("oc ", 0):
+            task = OCTask(action, kubeconfig)
+        elif os.path.isfile(action):
+            task = FileTask(action, kubeconfig)
+        else:
+            self.logger.warning(f"Customized action '{action}' is not supported. Provide an oc command or a file contains lines of oc command.")
+            return None
+        outout, rc = task.execute()
+        with global_data.customized_task_lock:
+            if rc == 0:
+                self.customized_task_succeeded += 1
+                return "Customized action succeeded for action: " + action
+            else:
+                self.customized_task_failed += 1
+                return "Customized action failed for action: " + action
+
+customizedTask = CustomizedTask()
+
+
+if __name__ == "__main__":
+    kubeconfig = "<path to kubeconfig of the cluster>"
+    # oc command
+    print("oc command")
+    print(customizedTask.execute_task("oc get clusterversion", kubeconfig))
+    # file
+    print("file")
+    print(customizedTask.execute_task("<path to a customized task file>", kubeconfig))
+    #

--- a/reliability/tasks/GlobalData.py
+++ b/reliability/tasks/GlobalData.py
@@ -16,6 +16,7 @@ class GlobalData:
         self.projects_lock = Lock()
         self.apps_lock = Lock()
         self.builds_lock = Lock()
+        self.customized_task_lock = Lock()
         self.total_build_count = 0
         self.app_visit_succeeded = 0
         self.app_visit_failed = 0

--- a/reliability/tasks/Task.py
+++ b/reliability/tasks/Task.py
@@ -7,6 +7,7 @@ from .Monitor import monitor
 from .Session import Session
 from .utils.oc import oc
 from .utils.LoadApp import LoadApp
+from .CustomizedTask import customizedTask
 import random
 import logging
 import time
@@ -263,3 +264,18 @@ class Task:
             if action == "clusteroperators":
                 self.logger.debug("Monitor clusteroperators")
                 monitor.check_operators()
+
+        # customized actions        
+        elif resource == "customize":
+            self.logger.debug("Execute customized oprations")
+            customize_task_args = []
+            self.logger.info(f"start customize tasks with {concurrency} users.")
+            for user in users:
+                kubeconfig = global_data.kubeconfigs[user]
+                customize_task_args.append((action, kubeconfig)) 
+            # execute customized task concurrently
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                    results =  executor.map(lambda t: customizedTask.execute_task(*t), customize_task_args)
+                    for result in results:
+                        if result != None:
+                            self.logger.info(f"{result}")

--- a/reliability/tasks/TaskManager.py
+++ b/reliability/tasks/TaskManager.py
@@ -4,6 +4,7 @@ from .Apps import all_apps
 from .Pods import all_pods
 from .Task import Task
 from .Session import Session
+from .CustomizedTask import customizedTask
 from .utils.oc import oc
 from concurrent.futures import ThreadPoolExecutor
 import logging
@@ -123,7 +124,8 @@ class TaskManager:
         self.logger.info("Successful app visits: " + str(global_data.app_visit_succeeded))
         self.logger.info("Failed app visits: " + str(global_data.app_visit_failed))
         self.logger.info("Total builds: " + str(global_data.total_build_count))
-
+        self.logger.info("Successful customized task: " + str(customizedTask.customized_task_succeeded))
+        self.logger.info("Failed customized task: " + str(customizedTask.customized_task_failed))
     def start(self):
         self.logger.info("Task manager started in working directory: " + self.cwd + " at: " + str(datetime.datetime.now()))
         self.next_execution_time = {}
@@ -147,7 +149,7 @@ class TaskManager:
             self.logger.warning("KeyError " + str(e))
         if projects_create_concurrency != 0:
             if max_projects < projects_create_concurrency:
-                self.logger.warn(f"maxProjects {max_projects} should be larger than the projects create concurrency {projects_create_concurrency}")
+                self.logger.warning(f"maxProjects {max_projects} should be larger than the projects create concurrency {projects_create_concurrency}")
             # as projects are created concurrently, the next round will not start if the left capacity is less than the concurrency 
             all_projects.max_projects = max_projects-max_projects%projects_create_concurrency
             self.logger.info(str(all_projects.max_projects) + " is set as the max projects number regarding to the concurrency " 
@@ -178,7 +180,7 @@ class TaskManager:
 if __name__ == "__main__":
     
     sys.path.append("..")
-    rc = ReliabilityConfig("/home/mifiedle/mffiedler_git/svt/reliability/nextgen/config/simple_reliability.yaml")
+    rc = ReliabilityConfig("<path to config file, example: ../config/simple_reliability.yaml>")
     rc.load_config()
     config = rc.config['reliability']
     tm = TaskManager(config)

--- a/reliability/tasks/Users.py
+++ b/reliability/tasks/Users.py
@@ -46,6 +46,6 @@ all_users=Users()
     
 if __name__ == "__main__":
     all_users.init()
-    all_users.load_users("/home/mifiedle/mffiedler_git/svt/reliability/config/users.spec")
+    all_users.load_users("<path to users.spec>")
     for current_name in all_users.users.keys():
         print(all_users.users[current_name].name + " " + all_users.users[current_name].password) 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-4292
[Reliability Test Tool Enhancement Plan ](https://docs.google.com/document/d/12n_yOXxZcsaokEE4rt04qpj3z7p9eWiSk4m5UqTEY7U/edit#heading=h.n4ceby94lm77)

**What**
Add customized task type.

**Why**
In the current design the tasks types are fixed/hard coded and limited, for example, project creation/deletion/modify, app creation/build/scale up/scale/down/visit. Most of them belongs to developers and end users personas. However, there are more operations can be added to reliability tests. To simulate the real world's cluster operation, we need to add more task types. It's flexible to have customized type to allow user to specify any oc commandsor file contains oc commands as a task.

**How**
Add a new task type for customized oc command or file contains oc commands.
example of the config file piece:
```
  tasks:
    minute:
      # Specify an oc command to execute as 'action'.
      # Don't use command that could return '1' as expected, e.g. oc get pods -A | egrep -v "Running|Completed".
      # Use oc get pods -A | awk '$4!="Running" && $4!="Completed"' instead.
      - action: oc whoami
        resource: customize
        persona: developer
        concurrency: 5
      # Specify a file to execute as 'action'.
      # File contains lines of oc command to execute. Don't use command that could return '1' as expected.
      - action: <path to file>
        resource: customize
        persona: admin
        concurrency: 1
```
example of the action file
```
oc get clusterversion
oc get co | awk '$3=="False" || $4=='True' || $5=="True"'
oc get pods -A | awk '$4!="Running" && $4!="Completed" && $4!="STATUS"'
```

**Exit Criteria**
User can customize any oc commands and run concurrently with multiple users.
