### PR TITLE
regression-test-fix

### DIFF
--- a/perfscale_regression_ci/scripts/common.sh
+++ b/perfscale_regression_ci/scripts/common.sh
@@ -156,7 +156,7 @@ function fix(){
   # fixing issues recorded in https://docs.google.com/document/d/148Q-pIZlkZlyqdMDBI3Zr_I10_IDwMcKiBpuwP14lZw/edit#heading=h.nnxdwzdzlvx
   echo "Fixing cakephp-mysql-persistent application that are not running ."
   # resolve mysql replicacontroller not ready by deleting the mysql replicationcontroller and let it recreate
-  for namespace in $(sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster="", node=~"ip-10-0-167-50.us-east-2.compute.internal"}) by (pod) | awk '{print $1}'); do
+  for namespace in $(oc get rc -A -l openshift.io/deployment-config.name=$database --no-headers| egrep -v '1.*1.*1' | awk '{print $1}'); do
     oc get rc -n $namespace
     echo "----Recreate mysql replicacontrollers in namespace $namespace----"
     oc delete rc -l openshift.io/deployment-config.name=$database -n $namespace

--- a/perfscale_regression_ci/scripts/network/network_policy_scalability.sh
+++ b/perfscale_regression_ci/scripts/network/network_policy_scalability.sh
@@ -1,7 +1,7 @@
 #/!/bin/bash -x
 ################################################
 ## Auth=mifiedle@redhat.com qili@redhat.com lhorsley@redhat.com
-## Desription: On a 10 node OVN cluster, time how long it takes to scale up to 2000 pods with and without the networkpolicy 
+## Desription: Time how long it takes to scale up to 2000 pods with and without the networkpolicy 
 ## Note: The scale up time with the networkpolicy in place will be more than without, but it should not be an order of magnitude difference.	
 ## Polarion test case: OCP-41535 - NetworkPolicy scalability - 2000 pods per namespace using customer network policy	
 ## https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-41535

--- a/perfscale_regression_ci/scripts/registry/conc_registry_pull.sh
+++ b/perfscale_regression_ci/scripts/registry/conc_registry_pull.sh
@@ -72,8 +72,7 @@ function fix(){
   # fixing issues recorded in https://docs.google.com/document/d/148Q-pIZlkZlyqdMDBI3Zr_I10_IDwMcKiBpuwP14lZw/edit#heading=h.nnxdwzdzlvx
   echo "Fixing cakephp-mysql-persistent application that are not running ."
   # resolve mysql replicacontroller not ready by deleting the mysql replicationcontroller and let it recreate
-  for namespace in $(sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster="", node=~"ip-10-0-167-50.us-east-2.compute.internal"}) by (pod)
- | awk '{print $1}'); do
+  for namespace in $(oc get rc -A -l openshift.io/deployment-config.name=$database --no-headers| egrep -v '1.*1.*1' | awk '{print $1}'); do
     oc get rc -n $namespace
     echo "----Recreate mysql replicacontrollers in namespace $namespace----"
     oc delete rc -l openshift.io/deployment-config.name=$database -n $namespace

--- a/perfscale_regression_ci/scripts/scalability/master-failover-two-master-stop-scale.sh
+++ b/perfscale_regression_ci/scripts/scalability/master-failover-two-master-stop-scale.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+##############################################################################
+# Author: skordas@redhat.com
+# Description:
+# Ensure that OpenShift Cluster basic functionality remains available
+# when two out of three master node services are stopped.
+# Polarion Test Case: OCP-22399
+# https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-22399]
+##############################################################################
+
+if [[ $(oc get nodes | grep -c master) -ne 3 ]]; then
+  echo "To run this script you need to provide cluster with 3 master nodes"
+  exit 1
+fi
+
+wait_time=10
+number_of_retries=20
+
+nodes=()
+for node in $(oc get nodes | grep master | awk '{print $1}'); do
+  nodes+=( $node )
+done
+
+
+function disable_kube_api_server_on_node {
+  echo "Disable kube-apiserver on node $1"
+  oc debug node/$1 -- chroot /host mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /root/
+
+  try=0
+  while :; do
+    oc get pods -o wide -n openshift-kube-apiserver | grep $1 | grep -v guard | grep Running
+    number_running_pods=$(oc get pods -o wide -n openshift-kube-apiserver | grep $1 | grep -v guard | grep -c Running)
+    if [[ $number_running_pods -eq 0 ]]; then
+      echo "kube-apiserver on node $1 is down"
+      break
+    fi
+    ((try=${try}+1))
+    if [[ $try -eq $number_of_retries ]]; then
+      echo "On node $1 kube-apiserver should be down."
+      exit 1
+    fi
+    echo "Retrying in $wait_time seconds"
+    sleep $wait_time
+  done
+}
+
+function disable_kube_controller_manager_on_node {
+  echo "Disable kube-controller-manager on node $1"
+  oc debug node/$1 -- chroot /host mv /etc/kubernetes/manifests/kube-controller-manager-pod.yaml /root/
+
+  try=0
+  while :; do
+    oc get pods -o wide -n openshift-kube-controller-manager | grep $1 | grep -v guard | grep Running
+    number_running_pods=$(oc get pods -o wide -n openshift-kube-controller-manager | grep $1 | grep -v guard | grep -c Running)
+    if [[ $number_running_pods -eq 0 ]]; then
+      echo "kube-controller-manager on node $1 is down"
+      break
+    fi
+    ((try=${try}+1))
+    if [[ $try -eq $number_of_retries ]]; then
+      echo "On node $1 kube-controller-manager should be down."
+      exit 1
+    fi
+    echo "Retrying in $wait_time seconds"
+    sleep $wait_time
+  done
+}
+
+function enable_kube_api_server_on_node {
+  echo "Enable kube-apiserver on node $1"
+  oc debug node/$1 -- chroot /host mv /root/kube-apiserver-pod.yaml /etc/kubernetes/manifests/
+
+  try=0
+  while :; do
+    oc get pods -o wide -n openshift-kube-apiserver | grep $1 | grep -v guard | grep Running
+    number_running_pods=$(oc get pods -o wide -n openshift-kube-apiserver | grep $1 | grep -v guard | grep Running | grep -c 5/5)
+    if [[ $number_running_pods -eq 1 ]]; then
+      echo "kube-apiserver on node $1 is up!"
+      break
+    fi
+    ((try=${try}+1))
+    if [[ $try -eq $number_of_retries ]]; then
+      echo "On node $1 should be 3 running kube-apiserver pods"
+      exit 1
+    fi
+    echo "Retrying in $wait_time seconds"
+    sleep $wait_time
+  done
+}
+
+function enable_kube_controller_manager_on_node {
+  echo "Enable kube-controller-manager no node $1"
+  oc debug node/$1 -- chroot /host mv /root/kube-controller-manager-pod.yaml /etc/kubernetes/manifests/
+
+  try=0
+  while :; do
+    oc get pods -o wide -n openshift-kube-controller-manager | grep $1 | grep -v guard | grep Running
+    number_running_pods=$(oc get pods -o wide -n openshift-kube-controller-manager | grep $1 | grep -v guard | grep Running | grep -c 4/4)
+    if [[ $number_running_pods -eq 1 ]]; then
+      echo "kube-controller-manager on node $1 is up!"
+      break
+    fi
+    ((try=${try}+1))
+    if [[ $try -eq $number_of_retries ]]; then
+      echo "On node $1 should be 3 running kube-controller-manager pods"
+      exit 1
+    fi
+    echo "Retrying in $wait_time seconds"
+    sleep $wait_time
+  done
+}
+
+function project_verification {
+  try=0
+  while :; do
+    oc get pods -n django | grep Running
+    v1=$(oc get pods -n django | grep Running | grep -v deploy | grep -v build | grep postgresql | grep -c 1/1)
+    v2=$(oc get pods -n django | grep Running | grep -v deploy | grep -v build | grep django-psql-example | grep -c 1/1)
+    if [[ $v1 -eq 1 ]] && [[ $v2 -eq 1 ]]; then
+      echo "django service is ready!"
+      break
+    fi
+    ((try=${try}+1))
+      if [[ $try -eq $number_of_retries ]]; then
+        echo "Project django is not ready!"
+        exit 1
+      fi
+      echo "Retrying in $wait_time seconds"
+      sleep $wait_time
+  done
+}
+
+function deployment_config_verification {
+  try=0
+  while :; do
+    oc get deploymentconfigs django-psql-example -n django
+    v1=$(oc get dc django-psql-example -o json | jq ".status.replicas")
+    if [[ $v1 -eq 2 ]]; then
+        echo "Deployment configs are ready!"
+        break
+    fi
+    ((try=${try}+1))
+    if [[ $try -eq $number_of_retries ]]; then
+      echo "deployment config is not ready!"
+      exit 1
+    fi
+    echo "Retrying in $wait_time seconds"
+    sleep $wait_time
+  done
+}
+
+# Test Run
+disable_kube_api_server_on_node ${nodes[0]}
+disable_kube_api_server_on_node ${nodes[1]}
+disable_kube_controller_manager_on_node ${nodes[0]}
+disable_kube_controller_manager_on_node ${nodes[1]}
+
+oc new-project django
+oc new-app --template=django-psql-example
+sleep 15
+project_verification
+oc scale --replicas=2 dc/django-psql-example
+sleep 10
+deployment_config_verification
+
+enable_kube_api_server_on_node ${nodes[0]}
+enable_kube_api_server_on_node ${nodes[1]}
+enable_kube_controller_manager_on_node ${nodes[0]}
+enable_kube_controller_manager_on_node ${nodes[1]}


### PR DESCRIPTION
1. I found some wrong code in https://github.com/paigerube14/svt/blob/44389c638b200dd6830d12e4ec191dac6fcd8230/perfscale_regression_ci/scripts/common.sh#L134
I dug the history, I did some wrong change in this commit
https://github.com/openshift/svt/commit/0c5a04996de7a011b1247ba15654fe5929fc5d01
And that code was copied to common.sh in this PR https://github.com/openshift/svt/pull/767#issuecomment-1708886751

2. Fixed a test case's description.
3. Added script for test case https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-22399 (https://issues.redhat.com/browse/OCPQE-19649)
Test Result(run from my mac): Passed
```
django service is ready!
Deployment configs are ready!
```
But I found run from Jenkins failed
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/regression-test/552
```
06-27 17:46:16.472  + tee /home/jenkins/ws/workspace/ibranch-pipeline_regression-test/output.out
06-27 17:46:18.581  Disable kube-apiserver on node ip-10-0-21-88.us-east-2.compute.internal
06-27 17:46:19.677  error: unable to get namespace namespaces "aos-qe-ci" not found
06-27 17:46:21.177  kube-apiserver-ip-10-0-21-88.us-east-2.compute.internal         5/5     Running     0          7m15s   10.0.21.88    ip-10-0-21-88.us-east-2.compute.internal   <none>           <none>
```