### PR TITLE
[Reliability][Enhancement]Reliability Slack integration

### DIFF
--- a/reliability/README.md
+++ b/reliability/README.md
@@ -35,6 +35,10 @@ For more detail explaination about the configuration, please go to [Configuratio
 
 ## Run
 
+### Run Reliability Test
+If you want to receive notifications about the start stop of the test and errors happen during the test.
+Check [Slack Integration](#Slack-Integration) before running the test.
+
 ```
 python3 reliability.py -c <path to config file> -c <path to log config file> -l ./reliability.log --cerberus-history <path to file to save cerberus history is cerberus is enabled>
 ```
@@ -109,6 +113,27 @@ reliability:
     # action to take when cerberus status is False, valid data: pause/halt/continue
     cerberus_fail_action: pause
 ```
+
+### Slack Integration
+Receive notifications about the start stop of the test and errors happen during the test.
+
+Set environment virable SLACK_API_TOKEN before running the test. Contact qili@redhat.com for the token.
+
+```yaml
+  slackIntegration:
+    slack_enable: False
+    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
+    slack_channel: C0266JJ4XM5
+    # slack_member is optional. If provided, the notification message will @ you. 
+    # you must be a member of the slack channel to receive the notification.
+    slack_member: <Your slack member id>
+```
+
+In the above configuration, notifications will be sent to [#ocp-qe-reliability-monitoring](https://coreos.slack.com/archives/C0266JJ4XM5) (Channel ID: C0266JJ4XM5) in [CoreOS](coreos.slack.com) workspace, and @ the user of slack_member if you configured.
+
+If you're in [CoreOS](coreos.slack.com) workspace, but you want to use your own slack channel, create a slack channel and install App `OCP Reliability` which already exists in CoreOS workspace.
+
+If you want to use your own App(slack_api_token), create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Slack Bot Token Scopes permissions are [channels:read] [chat:write] [groups:read] [im:read] [mpim:read]. You will get a token after the app is installed to a workspace. Install the app to your channel. Set the token to SLACK_API_TOKEN environment variable.
 
 ### Tasks
 Tasks defines what to do for each interval.

--- a/reliability/config/example_reliability.yaml
+++ b/reliability/config/example_reliability.yaml
@@ -15,11 +15,20 @@ reliability:
 
   cerberusIntegration:
     # start cerberus https://github.com/cloud-bulldozer/cerberus before starting reliabiity test.
-    cerberus_enable: True
+    cerberus_enable: False
     # if cerberus_enable is false, the following 2 items are ignored.
     cerberus_api: "http://0.0.0.0:8080"
     # action to take when cerberus status is False, valid data: pause/halt/continue
     cerberus_fail_action: pause
+  
+  slackIntegration:
+    slack_enable: False
+    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
+    slack_channel: C0266JJ4XM5
+    # slack_member is optional. If provided, the notification message will @ you. 
+    # you must be a member of the slack channel to receive the notification.
+    slack_member: <Your slack member id>
+
 
   appTemplates:
     - template: cakephp-mysql-persistent

--- a/reliability/requirements.txt
+++ b/reliability/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml==5.4.1
 requests==2.25.1
-aiohttp==3.7.4.post0
+aiohttp>=3.7.4
+slackclient==2.9.3

--- a/reliability/tasks/utils/LoadApp.py
+++ b/reliability/tasks/utils/LoadApp.py
@@ -1,3 +1,4 @@
+from .SlackIntegration import slackIntegration
 import logging
 from aiohttp import ClientSession
 import asyncio
@@ -23,6 +24,8 @@ class LoadApp():
                     self.app_visit_succeeded += 1
                 else:
                     self.app_visit_failed += 1
+                    # send slack message if response code is not 200
+                    slackIntegration.post_message_in_slack(f"Access to {url} failed. Response code: {str(code)}")
 
     def set_tasks(self, urls, num):
         for url in urls:

--- a/reliability/tasks/utils/SlackIntegration.py
+++ b/reliability/tasks/utils/SlackIntegration.py
@@ -1,0 +1,77 @@
+import os
+import slack
+import logging
+
+class SlackIntegration:
+    def __init__(self):
+        self.logger = logging.getLogger('reliability')
+        self.slack_enable = False
+        self.slack_api_token = ""
+        self.slack_channel = ""
+        self.slack_member = ""
+        self.slack_client = None
+        self.slack_tag = ""
+        self.thread_ts = None
+    
+    def init(self, slack_enable, slack_channel, slack_member):
+        # Init slack client
+        try:
+            self.slack_enable = slack_enable
+            self.slack_api_token = os.environ["SLACK_API_TOKEN"]
+            self.slack_channel = slack_channel
+            self.slack_member = slack_member
+            if self.slack_enable == True:
+                if self.slack_api_token != "" and self.slack_channel != "":
+                    self.slack_client = slack.WebClient(token=self.slack_api_token)
+                    self.logger.info("Slack client created.")
+                else:
+                    self.slack_enable = False
+                    self.logger.error("Couldn't create slack WebClient. Check if "
+                        "'slack_api_token' and 'slack_client' are configured.")
+                    self.logger.warning("Disable slack integration.")
+            else:
+                self.logger.info("Slack integration is disabled")
+
+            self.init_tag()
+        except Exception as e:
+            self.slack_enable = False
+            self.logger.error("Couldn't create slack WebClient or Slack channel not found."
+                              "Check if SLACK_API_TOKEN environment variable and slack_channel"
+                              " are correctly set. Exception: %s" % (e))
+            self.logger.warning("Disable slack integration.")
+
+    # Init slack tag
+    def init_tag(self):
+        if slackIntegration.slack_enable:
+            if self.slack_member != "":
+                channel_members = self.slack_client.conversations_members(token=self.slack_api_token, channel=self.slack_channel).get("members", [])
+                if self.slack_member in channel_members:
+                    self.slack_tag=f"<@{self.slack_member}>, "
+                else:
+                    self.logger.warning(f"The slack member id '{self.slack_member}' is not in slack channel '{self.slack_channel}'.")
+
+    # Post messages in slack
+    def post_message_in_slack(self, slack_message):
+        if slackIntegration.slack_enable:
+            self.slack_client.chat_postMessage(
+                channel=self.slack_channel,
+                text=self.slack_tag + slack_message,
+                thread_ts=self.thread_ts
+            )
+
+    # Get members of a channel
+    def get_channel_members(self):
+        return self.slack_client.conversations_members(
+            token=self.slack_api_token,
+            channel=self.slack_channel
+        )
+
+    # Report the start of reliability test in slack channel
+    def slack_report_reliability_start(self, cluster_info):
+        if slackIntegration.slack_enable:
+            response = self.slack_client.chat_postMessage(channel=self.slack_channel,
+                link_names=True,
+                text=f"{self.slack_tag}Reliability test has started on cluster: {cluster_info}")
+            self.thread_ts = response['ts']
+
+slackIntegration = SlackIntegration()

--- a/reliability/tasks/utils/oc.py
+++ b/reliability/tasks/utils/oc.py
@@ -1,3 +1,4 @@
+from .SlackIntegration import slackIntegration
 import subprocess
 import logging
 
@@ -11,6 +12,9 @@ def shell(cmd):
     except subprocess.CalledProcessError as cpe:
         rc = cpe.returncode
         result = cpe.output
+        result_decode = result.decode("utf-8")
+        # send slack message if oc command return code is not 
+        slackIntegration.post_message_in_slack(f"cmd: {cmd}  failed. Result: {result_decode}")
 
     string_result = result.decode("utf-8")
     logger.info(str(rc) + ": " + string_result)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-4657
[Reliability Test Tool Enhancement Plan ](https://docs.google.com/document/d/12n_yOXxZcsaokEE4rt04qpj3z7p9eWiSk4m5UqTEY7U/edit#heading=h.n4ceby94lm77)

Slack integration - priority 2

**What**
Generate slack notification when error happens.

**Why**
Current Reliability test needs to check for errors periodically in the tool's log file manually. This enhancement is to reduce manual monitoring effort, let the tool's user to ack problem easier and in time, by getting slack notification instead of manually checking reliability log file.

**How**

1. Install slack app and prepare slack channel.

Create a slack app

Add scopes to Slack Bot Token Scopes: [channels:read] [chat:write] [groups:read] [im:read] [mpim:read]

Request to Install and wait for the request to be approved in #forum-slack-apps slack channel.

After approved, open the app [OCP Reliability](https://coreos.slack.com/apps/A027ENMTKE3-ocp-reliability?next_id=0) and click 'Add to Slack', then click 'Install to Workspace', click 'Allow. You will get a Bot User OAuth Token. Record it for later use.

Create a slack channel #ocp-qe-reliability-alert. Click on the channel title, at the bottom of 'About' tab, there is a Channel ID, record it for later use.

Click on the channel title, click 'Integrations' tab, click 'Add apps', search for 'OCP Reliability' and add it to the slack channel.

2. Add code to send msg to slack channel when error happens. 
Send notification when Reliability test starts.
Send notification when error happens during the test. There are 2 kinds of errors

- oc command exit code != 0
- http access response code != 200

Send notification when test halts, then send test status.

How to config:
```
export SLACK_API_TOKEN=xxx
```
Configuration file example:
```yaml
  slackIntegration:
    slack_enable: False
    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
    slack_channel: C0266JJ4XM5
    # slack_member is optional. If provided, the notification message will @ you. 
    # you must be a member of the slack channel to receive the notification.
    slack_member: <Your slack member id>
```
3. Add instruction to README.md.

**Exit Criteria**

1. Reliability test send event to a slack channel to notify the tool's user about start/stop/errors/status of the test.
2. README and sample config files have clear instruction.
3. Config files is validated and mis configuration is handled.