### PR TITLE
debug cronjob failure

### DIFF
--- a/reliability-v2/config/example_reliability.yaml
+++ b/reliability-v2/config/example_reliability.yaml
@@ -56,7 +56,7 @@ reliability:
         #- func apply 2 "<path_to_content>/allow-same-namespace.yaml" # Apply network policy to 2 projects
         - func check_all_projects # check all project under this user
         - func new_app 2 # new app in 2 namespaces
-        - func load_app 2 10 # load apps in 2 namespaces with 10 clients for each
+        - func load_app 2 1 # load apps in 2 namespaces with 1 clients for each
         - func build 1 # build app in 1 namespace
         - func check_pods 2 # check pods in 2 namespaces 
         - func delete_project 2 # delete project in 2 namespaces

--- a/reliability-v2/tasks/script/cronjob.sh
+++ b/reliability-v2/tasks/script/cronjob.sh
@@ -10,6 +10,7 @@
 ## During the test, check the inode and worker node's memory usage on dittybopper's openshift-performance dashboard.
 ## Reference: https://docs.openshift.com/container-platform/4.12/nodes/jobs/nodes-nodes-jobs.html#nodes-nodes-jobs-creating-cron_nodes-nodes-jobs
 ################################################
+set -x
 
 USER=${USER:-""}
 image="image-registry.openshift-image-registry.svc:5000/openshift/cli"


### PR DESCRIPTION
Run relialibity-v2 on prow, I saw 2 differences compared to running on jumphost
1. cronjob failure
```
2024-01-11 09:36:38,694 - INFO - [User: testuser-16] [Task: /tmp/svt/reliability-v2/tasks/script/cronjob.sh -n 10]: will be run
2024-01-11 09:36:38,694 - INFO - => /tmp/svt/reliability-v2/tasks/script/cronjob.sh -n 10
2024-01-11 09:36:38,699 - ERROR - /tmp/svt/reliability-v2/tasks/script/cronjob.sh -n 10 
 2 : /tmp/svt/reliability-v2/tasks/script/cronjob.sh: 20: function: not found
Usage: cronjob.sh [-n <number of cronjobs>] [-s <schedule>] -d
  -n <number>                  : Number of cronjobs to be created. Default is 1.
  -s <schedule>                : Schedule for the cronjob. Default is '*/1 * * * *'
  -d                           : Delete all cronjobs and
/tmp/svt/reliability-v2/tasks/script/cronjob.sh: 30: Syntax error: "}" unexpected
```
When I manually run this script on the prow pod, it did not have this issue.
I tired to run the same python version as the prow pod 3.9.9 on my local, I can not reproduce the issue too.
Added 'set -x' to get more info to debug

2. load app failure rate is higher (7% in aws 8 hours run)
Reduce the load test client number from 10 to 1 to see if the failure rate can get down.