### PR TITLE
Rate limite some error message to be sent do slack to avoid too many …

### DIFF
--- a/reliability-v2/tasks/Tasks.py
+++ b/reliability-v2/tasks/Tasks.py
@@ -237,6 +237,8 @@ class Tasks:
             self.logger.error(f"Operator degraded: {result}")
             slackIntegration.error(f"Operator degraded: {result}")
             rc_return = 1
+        else:
+            rc_return = 1
         self.__log_result(rc_return)
         return(result,rc_return)
 


### PR DESCRIPTION
To fix #705
https://issues.redhat.com/browse/OCPQE-9017
Rate limit the following messages which may happen very frequently in some cases that will cause too many messages to be sent to slack channel.

1. Cluster can't be connected - when cluster is broken or destroyed during the test.
Result: Unable to connect to the server: dial tcp x.x.x.x:xxxx: i/o timeout
Result: Unable to connect to the server: dial tcp: lookup [api.xxx.qe-lrc.devcluster.openshift.com](http://api.mffiedler224b.qe-lrc.devcluster.openshift.com/): no such host
Result: Unable to connect to the server: dial tcp: lookup api.xxxx.qe.devcluster.openshift.com on x.x.x.x: server misbehaving
 
2. Continuous login failure - when user login has problem during the test.
error: You must be logged in to the server (Unauthorized)

3. BZ [2038780](https://bugzilla.redhat.com/show_bug.cgi?id=2038780)
Result: Error from server (AlreadyExists): project.project.openshift.io "testuser-x-y" already exists