### PR TITLE
Add oc apply task and network policy yaml and example

### DIFF
--- a/reliability-v2/config/example_reliability_networkpolicy.yaml
+++ b/reliability-v2/config/example_reliability_networkpolicy.yaml
@@ -1,0 +1,101 @@
+reliability:
+  kubeconfig: <path_to_kubeconfig>
+  users:
+    - kubeadmin_password: <path_to_kubeadmin-password>
+    - user_file: <path_to_users.spec>
+
+  appTemplates:
+    - template: nodejs-postgresql-persistent
+
+  # The max number of projects is limited by the size of cluster.
+  # For 3 nodes m5.xlarge cluster, 25 to 30 projects are recomended.
+  # For 5 nodes m5.xlarge cluster, 60 projects are recomended.
+  # The max number of projects = groups x users x new_project
+  groups:
+    - name: admin-1
+      # 'admin', 'developer' are supported.
+      persona: admin
+      # concurrent users to run the group. For admin, only 1 is supported.
+      users: 1
+      # run group for loops times. integer > 0 or 'forever', default is 1.
+      loops: forever
+      # wait trigger seconds between each loop
+      trigger: 600
+      # delay the group execution by jitter seconds at most. Default is 0.
+      jitter: 60
+      # wait interval seconds between tasks.
+      interval: 10
+      tasks: 
+        - func check_operators
+        - oc get project -l purpose=reliability
+        - kubectl get pods -A -o wide | egrep -v "Completed|Running"
+        
+    - name: developer-1
+      persona: developer
+      users: 15
+      loops: forever
+      trigger: 60
+      jitter: 300
+      interval: 10
+      tasks:
+        - func delete_all_projects # clear all projects
+        - func new_project 2 # new 2 projects
+        - func apply 2 "<path to /reliability-v2/networkpolicy/network_policy_nodejs-postgresql-persistent.yaml>" # Apply network policy to 2 projects
+        - func check_all_projects # check all project under this user
+        - func new_app 2 # new app in 2 namespaces
+        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
+        - func build 1 # build app in 1 namespace
+        - func scale_up 2 # scale up app in 2 namespaces
+        - func scale_down 1 # scale down app in 2 namespaces
+        - func check_pods 2 # check pods in 2 namespaces 
+        - func delete_project 2 # delete project in 2 namespaces
+
+  cerberusIntegration:
+    # start cerberus https://github.com/cloud-bulldozer/cerberus before starting reliabiity test.
+    cerberus_enable: False
+    # if cerberus_enable is false, the following 2 items are ignored.
+    cerberus_api: "http://0.0.0.0:8080"
+    # action to take when cerberus status is False, valid data: pause/halt/continue
+    cerberus_fail_action: pause
+  
+  slackIntegration:
+    slack_enable: False
+    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
+    slack_channel: C0266JJ4XM5
+    # slack_member is optional. If provided, the notification message will @ you. 
+    # you must be a member of the slack channel to receive the notification.
+    slack_member: <Your slack member id>
+
+  krakenIntegration:
+    kraken_enable: False
+    # supported Kraken scenarios: https://github.com/cloud-bulldozer/kraken-hub/blob/main/README.md#supported-chaos-scenarios
+    # pod-scenarios, container-scenarios, node-scenarios, zone-outages, time-scenarios, 
+    # node-cpu-hog, node-memory-hog, node-io-hog
+    # Please specify the parameters for each scenario. e.g. For pod-scenarios,
+    # refer to https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/pod-scenarios.md#supported-parameters
+    kraken_scenarios: 
+      - name: pod-scenarios_etcd
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 8
+        # start_date: "2021-10-28 17:36:00" # Optional. format: 2021-10-20 10:00:00.
+        # end_date: "2021-10-28 17:50:00" # Optional.
+        # timezone: "Asia/Shanghai" # Optional. e.g. US/Eastern. Default is "UTC
+      - name: pod-scenarios_monitoring
+        scenario: "pod-scenarios"
+        interval_unit: minutes # weeks,days,hours,minutes,seconds
+        interval_number: 10
+        parameters:
+          NAMESPACE: openshift-monitoring
+          POD_LABEL: app.kubernetes.io/component=prometheus
+          EXPECTED_POD_COUNT: 2
+      - name: node-scenarios_workerstopstart
+        scenario: "node-scenarios"
+        interval_unit: minutes
+        interval_number: 12
+        parameters:
+          AWS_DEFAULT_REGION: us-east-2
+          AWS_ACCESS_KEY_ID: xxxx
+          AWS_SECRET_ACCESS_KEY: xxxx
+          CLOUD_TYPE: aws
+

--- a/reliability-v2/networkpolicy/network_policy_nodejs-postgresql-persistent.yaml
+++ b/reliability-v2/networkpolicy/network_policy_nodejs-postgresql-persistent.yaml
@@ -1,0 +1,27 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector: 
+    matchLabels:
+      role: postgresql
+  ingress:
+  - from:
+    - podSelector: {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-http-and-https
+spec:
+  podSelector: 
+    matchLabels:
+      role: nodejs-postgresql-persistent
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443

--- a/reliability-v2/tasks/Tasks.py
+++ b/reliability-v2/tasks/Tasks.py
@@ -217,6 +217,13 @@ class Tasks:
         self.__log_result(rc)
         return (result,rc)
 
+    def apply(self,user,namespace,file):
+        kubeconfig = global_data.kubeconfigs[user]
+        self.logger.info(f"[Task] apply file {file} in namespace {namespace}.")
+        (result, rc) = oc(f"apply -f {file} -n {namespace}",kubeconfig)
+        self.__log_result(rc)
+        return (result,rc)
+
     # admin tasks
     def check_operators(self,user):
         # This operation can only be done by admin user


### PR DESCRIPTION
In 4.10, network policy with SDN network is added to reliability Network Backend Test Matrix https://docs.google.com/document/d/1zi7i4FkoSXLE_GhO5Iyn03f_t6zGDLc2sxdyrfldbik/edit#heading=h.q92ljkbz9tbf.
This PR added:
1. An 'apply' task to apply a yaml file to given number of projects for a user.
2. A network policy yaml file for application with template nodejs-postgresql-persistent to consume.
3. An example of configuration file to run reliability test with network policy.

Note:
As this requirement is added in later phase of 4.10, for time limit, network policy is only applied to template nodejs-postgresql-persistent now. Will extend to more template in the future.