### PR TITLE
Changing to correct template apiVersion

### DIFF
--- a/storage/git/files/oc/template_git.yaml
+++ b/storage/git/files/oc/template_git.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
From kube: Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource