### PR TITLE
add max_workers instead of using default and some log enhancements

### DIFF
--- a/reliability-v2/tasks/GlobalData.py
+++ b/reliability-v2/tasks/GlobalData.py
@@ -96,8 +96,9 @@ class GlobalData:
         if slack_enable:
             slackIntegration.init_slack_client(slack_channel, slack_member)
             # send start slack integration
-            (result, rc)=oc("whoami --show-server", self.kubeconfig)
-            cluster_info = result if rc == 0 else "unknown"
+            (server, rc)=oc("whoami --show-server", self.kubeconfig)
+            (version, rc)=oc("version", self.kubeconfig)
+            cluster_info = server + version if rc == 0 else "unknown"
             slackIntegration.slack_report_reliability_start(cluster_info)
 
         # init Ceberus integration

--- a/reliability-v2/tasks/Tasks.py
+++ b/reliability-v2/tasks/Tasks.py
@@ -161,7 +161,7 @@ class Tasks:
             urls = []
             for i in range(int(clients)):
                 urls.append(route)
-            with ThreadPoolExecutor() as executor:
+            with ThreadPoolExecutor(max_workers=int(clients)) as executor:
                 results = executor.map(self.__visit_app, urls)
                 return_value = 0
                 for result in results:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-9967

Changed in version 3.8: Default value of max_workers is changed to min(32, os.cpu_count() + 4). This default value preserves at least 5 workers for I/O bound tasks. It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL. And it avoids using very large resources implicitly on many-core machines.(ref: https://docs.python.org/3/library/concurrent.futures.html)

cpu count+4 is not enough for our concurrency, so I need to specify the max_workers.

I also did some output refine to make the logs more clear.