### PR TITLE
add slack notifications when visiting app fails in new_app and load_a…

### DIFF
--- a/reliability-v2/integrations/SlackIntegration.py
+++ b/reliability-v2/integrations/SlackIntegration.py
@@ -19,7 +19,8 @@ class SlackIntegration:
         self.limited_messages = ("Unable to connect to the server: dial tcp",
         "Unable to connect to the server: dial tcp: lookup",
         "error: You must be logged in to the server (Unauthorized)",
-        "Result: Error from server (AlreadyExists): project.project.openshift.io")
+        "Result: Error from server (AlreadyExists): project.project.openshift.io",
+        "load_app: visit route")
     
     def init_slack_client(self, slack_channel, slack_member):
         # Init slack client

--- a/reliability-v2/tasks/TaskManager.py
+++ b/reliability-v2/tasks/TaskManager.py
@@ -62,9 +62,10 @@ class TaskManager:
         jitter = users_task["jitter"]
         tasks = users_task["tasks"]
 
-        random_jitter = random.randint(1,jitter)
-        self.logger.info(f"User {user} will sleep {random_jitter} seconds as jitter")
-        time.sleep(random_jitter)
+        if jitter > 0:
+            random_jitter = random.randint(1,jitter)
+            self.logger.info(f"User {user} will sleep {random_jitter} seconds as jitter")
+            time.sleep(random_jitter)
 
         state = self.check_state()
 


### PR DESCRIPTION
…pp task
https://issues.redhat.com/browse/OCPQE-8913

In the current reliability test, when there is a failure, slack channel will get notification. This is to reduce the effort of monitoring the long run reliability test.
Currently there when there is 'load app' failure, reliability test doesn't slack notification, as there could be some flaky of application access error, sending notification could be a noise to the channel.
But in some rare case, the application isn't up and running due to problem such as template issues, the test is failing but tester doesn't get notification until checking log file.
I want to add notification when application visiting fails, at the same time avoid too much noise of flaky app load failure.
As now https://issues.redhat.com/browse/OCPQE-9017 added the ability to avoid slack message flood. It's possible to add notification when application visiting fails.