### PR TITLE
add script for regression test case OCP-41642

### DIFF
--- a/openshift_scalability/config/apf_template.yaml
+++ b/openshift_scalability/config/apf_template.yaml
@@ -1,0 +1,35 @@
+projects:
+  - num: NUM_PROJECTS
+    basename: BASENAME
+    nodeselector: "node-role.kubernetes.io/worker="
+    templates:
+      -
+        num: 3
+        file: ./content/build-config-template.json
+      -
+        num: 6
+        file: ./content/build-template.json
+      -
+        num: 1
+        file: ./content/image-stream-template.json
+      -
+        num: 2
+        file: ./content/deployment-1rep-pause-template.json
+        parameters:
+          -
+            ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+      -
+        num: 1
+        file: ./content/deployment-2rep-pause-template.json
+        parameters:
+          -
+            ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+      -
+        num: 10
+        file: ./content/ssh-secret-template.json
+      -
+        num: 3
+        file: ./content/route-template.json
+      # rcs and services are implemented in deployments.
+quotas:
+  - name: default

--- a/openshift_scalability/run_apf.sh
+++ b/openshift_scalability/run_apf.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+BASENAME=${1:-mva}
+NUM_PROJECTS=${2:-250}
+PARALLEL=${3:-10}
+
+CONFIG_TEMPLATE=config/apf_template.yaml
+
+cp $CONFIG_TEMPLATE config/apf_run.yaml
+
+sed -i "s/BASENAME/$BASENAME/g" config/apf_run.yaml
+sed -i "s/NUM_PROJECTS/$NUM_PROJECTS/g" config/apf_run.yaml
+
+date
+SECONDS=0
+./cluster-loader.py -f config/apf_run.yaml -p "$PARALLEL"
+duration=$SECONDS
+echo "Time taken: $duration"
+date
+
+#update 10 to real number
+for i in {0..10}; do oc get pods -A | grep -v Running | grep -v Completed; echo; sleep 1m; done
+date
+
+for ((i=0; i<NUM_PROJECTS; i++)); do
+  oc delete project "${BASENAME}${i}"
+done
+
+date
+
+
+# Build config Init:Error, I think the script needs update to get from a git that is reachable
+# build.build.openshift.io/buildconfig0-1   Source   Dockerfile,Git   Failed (FetchSourceFailed)   3 minutes ago   3m31s
+# Describe the build config got:
+# Log Tail:    Cloning "git://github.com/tiwillia/hello-openshift-example.git" ...
+#         WARNING: timed out waiting for git server, will wait 1m4s
+#         WARNING: timed out waiting for git server, will wait 4m16s
+#         error: fatal: unable to connect to github.com:
+#         github.com[0: 140.82.114.3]: errno=Connection timed out


### PR DESCRIPTION
OCP-41642 - Load cluster to test API priority and fairness
https://polarion.engineering.redhat.com/polarion/redirect/project/OSE/workitem?id=OCP-41642

The scripts for this test case was on Eric's personal fork, now move it to svt repo.
cd svt/openshift_scalability/ && wget https://github.com/RH-ematysek/svt/blob/4968d67f253cfdd4b948df2b6faf3d965f0f033e/openshift_scalability/run_apf.sh 
cd config && wget https://github.com/RH-ematysek/svt/blob/4968d67f253cfdd4b948df2b6faf3d965f0f033e/openshift_scalability/config/apf_template.yaml && cd ..