### PR TITLE
Reliability start script fixes

### DIFF
--- a/reliability-v2/start.sh
+++ b/reliability-v2/start.sh
@@ -194,7 +194,7 @@ python3 --version
 python3 -m venv reliability_venv > /dev/null
 source reliability_venv/bin/activate > /dev/null
 cd -
-pip3 install --upgrade pip >  > /dev/null 2>&1
+pip3 install --upgrade pip > /dev/null 2>&1
 pip3 install -r requirements.txt > /dev/null 2>&1
 
 cp config/example_reliability.yaml $folder_name/reliability.yaml

--- a/reliability-v2/start.sh
+++ b/reliability-v2/start.sh
@@ -194,6 +194,7 @@ python3 --version
 python3 -m venv reliability_venv > /dev/null
 source reliability_venv/bin/activate > /dev/null
 cd -
+pip3 install --upgrade pip >  > /dev/null 2>&1
 pip3 install -r requirements.txt > /dev/null 2>&1
 
 cp config/example_reliability.yaml $folder_name/reliability.yaml
@@ -225,7 +226,7 @@ export KUBECONFIG
 oc get ns| grep dittybopper
 if [[ $? -eq 1 ]];then
     echo "Install dittybopper"
-    git clone git@github.com:cloud-bulldozer/performance-dashboards.git
+    git clone https://github.com/cloud-bulldozer/performance-dashboards.git
     cd performance-dashboards/dittybopper
     ./deploy.sh
 fi
@@ -250,8 +251,7 @@ timestamp_start=$(date +%s)
 timestamp_end=$(($timestamp_start + $SECONDS_TO_RUN))
 if [[ $os == "linux" ]]; then
     date_end_format=$(date --date=@$timestamp_end)
-elif [[ $os == "mac" ]]; then
-    date_end_format=$(date -j -f "%s" $timestamp_end "+%Y-%m-%d %H:%M:%S")
+elif [[ $os == "mac" ]]; then date_end_format=$(date -j -f "%s" $timestamp_end "+%Y-%m-%d %H:%M:%S")
 fi
 log "info" "Reliability test will run $time_to_run. Test will end on $date_end_format. \
 If you want to halt the test before that, open another terminal and 'touch halt' under reliability-v2 folder."


### PR DESCRIPTION
I ran into some issues trying to run the reliability-v2 start.sh script in my `Red Hat Enterprise Linux release 8.6 (Ootpa)` environment. 

It required a couple tweaks to get it to work correctly:
- Change "dittybopper" git repo to use https rather than ssh
- pip3 update before install requirements