### PR TITLE
[Reliability]Reliability and kraken-hub integration

### DIFF
--- a/reliability/README.md
+++ b/reliability/README.md
@@ -36,9 +36,13 @@ For more detail explaination about the configuration, please go to [Configuratio
 ## Run
 
 ### Run Reliability Test
-If you want to receive notifications about the start stop of the test and errors happen during the test.
-Check [Slack Integration](#Slack-Integration) before running the test.
+If you want to receive notifications about the start stop of the test and errors happen during the Reliability test, configure [Slack Integration](#Slack-Integration) before running the Reliability test.
 
+If you want to leverage Cerberus to check the healthy of the cluster and take action during the Reliability test, configure [Cerberus Integration](#Cerberus-Integration) before running the Reliability test.
+
+If you want to add [Kraken](https://github.com/cloud-bulldozer/kraken-hub) to inject errors during the Reliability test, configure [Kraken Integration](#Kraken-Integration) before running the Reliability test.
+
+Run the test
 ```
 python3 reliability.py -c <path to config file> -c <path to log config file> -l ./reliability.log --cerberus-history <path to file to save cerberus history is cerberus is enabled>
 ```
@@ -90,9 +94,9 @@ reliability:
 ```
 
 ### Cerberus Integration
-Reliablity can integrate with [Cerberus](https://github.com/cloud-bulldozer/cerberus) to check the healthy of the cluster and take action accordingly.
+Reliablity can integrate with [Cerberus](https://github.com/cloud-bulldozer/cerberus) to check the healthy of the cluster and take action accordingly during the Reliability test.
 
-The below configuration enables the Cerberus integration `cerberus_enable: True`, and provided the Cerberus api `cerberus_api: "http://0.0.0.0:8080"` where Reliability test can get the [Cerberus status and history](https://github.com/cloud-bulldozer/cerberus#metrics-api) from. The `cerberus_fail_action` configures how Reliability test acts when Cerberus status is False.
+The below configuration example enables the Cerberus integration `cerberus_enable: True`, and provided the Cerberus api `cerberus_api: "http://0.0.0.0:8080"` where Reliability test can get the [Cerberus status and history](https://github.com/cloud-bulldozer/cerberus#metrics-api) from. The `cerberus_fail_action` configures how Reliability test acts when Cerberus status is False.
 
 `pause`: When Cerberus status is 'False', pause Reliability test until Cerberus status is changed to 'True'.
 
@@ -115,7 +119,7 @@ reliability:
 ```
 
 ### Slack Integration
-Receive notifications about the start stop of the test and errors happen during the test.
+Receive notifications about the start stop of the Reliability test and errors happen during the Reliability test.
 
 Set environment virable SLACK_API_TOKEN before running the test. Contact qili@redhat.com for the token.
 
@@ -128,12 +132,67 @@ Set environment virable SLACK_API_TOKEN before running the test. Contact qili@re
     # you must be a member of the slack channel to receive the notification.
     slack_member: <Your slack member id>
 ```
-
 In the above configuration, notifications will be sent to [#ocp-qe-reliability-monitoring](https://coreos.slack.com/archives/C0266JJ4XM5) (Channel ID: C0266JJ4XM5) in [CoreOS](coreos.slack.com) workspace, and @ the user of slack_member if you configured.
 
 If you're in [CoreOS](coreos.slack.com) workspace, but you want to use your own slack channel, create a slack channel and install App `OCP Reliability` which already exists in CoreOS workspace.
 
 If you want to use your own App(slack_api_token), create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Slack Bot Token Scopes permissions are [channels:read] [chat:write] [groups:read] [im:read] [mpim:read]. You will get a token after the app is installed to a workspace. Install the app to your channel. Set the token to SLACK_API_TOKEN environment variable.
+
+### Kraken Integration
+Configure Kraken scenario(s) to trigger error injection during the Reliability test.
+
+The below configuration example enables the Kraken integration by setting `kraken_enable: True`.
+
+`kraken_scenarios` defines the Kraken scenario(s) you want to run during Reliability test. For all supported Kraken scenarios, open [this link](https://github.com/cloud-bulldozer/kraken-hub/blob/main/README.md#supported-chaos-scenarios), click on a scenario, on the opened document check the image tag, it will be the scenario you want to configure. For example with `quay.io/openshift-scale/kraken:pod-scenarios`, the `scenario` should be `pod-scenarios` as the first one in the example below.
+
+Currently the supported Kraken scenarios are:
+- pod-scenarios
+- node-scenarios
+- zone-outages
+- time-scenarios
+- power-outages
+- container-scenarios
+- node-cpu-hog
+- node-io-hog
+- node-memory-hog
+- namespace-scenarios
+- application-outages
+
+Refer to each Kraken scenario's document for the supported parameters, e.g [pod-scenarios](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/pod-scenarios.md#supported-parameters). You can add any number of parameters under `parameters:`.
+
+`interval_unit` and `interval_number` schedules how often the Kraken scenario is triggered. `start_date` and `end_date` with `timezone` are used to limit the time range to schedule the Kraken scenario. The scheduler feature makes use of [apscheduler](https://apscheduler.readthedocs.io/en/latest/modules/triggers/interval.html#module-apscheduler.triggers.interval).
+
+Though Kraken senarios support to run the error injection multiple times with iterations or in daemon mode as parameter, in Reliability test, you may want to get notification of start and end time of each error injection, to check what errors happen in Reliability test during the error injection period. In this case, configure in Reliability test to trigger the Kraken snario with `interval_unit` and `interval_number` is recommended.
+
+If [Slack Integration](#Slack-Integration) is enabled, notification of the Kraken scenarios' start and end time as well as result will be send to the slack channel. You can check what errors of Reliability test happen during the Kraken error injection.
+
+```yaml
+    kraken_scenarios: 
+      - name: pod-scenarios_etcd
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 8
+        # start_date: "2021-10-28 17:36:00" # Optional. format: 2021-10-20 10:00:00.
+        # end_date: "2021-10-28 17:50:00" # Optional.
+        # timezone: "Asia/Shanghai" # Optional. e.g. US/Eastern. Default is "UTC
+      - name: pod-scenarios_monitoring
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 10
+        parameters:
+          NAMESPACE: openshift-monitoring
+          POD_LABEL: app.kubernetes.io/component=prometheus
+          EXPECTED_POD_COUNT: 2
+      - name: node-scenarios_workerstopstart
+        scenario: "node-scenarios"
+        interval_unit: minutes
+        interval_number: 12
+        parameters:
+          AWS_DEFAULT_REGION: us-east-2
+          AWS_ACCESS_KEY_ID: xxxx
+          AWS_SECRET_ACCESS_KEY: xxxx
+          CLOUD_TYPE: aws
+```
 
 ### Tasks
 Tasks defines what to do for each interval.

--- a/reliability/config/example_reliability.yaml
+++ b/reliability/config/example_reliability.yaml
@@ -29,6 +29,38 @@ reliability:
     # you must be a member of the slack channel to receive the notification.
     slack_member: <Your slack member id>
 
+  krakenIntegration:
+    kraken_enable: False
+    # supported Kraken scenarios: https://github.com/cloud-bulldozer/kraken-hub/blob/main/README.md#supported-chaos-scenarios
+    # pod-scenarios, container-scenarios, node-scenarios, zone-outages, time-scenarios, 
+    # node-cpu-hog, node-memory-hog, node-io-hog
+    # Please specify the parameters for each scenario. e.g. For pod-scenarios,
+    # refer to https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/pod-scenarios.md#supported-parameters
+    kraken_scenarios: 
+      - name: pod-scenarios_etcd
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 8
+        # start_date: "2021-10-28 17:36:00" # Optional. format: 2021-10-20 10:00:00.
+        # end_date: "2021-10-28 17:50:00" # Optional.
+        # timezone: "Asia/Shanghai" # Optional. e.g. US/Eastern. Default is "UTC
+      - name: pod-scenarios_monitoring
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 10
+        parameters:
+          NAMESPACE: openshift-monitoring
+          POD_LABEL: app.kubernetes.io/component=prometheus
+          EXPECTED_POD_COUNT: 2
+      - name: node-scenarios_workerstopstart
+        scenario: "node-scenarios"
+        interval_unit: minutes
+        interval_number: 12
+        parameters:
+          AWS_DEFAULT_REGION: us-east-2
+          AWS_ACCESS_KEY_ID: xxxx
+          AWS_SECRET_ACCESS_KEY: xxxx
+          CLOUD_TYPE: aws
 
   appTemplates:
     - template: cakephp-mysql-persistent

--- a/reliability/reliability.py
+++ b/reliability/reliability.py
@@ -1,5 +1,6 @@
 from tasks.TaskManager import TaskManager
 from tasks.GlobalData import global_data
+from tasks.KrakenIntegration import KrakenIntegration
 from optparse import OptionParser
 import logging
 import sys
@@ -33,6 +34,13 @@ if __name__ == "__main__":
     # init global data
     if not global_data.load_data(options.config):
         sys.exit(1)
+    
+    # init Kraken integration
+    kraken_enable = global_data.config["krakenIntegration"].get("kraken_enable", False)
+    if kraken_enable:
+        krakenIntegration = KrakenIntegration()
+        krakenIntegration.add_jobs()
+        krakenIntegration.start()
 
     # start task manager
     task_manager = TaskManager(options.cerberus_history)

--- a/reliability/requirements.txt
+++ b/reliability/requirements.txt
@@ -2,3 +2,4 @@ pyyaml==5.4.1
 requests==2.25.1
 aiohttp>=3.7.4
 slackclient==2.9.3
+apscheduler==3.8.0

--- a/reliability/tasks/KrakenIntegration.py
+++ b/reliability/tasks/KrakenIntegration.py
@@ -1,0 +1,132 @@
+import logging
+import sys
+from apscheduler.schedulers.background import BackgroundScheduler
+from .GlobalData import global_data
+from tasks.utils.SlackIntegration import slackIntegration
+from tasks.utils.oc import shell
+
+class KrakenIntegration:
+    def __init__(self):
+        self.logger = logging.getLogger('reliability')
+        self.job_parameters = {}
+        executors = {
+            'default': {'type': 'threadpool', 'max_workers': 20},
+        }
+        job_defaults = {
+            'coalesce': False,
+            'max_instances': 1
+        }
+        # init scheduler to be run in background
+        self.scheduler = BackgroundScheduler(executors=executors, job_defaults=job_defaults)
+        self.kubeconfig = global_data.config["kubeconfig"]
+
+        # init the command to run kraken-hub
+        _,rc = shell("podman ps -l",ignore_slack=True)
+        if rc ==  0:
+            self.cmd = "podman"
+        else:
+            _,rc = shell("docker ps -l",ignore_slack=True)
+            if rc ==  0:
+                self.cmd = "docker"
+            else:
+                slackIntegration.post_message_in_slack(f"Kraken Integration failed. Please install podman or install and start docker first.")
+                exit()
+
+    def add_jobs(self):
+        try:
+            kraken_enable = global_data.config["krakenIntegration"].get("kraken_enable", False)
+            kraken_scenarios = global_data.config["krakenIntegration"].get("kraken_scenarios", [])
+        except KeyError as e:
+            self.logger.error(f"[kraken Integration] config file should contain key {e}.")
+
+        if kraken_enable:
+            for kraken_scenario in kraken_scenarios:
+                name = kraken_scenario.get("name", "")
+                scenario = kraken_scenario.get("scenario", "")
+                parameters = kraken_scenario.get("parameters", {})
+                self.job_parameters[name] = parameters
+                interval_unit = kraken_scenario.get("interval_unit", "")
+                interval_number = kraken_scenario.get("interval_number", 0)
+                start_date = kraken_scenario.get("start_date", "")
+                end_date = kraken_scenario.get("end_date", "")
+                timezone = kraken_scenario.get("timezone", "")
+                interval = {interval_unit:interval_number}
+                if start_date != "":
+                    interval['start_date']= start_date
+                if end_date != "":  
+                    interval['end_date']= end_date
+                if timezone != "": 
+                    interval['timezone']= timezone
+                # pass interval parameters with a map interval, pass function args as list args
+                self.scheduler.add_job(self.run_kraken, 'interval', **interval, args=[name,scenario])
+                self.logger.info(f"[kraken Integration] Kraken scenario '{name}' is added with interval: {interval}.")
+                slackIntegration.post_message_in_slack(f"[kraken Integration] Kraken scenario '{name}' is added with interval: {interval}.")
+
+    def start(self):
+        # start the scheduler
+        self.scheduler.start()
+        self.logger.info("[kraken Integration] Kraken Job Scheduler started.")
+        self.logger.debug(self.scheduler.print_jobs())
+
+    def run_kraken(self, *args):
+        # generate env parameters to be used in command
+        name = args[0]
+        scenario = args[1]
+        parameters = self.job_parameters[name]
+        parameter_string = ""
+        for key in parameters:
+            value = parameters[key]
+            parameter_string = f"{parameter_string} --env {key}={value} "
+
+        # run the Kraken-hub scenario as container
+        run_result, run_rc = shell(f"{self.cmd} run --name={name} --net=host {parameter_string} -v {self.kubeconfig}:/root/.kube/config:Z -d quay.io/openshift-scale/kraken:{scenario}")
+        self.logger.info(f"[kraken Integration] Kraken scenario job '{name}' is triggered.")
+        slackIntegration.post_message_in_slack(f"[kraken Integration] Kraken scenario job '{name}' is triggered.")
+
+        # get container id
+        container_id = ""
+        container_log = ""
+        if run_rc == 0:
+            # pulling image
+            if "Unable to find image" in run_result: 
+                container_id = run_result.splitlines()[-1]
+            # no need to pull image
+            else:
+                container_id = run_result
+            # remove '\n'
+            container_id = container_id.replace("\n", "")
+
+            # get run exit code
+            # inspect_result, inspect_rc = shell(f"{self.cmd} inspect {container_id} --format " + '\"{{.State.ExitCode}}\"',ignore_slack=True)
+            # sometimes the ExitCode =0 but there is error in the container log.
+            # if inspect_rc != 0 or inspect_result.replace("\n", "") != "0":
+
+            # get logs
+            container_log, log_rc = shell(f"{self.cmd} logs -f {container_id}",ignore_slack=True)
+            # send events to slack and wirte to log file
+            log_error = ""
+            if log_rc  == 0:
+                for line in container_log.splitlines(True):
+                    if "[ERROR]" in line:
+                        log_error = f"{log_error}{line}"
+                if log_error != "":
+                    slackIntegration.post_message_in_slack(f"[kraken Integration] Kraken scenario job '{name}' is finished with Error.\n{log_error}")
+                    self.logger.error(f"[kraken Integration] Kraken scenario job '{name}' is finished with Error.\n{log_error}")
+                else:
+                    slackIntegration.post_message_in_slack(f"[kraken Integration] Kraken scenario job '{name}' is finished.")
+                    self.logger.info(f"[kraken Integration] Kraken scenario job '{name}' is finished.")
+            else:
+                self.logger.error(f"[kraken Integration] Kraken scenario job '{name}' log retrive failed.")
+
+            # remove container
+            _, rm_rc = shell(f"{self.cmd} rm {container_id}",ignore_slack=True)
+            if rm_rc == 0:
+                self.logger.info(f"[kraken Integration] Kraken scenario job '{name}' container is removed.")
+            else:
+                self.logger.error(f"[kraken Integration] Kraken scenario job '{name}' container failed to remove.")
+
+        else:
+            self.logger.error(f"container run failed for Kraken scenario job '{name}'. Result is {run_result}")
+
+        self.logger.debug(self.scheduler.print_jobs()) 
+        

--- a/reliability/tasks/Task.py
+++ b/reliability/tasks/Task.py
@@ -5,7 +5,6 @@ from .Projects import Projects
 from .Pods import all_pods
 from .Monitor import monitor
 from .Session import Session
-from .utils.oc import oc
 from .utils.LoadApp import LoadApp
 from .CustomizedTask import customizedTask
 import random

--- a/reliability/tasks/utils/SlackIntegration.py
+++ b/reliability/tasks/utils/SlackIntegration.py
@@ -1,6 +1,7 @@
 import os
 import slack
 import logging
+import time
 
 class SlackIntegration:
     def __init__(self):
@@ -52,10 +53,11 @@ class SlackIntegration:
 
     # Post messages in slack
     def post_message_in_slack(self, slack_message):
+        timestamp = (time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime()))
         if slackIntegration.slack_enable:
             self.slack_client.chat_postMessage(
                 channel=self.slack_channel,
-                text=self.slack_tag + slack_message,
+                text=f"[{timestamp}] {self.slack_tag} {slack_message}",
                 thread_ts=self.thread_ts
             )
 
@@ -68,10 +70,11 @@ class SlackIntegration:
 
     # Report the start of reliability test in slack channel
     def slack_report_reliability_start(self, cluster_info):
+        timestamp = (time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime()))
         if slackIntegration.slack_enable:
             response = self.slack_client.chat_postMessage(channel=self.slack_channel,
                 link_names=True,
-                text=f"{self.slack_tag}Reliability test has started on cluster: {cluster_info}")
+                text=f"[{timestamp}] {self.slack_tag} Reliability test has started on cluster: {cluster_info}")
             self.thread_ts = response['ts']
 
 slackIntegration = SlackIntegration()

--- a/reliability/tasks/utils/oc.py
+++ b/reliability/tasks/utils/oc.py
@@ -2,7 +2,7 @@ from .SlackIntegration import slackIntegration
 import subprocess
 import logging
 
-def shell(cmd):
+def shell(cmd,ignore_slack=False):
     logger = logging.getLogger('reliability')
     rc = 0
     result = ""
@@ -13,8 +13,9 @@ def shell(cmd):
         rc = cpe.returncode
         result = cpe.output
         result_decode = result.decode("utf-8")
-        # send slack message if oc command return code is not 
-        slackIntegration.post_message_in_slack(f"cmd: {cmd}  failed. Result: {result_decode}")
+        # send slack message if oc command failed
+        if not ignore_slack:
+            slackIntegration.post_message_in_slack(f"cmd: {cmd}  failed. Result: {result_decode}")
 
     string_result = result.decode("utf-8")
     logger.info(str(rc) + ": " + string_result)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-4281
**Why:**
Reliability & Kraken integration can discover the impact to the active user actions (admin/dev/user actions) generated by the Reliability tool during the error injections.
Run as 2 separated tools, it's not convenient to track the start/end time of the error injection and the error of the reliability test during the error injection. With the Reliability & Kraken integration, we can log the start/ end time and what kind of errors are injected, to help QE to check what Reliability errors happen during the error injection.

**What:**

- User can enable and configure multiple Kraken scenarios in Reliability configuration files.
- User can configure Kraken scenarios to be run in certain interval with a start and end date time.
- Kraken scenarios and their run interval information is logged to log file and send to Reliability test's slack channel at the beginning of the Reliability test.
- Kraken scenarios' start and end(succeed or fail) events are sent to Reliability test's slack channel where Reliability test's failure events are sent to. So that user can check what errors from Reliability test happen during Kraken's error injection.

**How:**

example configuration file(part of reliability configuration file):
```yaml
    kraken_scenarios: 
      - name: pod-scenarios_etcd
        scenario: "pod-scenarios"
        interval_unit: minutes # weeks,days,hours,minutes,seconds
        interval_number: 8
        # start_date: "2021-10-28 17:36:00" # Optional. format: 2021-10-20 10:00:00.
        # end_date: "2021-10-28 17:50:00" # Optional.
        # timezone: "Asia/Shanghai" # Optional. e.g. US/Eastern. Default is "UTC
      - name: pod-scenarios_monitoring
        scenario: "pod-scenarios"
        interval_unit: minutes # weeks,days,hours,minutes,seconds
        interval_number: 10
        parameters:
          NAMESPACE: openshift-monitoring
          POD_LABEL: app.kubernetes.io/component=prometheus
          EXPECTED_POD_COUNT: 2
      - name: node-scenarios_workerstopstart
        scenario: "node-scenarios"
        interval_unit: minutes
        interval_number: 12
        parameters:
          AWS_DEFAULT_REGION: us-east-2
          AWS_ACCESS_KEY_ID: xxxx
          AWS_SECRET_ACCESS_KEY: xxxx
          CLOUD_TYPE: aws
```
Enables the Kraken integration by setting `kraken_enable: True`. 
`kraken_scenarios` defines the [Kraken scenario(s)](https://github.com/cloud-bulldozer/kraken-hub/blob/main/README.md#supported-chaos-scenarios) you want to run during Reliability test. Refer to each Kraken scenario's document for the supported `parameters`, e.g [pod-scenarios](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/pod-scenarios.md#supported-parameters).

`interval_unit` and `interval_number` schedules how often the Kraken scenario is triggered. `start_date` and `end_date` with `timezone` are used to limit the time range to schedule the Kraken scenario. The scheduler feature makes use of [apscheduler](https://apscheduler.readthedocs.io/en/latest/modules/triggers/interval.html#module-apscheduler.triggers.interval).

Though Kraken scenarios support to run the error injection multiple times with iterations or in daemon mode as parameter, in Reliability test, you may want to get notification of start and end time of each error injection, to check what errors happen in Reliability test during the error injection period. In this case, configure in Reliability test to trigger the Kraken scenarios with interval_unit and interval_number is recommended.