### PR TITLE
Adding loads back instead of load

### DIFF
--- a/openshift_scalability/utils.py
+++ b/openshift_scalability/utils.py
@@ -568,7 +568,7 @@ def quota_handler(inputquota, globalvars):
         quotafile = "content/quota-default.json"
 
     with open(quotafile,'r') as infile:
-        qconfig = json.load(infile)
+        qconfig = json.loads(infile)
     qconfig["metadata"]["namespace"] = globalvars["namespace"]
     qconfig["metadata"]["name"] = quota["name"]
     tmpfile=tempfile.NamedTemporaryFile(mode='w')
@@ -619,7 +619,7 @@ def service_handler(inputservs, globalvars):
 
         service_config = {}
         with open(servfile) as stream:
-            service_config = json.load(stream)
+            service_config = json.loads(stream)
         service_config["metadata"]["namespace"] = namespace
         service_config["metadata"]["name"] = basename
 
@@ -634,7 +634,7 @@ def ebs_create(globalvars):
     global ebsvolumeid
     ebsvolumeid = ec2_volume(ebsvolumesize,ebsvtype,ebstagprefix,ebsregion)
     with open("content/pv-default.json", "r") as pvstream:
-        pvjson = json.load(pvstream)
+        pvjson = json.loads(pvstream)
     pvjson["metadata"]["name"] = ebsvolumeid
     pvjson["spec"]["capacity"]["storage"] = str(ebsvolumesize) + "Gi"  # this has to be like this till k8s 23357 is fixed
     pvjson["spec"]["accessModes"] = [pvpermissions]
@@ -653,7 +653,7 @@ def ebs_create(globalvars):
     pvtmpfile.close()
 
     with open("content/pvc-default.json", "r") as pvcstream:
-        pvcjson = json.load(pvcstream)
+        pvcjson = json.loads(pvcstream)
     pvcjson["metadata"]["name"] = ebsvolumeid
     pvcjson["metadata"]["namespace"] = namespace
     pvcjson["spec"]["resources"]["requests"]["storage"] = str(ebsvolumesize) + "Gi"
@@ -673,7 +673,7 @@ def ebs_create(globalvars):
 def ceph_secret_create(cephsecret,globalvars):
     namespace = globalvars["namespace"]
     with open("content/ceph-secret.json") as cephsec:
-        cephsecjson = json.load(cephsec)
+        cephsecjson = json.loads(cephsec)
 
     cephsecjson["metadata"]["name"] = cephsecretname
     cephsecjson["metadata"]["namespace"] = namespace
@@ -704,7 +704,7 @@ def ceph_image_create(i,globalvars):
     # ceph_volume function will create ceph images at ceph storage cluster side
     ceph_volume(cephpool,cephimagename,imagesize)
     with open("content/pv-ceph.json") as pvstream:
-        pvjson = json.load(pvstream)
+        pvjson = json.loads(pvstream)
 
     pvjson["metadata"]["name"] =  "cephvol" + str(i)
     pvjson["metadata"]["namespace"] = namespace
@@ -730,7 +730,7 @@ def ceph_image_create(i,globalvars):
     pvtmpfile.close()
 
     with open("content/pvc-default.json", "r") as pvcstream:
-        pvcjson = json.load(pvcstream)
+        pvcjson = json.loads(pvcstream)
     pvcjson["metadata"]["name"] = "cephclaim" + str(i)
     pvcjson["metadata"]["namespace"] = namespace
     pvcjson["spec"]["resources"]["requests"]["storage"] = str(cephimagesize) + "Gi"
@@ -839,7 +839,7 @@ def pod_handler(inputpods, globalvars):
 
         pod_config = {}
         with open(podfile) as stream:
-            pod_config = json.load(stream)
+            pod_config = json.loads(stream)
         pod_config["metadata"]["namespace"] = namespace
         pod_config["metadata"]["name"] = basename
 
@@ -872,7 +872,7 @@ def rc_handler(inputrcs, globalvars):
 
         rc_config = {}
         with open(rcfile) as stream:
-            rc_config = json.load(stream)
+            rc_config = json.loads(stream)
         rc_config["metadata"]["namespace"] = namespace
         rc_config["metadata"]["name"] = basename
         rc_config["spec"]["replicas"] = replicas


### PR DESCRIPTION
Added incorrect json load function, needs to be load**s**

```
(venv) [sninganu@sninganu openshift_scalability]$ ./cluster-loader.py config/ocp-logtest.yaml 
2022-08-19::16:23:10 :: 51857 :: INFO     :: OC_Command: KUBECONFIG=/tmp/tmp9xgqkncv oc version :: Return Code: 0
2022-08-19::16:23:10 :: 51876 :: INFO     :: forking clusterproject0
2022-08-19::16:23:11 :: 51876 :: ERROR    :: OC_Command: KUBECONFIG=/tmp/tmpnsxabu9o oc get project -o name clusterproject0 :: Return Code: 1
2022-08-19::16:23:12 :: 51876 :: INFO     :: OC_Command: KUBECONFIG=/tmp/tmpynn63l69 oc new-project --skip-config-write=true clusterproject0 :: Return Code: 0
2022-08-19::16:23:13 :: 51876 :: INFO     :: OC_Command: KUBECONFIG=/tmp/tmp6560q71t oc label --overwrite namespace clusterproject0 purpose=test :: Return Code: 0
Traceback (most recent call last):
  File "./cluster-loader.py", line 92, in <module>
    project_handler(config,globalvars)
  File "/home/sninganu/Logging/svt/openshift_scalability/Paige2/svt/openshift_scalability/utils.py", line 557, in project_handler
    single_project(testconfig, projname, globalvars)
  File "/home/sninganu/Logging/svt/openshift_scalability/Paige2/svt/openshift_scalability/utils.py", line 468, in single_project
    quota_handler(testconfig["quota"],globalvars)
  File "/home/sninganu/Logging/svt/openshift_scalability/Paige2/svt/openshift_scalability/utils.py", line 571, in quota_handler
    qconfig = json.loads(infile)
  File "/usr/lib64/python3.8/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
```