### PR TITLE
Log & security enhancement & a fix

### DIFF
--- a/reliability-v2/config/example_reliability.yaml
+++ b/reliability-v2/config/example_reliability.yaml
@@ -1,8 +1,8 @@
 reliability:
-  kubeconfig: /Users/qili/Downloads/kubeconfig
+  kubeconfig: <path_to_kubeconfig>
   users:
-    - kubeadmin_password: /Users/qili/Downloads/kubeadmin-password
-    - user_file: /Users/qili/Downloads/users.spec
+    - kubeadmin_password: <path_to_kubeadmin-password>
+    - user_file: <path_to_users.spec>
 
   appTemplates:
     - template: cakephp-mysql-persistent
@@ -31,16 +31,15 @@ reliability:
       interval: 10
       tasks: 
         - func check_operators
-        - oc whoami --show-server
+        - oc get project -l purpose=reliability
         - kubectl get pods -A -o wide | egrep -v "Completed|Running"
-        - pwd
-
+        
     - name: developer-1
       persona: developer
-      users: 2
-      loops: 10
+      users: 15
+      loops: forever
       trigger: 60
-      jitter: 60
+      jitter: 300
       interval: 10
       tasks:
         - func delete_all_projects # clear all projects

--- a/reliability-v2/integrations/SlackIntegration.py
+++ b/reliability-v2/integrations/SlackIntegration.py
@@ -55,7 +55,7 @@ class SlackIntegration:
         )
         
     # Post messages in slack
-    def post_message_in_slack(self, slack_message):
+    def info(self, slack_message):
         timestamp = (time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime()))
         try:
             self.slack_client.chat_postMessage(
@@ -64,7 +64,18 @@ class SlackIntegration:
                 thread_ts=self.thread_ts
             )
         except Exception as e:
-            self.logger.warning(f"post_message_in_slack had exception: '{e}")
+            self.logger.warning(f"post_info_to_slack had exception: '{e}")
+
+    def error(self, slack_message):
+        timestamp = (time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime()))
+        try:
+            self.slack_client.chat_postMessage(
+                channel=self.slack_channel,
+                text=f"[{timestamp}] {self.slack_tag} :boom: {slack_message}",
+                thread_ts=self.thread_ts
+            )
+        except Exception as e:
+            self.logger.warning(f"post_error_to_slack had exception: '{e}")        
 
     # Report the start of reliability test in slack channel
     def slack_report_reliability_start(self, cluster_info):

--- a/reliability-v2/reliability.py
+++ b/reliability-v2/reliability.py
@@ -36,8 +36,7 @@ if __name__ == "__main__":
 
         global_data.init_scheduler()
         global_data.init_intgration()
-        global_data.init_users()
-
-        # start task manager
-        taskManager = TaskManager(options.cerberus_history)
-        taskManager.start()
+        if global_data.init_users():
+            # start task manager
+            taskManager = TaskManager(options.cerberus_history)
+            taskManager.start()

--- a/reliability-v2/tasks/TaskManager.py
+++ b/reliability-v2/tasks/TaskManager.py
@@ -87,13 +87,13 @@ class TaskManager:
                 elif state == "pause":
                     time.sleep(60)
                     state = self.check_state()
-            slackIntegration.post_message_in_slack(f"Reliability test is going to halt")
+            slackIntegration.info(f"Reliability test is going to halt")
             rc = 1
 
         elif isinstance(loops,int) and loops > 0:
             for loop in range(loops):
                 if state == "halt":
-                    slackIntegration.post_message_in_slack(f"Reliability test is going to halt")
+                    slackIntegration.info(f"Reliability test is going to halt")
                     rc = 1
                     break
                 while state == "pause":
@@ -111,7 +111,7 @@ class TaskManager:
                     self.logger.info(f"Will sleep {trigger} before next loop of group '{name}'")
                     time.sleep(trigger)
                 elif state == "halt":
-                    slackIntegration.post_message_in_slack(f"Reliability test is going to halt")
+                    slackIntegration.info(f"Reliability test is going to halt")
                     rc = 1
                     break
         else:
@@ -152,7 +152,7 @@ class TaskManager:
 
     def check_state(self):
         if os.path.isfile(os.getcwd() + "/halt"):
-            slackIntegration.post_message_in_slack("Reliability test is going to halt.")
+            slackIntegration.info("Reliability test is going to halt.")
             state = "halt"
             self.logger.info("Halt file found, shutting down reliability.")
         elif os.path.isfile(os.getcwd() + "/pause"):
@@ -190,4 +190,4 @@ class TaskManager:
 
         # get results
         results = self.tasks.get_results()
-        slackIntegration.post_message_in_slack("Reliability test results:\n" + results)
+        slackIntegration.info("Reliability test results:\n" + results)

--- a/reliability-v2/users/Contexts.py
+++ b/reliability-v2/users/Contexts.py
@@ -40,15 +40,16 @@ class Contexts:
         # if max_workers=None, default is 5 * cpu cores
         with ThreadPoolExecutor(max_workers=workers) as executor:
             results = executor.map(lambda t: Session().login(*t), login_args)
+            # if any of the user login fails, return False
             for result in results:
-                self.logger.info(result)
+                if result == False:
+                    return False
+                #self.logger.info(result)
         #end = perf_counter()
         #print('perf of {} workers is: {} second'.format(workers, end - start))
         self.logger.info('Creating context for users is done.\n' +
             '====================================================================')
-
-    def init(self):
-        pass
+        return True
 
 all_contexts = Contexts()
 

--- a/reliability-v2/users/Session.py
+++ b/reliability-v2/users/Session.py
@@ -6,13 +6,17 @@ class Session:
         self.logger = logging.getLogger('reliability')
 
     def login(self, username, password, kubeconfig):
-        result, rc = oc('login -u ' + username + ' -p ' + password, kubeconfig)
-        if rc !=0:
+        retry = 10
+        rc = 1
+        while rc != 0 and retry > 0:
+            if retry != 1:
+                result, rc = oc(f"login -u {username} -p {password}", kubeconfig,ignore_slack=True)
+            else:
+                result, rc = oc(f"login -u {username} -p {password}", kubeconfig)
+            retry -= 1
+        if rc != 0:
             self.logger.error(f"Login with user {username} failed")
             self.logger.info(result)
-            return f"Login with user {username} failed"
+            return False
         else:
-            return f"Login with user {username} successfully."
-
-    def init(self):
-        pass
+            return True

--- a/reliability-v2/utils/LoadApp.py
+++ b/reliability-v2/utils/LoadApp.py
@@ -27,7 +27,7 @@ class LoadApp():
                     else:
                         self.app_visit_failed += 1
                         # send slack message if response code is not 200
-                        slackIntegration.post_message_in_slack(f":boom: Access to {url} failed. Response code: {str(code)}")
+                        slackIntegration.error(f"Access to {url} failed. Response code: {str(code)}")
                         return 1
         except Exception as e :
             self.logger.error(f"LoadApp get: {url} Exception {e}")

--- a/reliability-v2/utils/cli.py
+++ b/reliability-v2/utils/cli.py
@@ -2,43 +2,52 @@ from integrations.SlackIntegration import slackIntegration
 import subprocess
 import logging
 
-def shell(cmd,ignore_slack=False):
+def shell(cmd,ignore_log=False,ignore_slack=False):
     logger = logging.getLogger('reliability')
     rc = 0
     result = ""
-    logger.info("=>" + cmd)
+    # mask password to avoid output in log file or slack channel
+    if " -p " in cmd:
+        pwd = cmd.partition(" -p ")[2].partition(" ")[0]
+        cmd_output = cmd.replace(pwd, "xxxx")
+    else:
+        cmd_output = cmd
+    if not ignore_log:
+        logger.info(f"=> {cmd_output}")
     try:
         result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+        string_result = result.decode("utf-8")
+        if not ignore_log:
+            logger.info(f"{cmd_output} \n {str(rc)} : {string_result}")
     except subprocess.CalledProcessError as cpe:
         rc = cpe.returncode
         result = cpe.output
-        result_decode = result.decode("utf-8")
+        string_result = result.decode("utf-8")
+        if not ignore_log:
+            logger.error(f"{cmd_output} \n {str(rc)} : {string_result}")
         # send slack message if oc command failed
         if not ignore_slack:
-            slackIntegration.post_message_in_slack(f":boom: cmd: {cmd}  failed. Result: {result_decode}")
-
-    string_result = result.decode("utf-8")
-    logger.info(str(rc) + ": " + string_result)
+            slackIntegration.error(f"cmd: {cmd_output}  failed. Result: {string_result}")
     return string_result, rc
 
-def oc(cmd, config="",ignore_slack=False):
+def oc(cmd, config="",ignore_log=False,ignore_slack=False):
     rc = 0
     result = ""
     if config:
         cmd = "oc --kubeconfig " + config + ' ' + cmd
     else:
         cmd = "oc " + cmd
-    result,rc = shell(cmd,ignore_slack=ignore_slack)
+    result,rc = shell(cmd,ignore_log=ignore_log,ignore_slack=ignore_slack)
     return result,rc
 
-def kubectl(cmd, config=""):
+def kubectl(cmd, config="",ignore_log=False,ignore_slack=False):
     rc = 0
     result = ""
     if config:
         cmd = "kubectl --kubeconfig " + config + ' ' + cmd
     else:
         cmd = "kubectl " + cmd
-    result,rc = shell(cmd)
+    result,rc = shell(cmd,ignore_log=ignore_log,ignore_slack=ignore_slack)
     return result,rc
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Log enhancement: added `ignore_log` flag to enable or disable command output written to log file (https://github.com/openshift/svt/issues/678) https://github.com/openshift/svt/pull/700/commits/2803e207b3b7c796f867e585c56ee0bb0acaa7ca

2. Log enhancement: set `ignore_log=True` for step whose output can be ignore, especially for positive false Errors. https://github.com/openshift/svt/pull/700/commits/2803e207b3b7c796f867e585c56ee0bb0acaa7ca

3. SlackIntegration enhancement: Add `info` and `error` function to SlackIntegration to aline with log output.  https://github.com/openshift/svt/pull/700/commits/82e96d495e29b3cd199754d77e0069f67bc5ede4

4. Fix a seldom happened issue found in recent test: Ensure login to init kubeconfig succcssful to all users. This is to avoid task being done by admin role(if a user login failed, default kubeconfig will fall into kubeadmin). If some user login fails, retry 10 times to ensure its success, if any of the user login failed after retry, stop the reliability test and ask user to check. https://github.com/openshift/svt/pull/700/commits/b41522b2b5a8ac54ddcfc8c607f5757909c635af

5. Security & Log enhancement: Mask password as `xxxx` to avoid credential exposed to log file or slack channel. https://github.com/openshift/svt/pull/700/commits/56871db7ddfc1ed9b1a5b6ead954573cca551141