### PR TITLE
Update imagestreamtag of applications

### DIFF
--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-build.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-build.json
@@ -117,11 +117,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (7.2 or latest).",
+            "description": "Version of PHP image to be used (7.3 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "latest"
+            "value": "7.3"
         },
         {
             "description": "The URL of the repository with your application source code.",

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
@@ -449,7 +449,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "mysql:8.0",
+                                "name": "mysql:latest",
                                 "namespace": "${NAMESPACE}"
                             }
                         },

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql-pv.json
@@ -449,7 +449,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "mysql:5.7",
+                                "name": "mysql:8.0",
                                 "namespace": "${NAMESPACE}"
                             }
                         },
@@ -482,7 +482,7 @@
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.2"
+            "value": "7.3"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
@@ -427,7 +427,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "mysql:5.7",
+                                "name": "mysql:latest",
                                 "namespace": "${NAMESPACE}"
                             }
                         },

--- a/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
+++ b/openshift_scalability/content/quickstarts/cakephp/cakephp-mysql.json
@@ -456,11 +456,11 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (7.2 or latest).",
+            "description": "Version of PHP image to be used (7.3 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,
-            "value": "7.2"
+            "value": "7.3"
         },
         {
             "description": "Maximum amount of memory the CakePHP container can use.",

--- a/openshift_scalability/content/quickstarts/dancer/dancer-build.json
+++ b/openshift_scalability/content/quickstarts/dancer/dancer-build.json
@@ -52,7 +52,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.26",
+                            "name": "perl:latest",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/openshift_scalability/content/quickstarts/dancer/dancer-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/dancer/dancer-mysql-pv.json
@@ -118,7 +118,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.26",
+                            "name": "perl:latest",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/openshift_scalability/content/quickstarts/dancer/dancer-mysql.json
+++ b/openshift_scalability/content/quickstarts/dancer/dancer-mysql.json
@@ -118,7 +118,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.26",
+                            "name": "perl:latest",
                             "namespace": "${NAMESPACE}"
                         }
                     },
@@ -391,7 +391,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "mysql:5.7",
+                                "name": "mysql:8.0",
                                 "namespace": "${NAMESPACE}"
                             }
                         },

--- a/openshift_scalability/content/quickstarts/django/django-postgresql.json
+++ b/openshift_scalability/content/quickstarts/django/django-postgresql.json
@@ -421,15 +421,15 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6 or latest).",
-      "value": "3.6",
+      "description": "Version of Python image to be used (3.8 or latest).",
+      "value": "3.8",
       "required": true
     },
     {
       "name": "POSTGRESQL_VERSION",
       "displayName": "Version of PostgreSQL Image",
       "description": "Version of PostgreSQL image to be used (10 or latest).",
-      "value": "10",
+      "value": "12",
       "required": true
     },
     {

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql-pv.json
@@ -724,7 +724,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "mysql:5.7"
+                                "name": "mysql:8.0"
                             }
                         }
                     },

--- a/openshift_scalability/content/quickstarts/eap/eap64-mysql.json
+++ b/openshift_scalability/content/quickstarts/eap/eap64-mysql.json
@@ -717,7 +717,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "mysql:latest"
+                                "name": "mysql:8.0"
                             }
                         }
                     },

--- a/openshift_scalability/content/quickstarts/eap/eap71-build.json
+++ b/openshift_scalability/content/quickstarts/eap/eap71-build.json
@@ -83,7 +83,7 @@
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "jboss-eap71-openshift:1.3",
+                            "name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:latest",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}"
                         }
                     },

--- a/openshift_scalability/content/quickstarts/eap/eap71-mysql-pv.json
+++ b/openshift_scalability/content/quickstarts/eap/eap71-mysql-pv.json
@@ -252,7 +252,7 @@
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "jboss-eap71-openshift:1.3",
+                            "name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:latest",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}"
                         }
                     },
@@ -918,7 +918,7 @@
             "displayName": "MySQL Image Stream Tag",
             "name": "MYSQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "5.7"
+            "value": "latest"
         },
         {
             "description": "Container memory limit",

--- a/openshift_scalability/content/quickstarts/eap/eap71-mysql.json
+++ b/openshift_scalability/content/quickstarts/eap/eap71-mysql.json
@@ -252,7 +252,7 @@
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "jboss-eap71-openshift:1.3",
+                            "name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:latest",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}"
                         }
                     },
@@ -888,7 +888,7 @@
             "displayName": "MySQL Image Stream Tag",
             "name": "MYSQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "5.7"
+            "value": "latest"
         },
         {
             "description": "Container memory limit",

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-build.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-build.json
@@ -48,7 +48,7 @@
 			"from": {
 			    "kind": "ImageStreamTag",
 			    "namespace": "openshift",
-			    "name": "nodejs:10"
+			    "name": "nodejs:latest"
 			}
 		    }
 		},

--- a/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb.json
+++ b/openshift_scalability/content/quickstarts/nodejs/nodejs-mongodb.json
@@ -84,7 +84,7 @@
 			"from": {
 			    "kind": "ImageStreamTag",
 			    "namespace": "openshift",
-			    "name": "nodejs:10"
+			    "name": "nodejs:latest"
 			}
 		    }
 		},

--- a/openshift_scalability/content/quickstarts/rails/rails-build.json
+++ b/openshift_scalability/content/quickstarts/rails/rails-build.json
@@ -78,7 +78,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/openshift_scalability/content/quickstarts/rails/rails-postgresql.json
+++ b/openshift_scalability/content/quickstarts/rails/rails-postgresql.json
@@ -129,7 +129,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/openshift_scalability/content/quickstarts/tomcat/tomcat8-build.json
+++ b/openshift_scalability/content/quickstarts/tomcat/tomcat8-build.json
@@ -51,7 +51,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-webserver30-tomcat8-openshift:1.2"
+                            "name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:latest"
                         }
                     }
                 },

--- a/openshift_scalability/content/quickstarts/tomcat/tomcat8-mongodb.json
+++ b/openshift_scalability/content/quickstarts/tomcat/tomcat8-mongodb.json
@@ -383,7 +383,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-webserver30-tomcat8-openshift:1.2"
+                            "name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:latest"
                         }
                     }
                 },


### PR DESCRIPTION
Updated imagestreams of few applications listed below
1. Cakephp
2. nodejs
3. tomcat
4. rails
5. eap
6. django
7. dancer

Signed-off-by: Shrivaibavi Raghaventhiran <sraghave@redhat.com>