### PR TITLE
Large network policy update

### DIFF
--- a/perfscale_regression_ci/scripts/custom_workload_env.sh
+++ b/perfscale_regression_ci/scripts/custom_workload_env.sh
@@ -6,5 +6,5 @@ export WORKLOAD=${WORKLOAD:-"custom"}
 export INDEXING=${INDEXING:-"false"}
 export METRICS_PROFILE=${METRICS_PROFILE:-"metrics-profiles/metrics.yaml"}
 export ALERTS_PROFILE=${ALERTS_PROFILE:-""}
-export COMPARISON_CONFIG="clusterVersion.json nodeMasters-max.json nodeAggWorkers.json"
-export GEN_CSV=true
+export COMPARISON_CONFIG="clusterVersion.json"
+export GEN_CSV=false

--- a/perfscale_regression_ci/scripts/network/large_network_policy.sh
+++ b/perfscale_regression_ci/scripts/network/large_network_policy.sh
@@ -40,7 +40,7 @@ sdn_project_count=$(oc get projects | grep sdn | wc -l | xargs)
 #   container_name="ovnkube-node"
 # fi
 
-network_pods=$(oc get pods -n $network_namespace -o name)
+network_pods=$(oc get pods -n $network_namespace -o name | grep -v controller)
 
 echo $network_pods
 


### PR DESCRIPTION
1. Remove extra env file from the common [custom_workload_env.sh file](https://github.com/openshift/svt/blob/e213e7b99803d410e00cb9c56172905607868320/perfscale_regression_ci/scripts/custom_workload_env.sh)
2. A little refine to get sdn pods

@svetsa-rh 
I saw you added these [2 lines](https://github.com/openshift/svt/blob/e213e7b99803d410e00cb9c56172905607868320/perfscale_regression_ci/scripts/custom_workload_env.sh#L9-L10) in [PR](https://github.com/openshift/svt/pull/733) . I found the 2 lines doesn’t work in my test case [large_network_policy.sh](https://github.com/openshift/svt/blob/master/perfscale_regression_ci/scripts/network/large_network_policy.sh).  I know you added them to get the performance of worker nodes for your enhanced test case. I think you should be using some extra metrics files too to get those metrics into es, is that this [line](https://github.com/svetsa-rh/svt/blob/e08813cf8dfcc273665fb0cba2268a8bc4c263ab/perfscale_regression_ci/scripts/scalability/replace_loadedworker_nodes_env.sh#L6)?
```
11-15 02:48:44.955  2022-11-14 18:48:44,898 - touchstone - ERROR - Error: Issue capturing results from elasticsearch using config {'filter': {'metricName.keyword': 'nodeCPU-Masters'}, 'buckets': ['labels.mode.keyword', 'labels.instance.keyword'], 'aggregations': {'value': ['max']}}
11-15 02:48:45.586  2022-11-14 18:48:45,215 - touchstone - ERROR - Error: Issue capturing results from elasticsearch using config {'filter': {'metricName.keyword': 'nodeMemoryUtilization-Masters'}, 'buckets': ['labels.instance.keyword'], 'aggregations': {'value': ['max']}}
```

I suggest we can keep these 2 lines only in your test case’s specific env file. 
```
export COMPARISON_CONFIG="clusterVersion.json nodeMasters-max.json nodeAggWorkers.json"
export GEN_CSV=true
```

Please let me know if this change works for your test cases.