### PR TITLE
add privileged labels to kube-burner config

### DIFF
--- a/perfscale_regression_ci/kubeburner-object-templates/pause-config.yml
+++ b/perfscale_regression_ci/kubeburner-object-templates/pause-config.yml
@@ -7,6 +7,11 @@ jobs:
     namespacedIterations: true
     podWait: false
     verifyObjects: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
     - objectTemplate: "pause-deployment.yml"
       replicas: 1


### PR DESCRIPTION
With addition of [PR](https://github.com/cloud-bulldozer/kube-burner/pull/184) in kube-burner we need to add the privileged namespaces labels to our config file like [here](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/258c0ddc5aa751935ccf6c45fa0ec74a387c668d/workloads/kube-burner/workloads/cluster-density/cluster-density.yml#L73) in cluster-density

Ran on ovn cluster so it failed but pod creation passed which was the update https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/regression-test/34/console
