### PR TITLE
Add pre and post tasks

### DIFF
--- a/reliability-v2/README.md
+++ b/reliability-v2/README.md
@@ -1,11 +1,9 @@
 OpenShift V4 Reliability - V2
 # Introduction
-Software reliability testing is a field of software testing that relates to testing a software's ability to function, given environmental conditions, for a particular amount of time.
-Openshift Reliability testing is an operational testing scheme that uses a baseline work efficiency specification to evaluate the stability of openshift system in the given amount of time. The purpose is to discover problems in functionality. The baseline work efficiency specification was made up of daily tasks such as applications developing, hosting and scaling. 
+Reliability-v2 is a longevity test tool simulating customer actions with load, integrated with health check, error injection and failure & performance monitoring. 
 
-Reliability-v2 can simulate real world by concurrently running different tasks by multiple groups and users. 
-
-## Git
+## Source
+Get the reliability-v2 tool from this git repo
 ```
 $ git clone git@github.com:openshift/svt.git
 cd svt/reliability-v2
@@ -15,33 +13,8 @@ cd svt/reliability-v2
 ## Tmux
 [tmux](https://github.com/tmux/tmux/wiki) is a tool that can help to keep the reliability running in the background to avoid the termination of the run due to the unexpected termination of the terminal. Ad reliability test sometimes run for several days, we recommend you to run reliability in a tmux session.
 
-## start.sh
-[start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh) is a script to wrap the configuration and run steps below to quick start a reliability test. It can also upgrade the cluster every 24 hours if there is new nightly build.
-e.g. Run reliability test for 7 days and upgrade every 24 hours if there is new nightly build
-```
-start.sh -p <path to the folder holding kubeconfig kubeadmin-password and users.spec files> -t 7d -u
-```
-
-To enable slack notification, export the following env viriables before running start.sh
-
-export SLACK_API_TOKEN=<ask qili@redhat for the token>
-
-export SLACK_MEMBER=<get it by clicking 'Copy member ID' in your slack Profile>
-
-# Config and Run
-If you don't use [start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh), read the folowing steps know about more details about reliability configuration and run.
-## Install dependencies
-**NOTE**: Recommended to use a virtual environment(pyenv,venv) so as to prevent conflicts with already installed packages.
-```
-$ pip3 install -r requirements.txt
-```
-
-## Configuration
-Example [config](https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml). 
-
-### Files needed
-
-If you installed your cluster with [Flexy-install](https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/), download kubeconfig, users.spec and kubeadmin-password files. If you installed cluster in other way, prepare the above files accordingly.
+## Prepare Authentication files
+If you installed your cluster with [Flexy-install](https://mastern-jenkins-csb-openshift-qe.apps.ocp4.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/), download kubeconfig, users.spec and kubeadmin-password files from the Build Artifacts after the job completed successfully. The user `kubeadmin` has admin priviledge and its password is in kubeadmin-password. users.spec contains username and password pairs of 50 test users.
 
 Replace `kubeconfig` `kubeadmin_password` and `user_file` with above files in your config file.
 ```yaml
@@ -59,24 +32,42 @@ If you installed your cluster with other ways, you need to prepare 3 files
 
 For more detail explaination about the configuration, please go to [Configuration Detail](#Configuration-Detail).
 
-## Run
+## A quick start script: start.sh
+[start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh) is a quick start script that helps you to do nessessary preparations and generate a default configurations based on [example_reliability.yaml](https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml) and start a reliability test to run for a certain time. It can upgrade the cluster every 24 hours if there is new nightly build.
 
-### Run Reliability Test
-
-#### Run the test
+e.g. Run reliability test for 7 days with the default configuration and upgrade the cluster every 24 hours if there is new nightly build
 ```
-python3 reliability.py -c <path to config file>
-```
-`-l` and `--cerberus-history` are optional.
-
-Logs will go to stdout and `/tmp/reliability.log` by default if `-l` is not specified.
-
-Cerberus history file will go to `/tmp/cerberus-history.json` by default if `--cerberus-history` is not specified.
-```
-python3 reliability.py -c <path to config file> -l <path to log config file> --cerberus-history <path to file to save cerberus history is cerberus is enabled>
+start.sh -p <path to the folder holding kubeconfig, kubeadmin-password and users.spec files> -t 7d -u
 ```
 
-#### Integration
+To enable slack notification, export the following env viriables before running start.sh
+
+export SLACK_API_TOKEN=<ask qili@redhat for the token>
+
+export SLACK_MEMBER=<get it by clicking 'Copy member ID' in your slack Profile>
+
+If you don't want to use the default configuration, you can update (https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml) before you trigger [start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh)
+
+For configuration details, check [Configuration](#Configuration)
+
+# Run without start.sh
+If [start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh) can not fit your requirment, you can run it with python. Read the folowing steps to know more details.
+
+## Install dependencies
+**NOTE**: Recommended to use a virtual environment(pyenv,venv) so as to prevent conflicts with already installed packages.
+```
+$ pip3 install -r requirements.txt
+```
+
+## Prepare Configuration
+Example [config](https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml). 
+
+You can customize the configuration file, check [Configuration](#Configuration) for details.
+
+### Groups and Tasks
+Define your test scenario by adding [Groups and Tasks](Groups-And-Tasks).
+
+### Integration
 [Slack Integration](#Slack-Integration) 
 
 If you want to receive notifications about the start stop of the test and errors happen during the Reliability test, configure Slack Integration before running the Reliability test.
@@ -89,20 +80,153 @@ If you want to leverage Cerberus to check the health of the cluster and take act
 
 If you want to add [Kraken](https://github.com/cloud-bulldozer/kraken-hub) to inject chaos during the Reliability test, configure Kraken Integration before running the Reliability test.
 
-## Control activity execution (in script working directory):
+
+## Run
+
+```
+python3 reliability.py -c <path to the configuration file>
+```
+`-l` and `--cerberus-history` are optional.
+
+Logs will go to stdout and `/tmp/reliability.log` by default if `-l` is not specified.
+
+Cerberus history file will go to `/tmp/cerberus-history.json` by default if `--cerberus-history` is not specified.
+```
+python3 reliability.py -c <path to config file> -l <path to log config file> --cerberus-history <path to file to save cerberus history is cerberus is enabled>
+```
+
+## Pause and Stop 
+In the directory where you start reliability test:
 ```bash
 # pause execution
 touch pause
-# when ready to resume
+# resume from pause
 rm pause
-# clean shutdown at end of next activity cycle
+# clean shutdown at end of next loop
 touch halt
 ```
 
-## Configuration Detail
+# Configuration
 Example [config](https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml). Below sections explains each part of the configuration file.
 
-### Cerberus Integration
+## Groups and Tasks
+A group defines a group of users with the similar behavior, they will run the same tasks. You can use any meaningful name for a group
+
+`user_name` the name of test user. If user_start and user_end exist, this will be username prefix
+
+`user_start` and `user_end` it defines the start and end range of users. `user_start` is inclusive, `user_end` is exclusive.
+
+`loops` defines the number of times each user will run the tasks. default is 1.
+
+`trigger` defines the time in second to wait between each loop. 
+
+`jitter` defines a random time in second to be added at the start of the first loop for a user. The purpose is to let users in a group to start at a different time. Default is 0.
+
+`tasks` define a list of tasks to run by a user. Each user will run the tasks in serial for the defined loops.
+
+`interval` defines the time in second to wait between each task in a tasks list.
+
+All users in a group run in parrellel. All groups run in parrellel.
+
+For tasks, oc cli, kubeconfig, shell script and build-in [func](Supported-Func)s are supported.
+
+```yaml
+reliability:
+  groups:
+    - name: admin
+      user_name: kubeadmin # username
+      loops: forever # run group for loops times. integer > 0 or 'forever', default is 1.
+      trigger: 600 # wait trigger seconds between each loop
+      jitter: 60 # randomly start the users in this group in trigger seconds. Default is 0.
+      interval: 10 # wait interval seconds between tasks.
+      tasks: 
+        - func check_operators
+        - oc get project -l purpose=reliability
+        - func check_nodes
+        - kubectl get pods -A -o wide | egrep -v "Completed|Running"
+        # Run test case as scripts. KUBECONFIG of the current user is set as env variable by reliability-v2. 
+        #- . <path to /content/create-delete-pod-ensure-service.sh>
+        
+    - name: dev-test
+      user_name: testuser- # if user_start and user_end exist, this will be username prefix
+      user_start: 0 # user_start is inclusive, start with testuser-0 in the users.spec file
+      user_end: 15 # user_end is exclusive, end with testuser-14 in the users.spec file
+      loops: forever
+      trigger: 60
+      jitter: 600 # randomly start the users in this group in 10 minutes
+      interval: 10
+      tasks:
+        - func delete_all_projects # clear all projects
+        - func new_project 2 # new 2 projects
+        # If network policy is planed in the test, uncomment the following line
+        #- func apply 2 "<path to /reliability-v2/networkpolicy/allow-same-namespace.yaml>" # Apply network policy to 2 projects
+        - func check_all_projects # check all project under this user
+        - func new_app 2 # new app in 2 namespaces
+        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
+        - func build 1 # build app in 1 namespace
+        - func check_pods 2 # check pods in 2 namespaces 
+        - func delete_project 2 # delete project in 2 namespaces
+
+    - name: dev-prod
+      user_name: testuser- 
+      user_start: 15 # user_start is inclusive, start with testuser-15 in users.spec
+      user_end: 45 # user_end is exclusive, end with testuser-44 in users.spec
+      loops: forever
+      trigger: 600
+      jitter: 1200 # randomly start the users in this group in 20 minutes
+      interval: 600
+      pre_tasks: 
+          - func delete_all_projects # clear all projects
+          - func new_project 2 # new 2 projects
+          - func new_app 2 # new app in 2 namespaces
+      tasks:
+        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
+        - func scale_deployment 2 2 # scale app in 2 namespaces to 2 replicas
+        - func scale_deployment 2 1 # scale app in 2 namespaces to 1 replicas
+      post_tasks: 
+        - func delete_project 2
+```
+## Supported func
+Funs are some build-in functions that calls oc cli to run some common operation(s).
+
+The following funcs are supported now:
+
+| name | parameters | user | comment |
+| ---- | ---- | ---- | ---- |
+| delete_all_projects  | N/A | developer | delete all projects for a user | 
+| new_project | number_of_projects | developer | Create n projects for the user|
+| check_all_projects  | N/A | developer | Check projects under the user|
+| new_app  | number_of_projects | developer | New an app under each project|
+| load_app  | number_of_projects  number_of_clients | developer | Load an app under each project with a number of clients|
+| apply  | number_of_projects  file_location | developer admin | apply a file under each project|
+| build  | number_of_projects | developer | Build under each project|
+| scale_deployment  | number_of_projects number_of_replicas | developer | Scaleup the deployment to number_of_replicas replicas under each project|
+| check_pods  | number_of_projects | developer | Check pods under each project|
+| delete_project  | number_of_projects | developer | Delete each project|
+| check_operators  | N/A | admin | Check Degraded operators|
+| check_nodes  | N/A | admin | Check not Ready nodes|
+
+## Slack Integration
+Receive notifications about the start stop of the Reliability test and errors happen during the Reliability test.
+
+Set environment virable SLACK_API_TOKEN before running the test. Contact qili@redhat.com for the token.
+
+```yaml
+  slackIntegration:
+    slack_enable: False
+    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
+    slack_channel: C0266JJ4XM5
+    # slack_member is optional. If provided, the notification message will @ you. 
+    # you must be a member of the slack channel to receive the notification.
+    slack_member: <Your slack member id>
+```
+In the above configuration, notifications will be sent to [#ocp-qe-reliability-monitoring](https://coreos.slack.com/archives/C0266JJ4XM5) (Channel ID: C0266JJ4XM5) in [CoreOS](coreos.slack.com) workspace, and @ the user of slack_member if you configured.
+
+If you're in [CoreOS](coreos.slack.com) workspace, but you want to use your own slack channel, create a slack channel and install App `OCP Reliability` which already exists in CoreOS workspace.
+
+If you want to use your own App(slack_api_token), create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Slack Bot Token Scopes permissions are [channels:read] [chat:write] [groups:read] [im:read] [mpim:read]. You will get a token after the app is installed to a workspace. Install the app to your channel. Set the token to SLACK_API_TOKEN environment variable.
+
+## Cerberus Integration
 Reliablity can integrate with [Cerberus](https://github.com/cloud-bulldozer/cerberus) to check the healthy of the cluster and take action accordingly during the Reliability test.
 
 The below configuration example enables the Cerberus integration `cerberus_enable: True`, and provided the Cerberus api `cerberus_api: "http://0.0.0.0:8080"` where Reliability test can get the [Cerberus status and history](https://github.com/cloud-bulldozer/cerberus#metrics-api) from. The `cerberus_fail_action` configures how Reliability test acts when Cerberus status is False.
@@ -127,27 +251,7 @@ reliability:
     cerberus_fail_action: pause
 ```
 
-### Slack Integration
-Receive notifications about the start stop of the Reliability test and errors happen during the Reliability test.
-
-Set environment virable SLACK_API_TOKEN before running the test. Contact qili@redhat.com for the token.
-
-```yaml
-  slackIntegration:
-    slack_enable: False
-    # the ID in the example is the id of slack channel #ocp-qe-reliability-monitoring.
-    slack_channel: C0266JJ4XM5
-    # slack_member is optional. If provided, the notification message will @ you. 
-    # you must be a member of the slack channel to receive the notification.
-    slack_member: <Your slack member id>
-```
-In the above configuration, notifications will be sent to [#ocp-qe-reliability-monitoring](https://coreos.slack.com/archives/C0266JJ4XM5) (Channel ID: C0266JJ4XM5) in [CoreOS](coreos.slack.com) workspace, and @ the user of slack_member if you configured.
-
-If you're in [CoreOS](coreos.slack.com) workspace, but you want to use your own slack channel, create a slack channel and install App `OCP Reliability` which already exists in CoreOS workspace.
-
-If you want to use your own App(slack_api_token), create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Slack Bot Token Scopes permissions are [channels:read] [chat:write] [groups:read] [im:read] [mpim:read]. You will get a token after the app is installed to a workspace. Install the app to your channel. Set the token to SLACK_API_TOKEN environment variable.
-
-### Kraken Integration
+## Kraken Integration
 Configure Kraken scenario(s) to trigger error injection during the Reliability test.
 
 The below configuration example enables the Kraken integration by setting `kraken_enable: True`. 
@@ -186,92 +290,3 @@ If [Slack Integration](#Slack-Integration) is enabled, notification of the Krake
           AWS_SECRET_ACCESS_KEY: xxxx
           CLOUD_TYPE: aws
 ```
-
-### Groups and Tasks
-Groups define user groups. It simulate a number of users that have the similar behavior. 
-
-Tasks define the tasks to do for the users in each group.
-
-In the below example, it defines a group `developer-1`. `Users` in the group are 10 `developer` users as defined in `persona`. The group has some `tasks`. The 10 users will be run concurrently, each user will execute the tasks for 2 loops. There will be 60 seconds as `trigger` between each loop. Between each task, there will be 10 seconds as `interval`. Each user will delay the execution by jitter seconds at most, this is to add random to this group, so that at any given time different users could execute different tasks.
-
-For tasks, `oc` `kubeconfig` shell and `func` are supported.
-
-```yaml
-reliability:
-  groups:
-    - name: admin-1
-      # 'admin', 'developer' are supported.
-      persona: admin
-      # concurrent users to run the group. For admin, only 1 is supported.
-      users: 1
-      # run group for loops times. integer > 0 or 'forever', default is 1.
-      loops: forever
-      # wait trigger seconds between each loop
-      trigger: 600
-      # delay the group execution by jitter seconds at most. Default is 0.
-      jitter: 60
-      # wait interval seconds between tasks.
-      interval: 10
-      tasks: 
-        - func check_operators
-        - oc get project -l purpose=reliability
-        - func check_nodes
-        - kubectl get pods -A -o wide | egrep -v "Completed|Running"
-        # Run test case as scripts. KUBECONFIG of the current user is set as env. 
-        #- . <path to /content/create-delete-pod-ensure-service.sh>
-
-    - name: developer-1
-      persona: developer
-      user_start: 0 #user_start is inclusive
-      user_end: 15 #user_end is exclusive
-      loops: forever
-      trigger: 60
-      jitter: 300
-      interval: 10
-      tasks:
-        - func delete_all_projects # clear all projects
-        - func new_project 2 # new 2 projects
-        # If network policy is planed in the test, uncomment the following line
-        #- func apply 2 "<path to /reliability-v2/networkpolicy/allow-same-namespace.yaml>" # Apply network policy to 2 projects
-        - func check_all_projects # check all project under this user
-        - func new_app 2 # new app in 2 namespaces
-        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
-        - func build 1 # build app in 1 namespace
-        - func scale_up 2 # scale up app in 2 namespaces
-        - func scale_down 1 # scale down app in 2 namespaces
-        - func check_pods 2 # check pods in 2 namespaces 
-        - func delete_project 2 # delete project in 2 namespaces
-
-    - name: developer-2
-      persona: developer
-      user_start: 15 #user_start is inclusive
-      user_end: 16 #user_end is exclusive
-      loops: 1
-      tasks:
-        - func new_project 2 # new 2 projects
-        - func new_app 2 # new app in 2 namespaces
-```
-
-Currenlty there is one admin user, defined in kubeadmin-password file, and multiple(50 in Flexy-install created cluster) developer users, defeined in users.spec.
-
-The following funcs are supported now:
-
-| func | parameters | persona | comment |
-| ---- | ---- | ---- | ---- |
-| delete_all_projects  | N/A | developer | delete all projects for a user | 
-| new_project | number_of_projects | developer | Create n projects for the user|
-| check_all_projects  | N/A | developer | Check projects under the user|
-| new_app  | number_of_projects | developer | New an app under each project|
-| load_app  | number_of_projects  number_of_clients | developer | Load an app under each project with a number of clients|
-| apply  | number_of_projects  file_location | developer admin | apply a file under each project|
-| build  | number_of_projects | developer | Build under each project|
-| scale_up  | number_of_projects | developer | Scaleup the deployment from 1 to 2 under each project|
-| scale_down  | number_of_projects | developer | Scaledown the deployment from 2 to 1 under each project|
-| check_pods  | number_of_projects | developer | Check pods under each project|
-| delete_project  | number_of_projects | developer | Delete each project|
-| check_operators  | N/A | admin | Check Degraded operators|
-| check_nodes  | N/A | admin | Check not Ready nodes|
-
-
-
-

--- a/reliability-v2/config/example_reliability.yaml
+++ b/reliability-v2/config/example_reliability.yaml
@@ -16,19 +16,12 @@ reliability:
   # For 5 nodes m5.xlarge cluster, 60 projects are recomended.
   # The max number of projects = groups x users x new_project
   groups:
-    - name: admin-1
-      # 'admin', 'developer' are supported.
-      persona: admin
-      # concurrent users to run the group. For admin, only 1 is supported.
-      users: 1
-      # run group for loops times. integer > 0 or 'forever', default is 1.
-      loops: forever
-      # wait trigger seconds between each loop
-      trigger: 600
-      # delay the group execution by jitter seconds at most. Default is 0.
-      jitter: 60
-      # wait interval seconds between tasks.
-      interval: 10
+    - name: admin
+      user_name: kubeadmin # username
+      loops: forever # run group for loops times. integer > 0 or 'forever', default is 1.
+      trigger: 600 # wait trigger seconds between each loop
+      jitter: 60 # randomly start the users in this group in trigger seconds. Default is 0.
+      interval: 10 # wait interval seconds between tasks.
       tasks: 
         - func check_operators
         - oc get project -l purpose=reliability
@@ -37,13 +30,13 @@ reliability:
         # Run test case as scripts. KUBECONFIG of the current user is set as env variable by reliability-v2. 
         #- . <path to /content/create-delete-pod-ensure-service.sh>
         
-    - name: developer-1
-      persona: developer
-      user_start: 0 #user_start is inclusive
-      user_end: 15 #user_end is exclusive
+    - name: dev-test
+      user_name: testuser- # if user_start and user_end exist, this will be username prefix
+      user_start: 0 # user_start is inclusive, start with testuser-0 in the users.spec file
+      user_end: 15 # user_end is exclusive, end with testuser-14 in the users.spec file
       loops: forever
       trigger: 60
-      jitter: 300
+      jitter: 600 # randomly start the users in this group in 10 minutes
       interval: 10
       tasks:
         - func delete_all_projects # clear all projects
@@ -54,19 +47,27 @@ reliability:
         - func new_app 2 # new app in 2 namespaces
         - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
         - func build 1 # build app in 1 namespace
-        - func scale_up 2 # scale up app in 2 namespaces
-        - func scale_down 1 # scale down app in 2 namespaces
         - func check_pods 2 # check pods in 2 namespaces 
         - func delete_project 2 # delete project in 2 namespaces
 
-    - name: developer-2
-      persona: developer
-      user_start: 15 #user_start is inclusive
-      user_end: 16 #user_end is exclusive
-      loops: 1
+    - name: dev-prod
+      user_name: testuser- 
+      user_start: 15 # user_start is inclusive, start with testuser-15 in users.spec
+      user_end: 45 # user_end is exclusive, end with testuser-44 in users.spec
+      loops: forever
+      trigger: 600
+      jitter: 1200 # randomly start the users in this group in 20 minutes
+      interval: 600
+      pre_tasks: 
+          - func delete_all_projects # clear all projects
+          - func new_project 2 # new 2 projects
+          - func new_app 2 # new app in 2 namespaces
       tasks:
-        - func new_project 2 # new 2 projects
-        - func new_app 2 # new app in 2 namespaces
+        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
+        - func scale_deployment 2 2 # scale app in 2 namespaces to 2 replicas
+        - func scale_deployment 2 1 # scale app in 2 namespaces to 1 replicas
+      post_tasks: 
+        - func delete_project 2
 
   cerberusIntegration:
     # start cerberus https://github.com/cloud-bulldozer/cerberus before starting reliabiity test.
@@ -116,4 +117,3 @@ reliability:
           AWS_ACCESS_KEY_ID: xxxx
           AWS_SECRET_ACCESS_KEY: xxxx
           CLOUD_TYPE: aws
-

--- a/reliability-v2/start.sh
+++ b/reliability-v2/start.sh
@@ -175,7 +175,7 @@ function dhms_to_seconds {
     echo "Total seconds to run is: $SECONDS_TO_RUN"
 }
 
-RELIABILITY_DIR=$(cd ${BASH_SOURCE[0]};pwd)
+RELIABILITY_DIR=$(cd $(dirname ${BASH_SOURCE[0]});pwd)
 SECONDS_TO_RUN=0
 start_log=start_$(date +"%Y%m%d_%H%M%S").log
 echo start.sh logs will be saved to $start_log.

--- a/reliability-v2/tasks/TaskManager.py
+++ b/reliability-v2/tasks/TaskManager.py
@@ -60,7 +60,9 @@ class TaskManager:
         trigger = users_task["trigger"]
         interval = users_task["interval"]
         jitter = users_task["jitter"]
+        pre_tasks = users_task["pre_tasks"]
         tasks = users_task["tasks"]
+        post_tasks = users_task["post_tasks"]
         label = f"[Group:{group_name}] [User: {user}] [Total Loops: {loops}]"
 
         if jitter > 0:
@@ -69,88 +71,117 @@ class TaskManager:
             time.sleep(random_jitter)
 
         state = self.check_state()
-
-        if loops == "forever":
-            loop = 0
-            while state != "halt":
-                if state == "run":
-                    self.logger.info(f"{label}: will run loop {loop}")
-                    rc = 0
-                    for task in tasks:
-                        if rc == 0:
-                            rc = self.run_task(task, user)
-                            # sleep interval seconds between tasks
-                            self.logger.info(f"{label}: will sleep {interval}s before next task")
-                            time.sleep(interval)           
-                    loop += 1
-                    self.logger.info(f"{label}: will sleep {trigger}s after loop '{loop}'")
-                    time.sleep(trigger)
-                    state = self.check_state()
-                elif state == "pause":
-                    time.sleep(60)
-                    state = self.check_state()
-            slackIntegration.info(f"{label}: is going to halt after loop '{loop}'")
-            result = "{label}: halted after loop '{loop}'"
-
-        elif isinstance(loops,int) and loops > 0:
-            for loop in range(loops):
-                if state == "halt":
-                    slackIntegration.info(f"{label}: is going to halt before loop '{loop}'")
-                    result = "{label}: halted before loop '{loop}'"
-                    break
-                while state == "pause":
-                    time.sleep(60)
-                    state = self.check_state()
-                if state == "run":
-                    self.logger.info(f"{label}: will run loop {loop}")
-                    rc = 0
-                    for task in tasks:
-                        if rc == 0:
-                            rc = self.run_task(task, user)
-                            self.logger.info(f"{label}: will sleep {interval}s before next task")
-                            time.sleep(interval)
-                    self.logger.info(f"{label}: will sleep {trigger}s after loop '{loop}'")
-                    time.sleep(trigger)
-                    state = self.check_state()
-                elif state == "halt":
-                    slackIntegration.info(f"{label}: is going to halt after loop '{loop}'")
-                    result = f"{label}: halted after loop '{loop}'"
-                    break
-            result = f"{label}: loop finished"
+        # run pre tasks
+        while state == "pause":
+            time.sleep(60)
+            state = self.check_state()
+        pre_rc = 0
+        if state == "run":
+            self.logger.info(f"{label}: will run pre_tasks")
+            for pre_task in pre_tasks:
+                if pre_rc == 0:
+                    pre_rc = self.run_task(pre_task, user)
+                    time.sleep(20)
+        if pre_rc != 0:
+            result = f"{label}: pre tasks failed." 
         else:
-            self.logger.error(f"Invalid loop '{loops}'.")
+            state = self.check_state()
+            if loops == "forever":
+                loop = 0
+                while state != "halt":
+                    if state == "run":
+                        self.logger.info(f"{label}: will run loop {loop}")
+                        rc = 0
+                        for task in tasks:
+                            if rc == 0:
+                                rc = self.run_task(task, user)
+                                # sleep interval seconds between tasks
+                                self.logger.info(f"{label}: will sleep {interval}s before next task")
+                                time.sleep(interval)           
+                        loop += 1
+                        self.logger.info(f"{label}: will sleep {trigger}s after loop '{loop}'")
+                        time.sleep(trigger)
+                        state = self.check_state()
+                    elif state == "pause":
+                        time.sleep(60)
+                        state = self.check_state()
+                slackIntegration.info(f"{label}: is going to halt after loop '{loop}'")
+                result = f"{label}: halted after loop '{loop}'"
 
+            elif isinstance(loops,int) and loops > 0:
+                for loop in range(loops):
+                    if state == "halt":
+                        slackIntegration.info(f"{label}: is going to halt before loop '{loop}'")
+                        result = f"{label}: halted before loop '{loop}'"
+                        break
+                    while state == "pause":
+                        time.sleep(60)
+                        state = self.check_state()
+                    if state == "run":
+                        self.logger.info(f"{label}: will run loop {loop}")
+                        rc = 0
+                        for task in tasks:
+                            if rc == 0:
+                                rc = self.run_task(task, user)
+                                self.logger.info(f"{label}: will sleep {interval}s before next task")
+                                time.sleep(interval)           
+                        self.logger.info(f"{label}: will sleep {trigger}s after loop '{loop}'")
+                        time.sleep(trigger)
+                        state = self.check_state()
+                    elif state == "halt":
+                        slackIntegration.info(f"{label}: is going to halt after loop '{loop}'")
+                        result = f"{label}: halted after loop '{loop}'"
+                        break
+                result = f"{label}: loop finished"
+            else:
+                self.logger.error(f"Invalid loop '{loops}'.")
+            
+            # run post tasks even when there is halt
+            state = self.check_state()
+            while state == "pause":
+                time.sleep(60)
+                state = self.check_state()
+            self.logger.info(f"{label}: will run post_tasks")
+
+            post_rc = 0
+            for post_task in post_tasks:
+                if post_rc == 0:
+                    post_rc = self.run_task(post_task, user)
+                    time.sleep(20)
         return result
 
     def run_users_tasks(self,group):
         name = group.get("name","")
-        persona = group.get("persona","os")
+        user_name = group.get("user_name","")
+        user_start = group.get("user_start",None)
+        user_end = group.get("user_end",None)
         loops = group.get("loops",1)
         trigger = group.get("trigger",0)
         jitter = group.get("jitter",0)
+        pre_tasks = group.get("pre_tasks",[])
         tasks = group.get("tasks",[])
+        post_tasks = group.get("post_tasks",[])
         interval = group.get("interval",60)
         users_tasks = []
-        # todo: validate
-        if persona == "admin":
-            users = group.get("users",1)
-            # we have only one kubeadmin admin user, to avoid conflict admin operation bwtween different login session, only 1 admin user is supported now.
-            users_tasks.append({"user":"kubeadmin","group_name":name,"loops":loops,"trigger":trigger,"interval":interval,"jitter":jitter,"tasks":tasks})
-            self.logger.info(f"Will run group '{name}' with admin user in {users} sessions concurrently")
-        elif persona == "developer":
-            user_start = group.get("user_start",0)
-            user_end = group.get("user_end",15)
+        user_count = 0
+        if user_start == None and user_end == None: 
+            users_tasks.append({"user":user_name,"group_name":name,"loops":loops,"trigger":trigger,"interval":interval,"jitter":jitter,"pre_tasks":pre_tasks,"tasks":tasks,"post_tasks":post_tasks})
+            user_count = 1
+        elif user_end > user_start:   
             for i in range(user_start, user_end):
-                users_tasks.append({"user":f"testuser-{i}","group_name":name,"loops":loops,"trigger":trigger,"interval":interval,"jitter":jitter,"tasks":tasks})
-            users = user_end - user_start
-            self.logger.info(f"Will run group '{name}' with {users} users concurrently")
-        slackIntegration.info(f"Group {name} will run tasks with {users} users for {loops} loops. Adding a jitter of {jitter}s before group test started, wait {trigger}s between loops, wait {interval}s between tasks.")
-        # run tasks with concurrent users
-        with ThreadPoolExecutor(max_workers=users) as executor:
-            results = executor.map(self.run_tasks, users_tasks)
-            for result in results:
-                self.logger.info(f"Finished running group '{name}'. Result is {result}")
-        return (f"Finished running group '{name}'. Result is {result}")
+                users_tasks.append({"user":f"{user_name}{i}","group_name":name,"loops":loops,"trigger":trigger,"interval":interval,"jitter":jitter,"pre_tasks":pre_tasks,"tasks":tasks,"post_tasks":post_tasks})
+            user_count = user_end - user_start
+        if user_count > 0:
+            self.logger.info(f"Will run group '{name}' with {user_count} users.")
+            slackIntegration.info(f"Group {name} will run tasks with {user_count} users for {loops} loops. Adding a jitter of {jitter}s before group test started, wait {trigger}s between loops, wait {interval}s between tasks.")
+            # run tasks with concurrent users
+            with ThreadPoolExecutor(max_workers=user_count) as executor:
+                results = executor.map(self.run_tasks, users_tasks)
+                for result in results:
+                    self.logger.info(f"User in group '{name} finished its run'. Result is {result}")
+            return (f"Finished running group '{name}'.")
+        else:
+            return (f"Can not run group '{name}'. user_end should be larger than user_end.")
 
     def run_groups(self,groups):
         with ThreadPoolExecutor() as executor:

--- a/reliability/README.md
+++ b/reliability/README.md
@@ -1,4 +1,5 @@
 # OpenShift V4 Reliability
+This tool is not being maintained now. The new Reliability tool is here https://github.com/openshift/svt/tree/master/reliability-v2.
 ## Introduction
 Software reliability testing is a field of software testing that relates to testing a software's ability to function, given environmental conditions, for a particular amount of time.
 Openshift Reliability testing is an operational testing scheme that uses a baseline work efficiency specification to evaluate the stability of openshift system in the given amount of time. The purpose is to discover problems in functionality. The baseline work efficiency specification was made up of daily tasks such as applications developing, hosting and scaling. 


### PR DESCRIPTION
1. Add pre_tasks and post_tasks to run before and after the looped tasks, only once, to do some preparation and cleanup work. https://issues.redhat.com/browse/OCPQE-14484
2. Updated the example_reliability.yaml file to include the pre_tasks and post_tasks
3. Merged the scale_up and scale_down funcs to a unified scale_deployment func, add a __check_replicas func to check replicas reach the expected number
4. Replace 'persona' with 'user_name' to make it easier to understand  and compatible to other customized user password files
5. Updated the README.md to include the new changes and to a more organized order.