### PR TITLE
Scripts to support loading cluster for ETCD perf/scale tests.

### DIFF
--- a/openshift_scalability/scripts/etcd/test_too_many_big_secrets/load_cluster_with_secrets.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_big_secrets/load_cluster_with_secrets.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#################################################
+# Author: skordas@redhat.com
+# Related Test Case: OCP-69214
+#
+# Description:
+# Script to create large number of big secrets
+# ###############################################
+
+
+START=$(date)
+
+# Configure the name of the secret and namespace
+NAMESPACE="my-namespace"
+
+# SSH key
+ssh-keygen -t rsa -b 4096 -f sshkey -N ''
+SSH_PRIVATE_KEY=$(cat sshkey | base64 | tr -d '\n')
+SSH_PUBLIC_KEY=$(cat sshkey.pub | base64 | tr -d '\n')
+
+# Token (example token here, replace with your actual token generation method)
+TOKEN_VALUE=$(openssl rand -hex 32 | base64 | tr -d '\n')
+
+# Self-signed Certificate
+openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -days 365 -nodes -subj "/CN=mydomain.com"
+CERTIFICATE=$(cat tls.crt | base64 | tr -d '\n')
+PRIVATE_KEY=$(cat tls.key | base64 | tr -d '\n')
+
+# Creating sectret template for this test run.
+TEMPLATE=secret_template.yaml
+SECRET_TEMPLATE=secret_template_run.yaml
+
+cp $TEMPLATE $SECRET_TEMPLATE
+
+sed -i "s/NAMESPACE/$NAMESPACE/g" $SECRET_TEMPLATE
+sed -i "s/SSH_PRIVATE_KEY/$PRIVATE_KEY/g" $SECRET_TEMPLATE
+sed -i "s/SSH_PUBLIC_KEY/$SSH_PUBLIC_KEY/g" $SECRET_TEMPLATE
+sed -i "s/TOKEN_VALUE/$TOKEN_VALUE/g" $SECRET_TEMPLATE
+sed -i "s/CERTIFICATE/$CERTIFICATE/g" $SECRET_TEMPLATE
+sed -i "s/PRIVATE_KEY/$PRIVATE_KEY/g" $SECRET_TEMPLATE
+
+# Create project and load with secrets
+oc new-project $NAMESPACE
+oc label ns $NAMESPACE purpose=test
+
+for i in {1..50000};
+do
+  sh load_secret.sh $i &
+done
+
+END=$(date)
+sleep 5 # Some time to finish all secrets to be created.
+echo "Start: $START"
+echo "End  : $END"

--- a/openshift_scalability/scripts/etcd/test_too_many_big_secrets/load_secret.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_big_secrets/load_secret.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+i=$1
+SECRET_TEMPLATE=secret_template_run.yaml
+SECRET_NAME="my-large-secret-$i"
+TMP_FILE="/tmp/secret_$(date +%s)_$i.yaml"
+sed "s/SECRET_NAME/$SECRET_NAME/g" $SECRET_TEMPLATE > $TMP_FILE
+
+oc create -f $TMP_FILE

--- a/openshift_scalability/scripts/etcd/test_too_many_big_secrets/secret_template.yaml
+++ b/openshift_scalability/scripts/etcd/test_too_many_big_secrets/secret_template.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: SECRET_NAME
+  namespace: NAMESPACE
+type: Opaque
+data:
+  ssh-private-key: SSH_PRIVATE_KEY
+  ssh-public-key: SSH_PUBLIC_KEY
+  token: TOKEN_VALUE
+  tls.crt: CERTIFICATE
+  tls.key: PRIVATE_KEY

--- a/openshift_scalability/scripts/etcd/test_too_many_images/load_cluster_with_images.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_images/load_cluster_with_images.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#################################################
+# Author: skordas@redhat.com
+# Related Test Case: OCP-69210
+#
+# Description:
+# Script to support loading cluster with large
+# number of images.
+# ###############################################
+
+START=$(date)
+
+for i in {1..120000}
+  do sh load_image.sh $i &
+done
+
+END=$(date)
+sleep 5 # Some time to finish all images to be created.
+echo "Start: $START"
+echo "End  : $END" 

--- a/openshift_scalability/scripts/etcd/test_too_many_images/load_image.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_images/load_image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+i=$1
+echo "create testImage-$i"
+oc process -f template_image.yaml -p NAME=testImage-$i | oc create -f -

--- a/openshift_scalability/scripts/etcd/test_too_many_images/template_image.yaml
+++ b/openshift_scalability/scripts/etcd/test_too_many_images/template_image.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: img-template
+objects:
+  - kind: Image
+    apiVersion: image.openshift.io/v1
+    metadata:
+      name: "${NAME}"
+      creationTimestamp:
+    dockerImageReference: registry.redhat.io/ubi8/ruby-27:latest
+    dockerImageMetadata:
+      kind: DockerImage
+      apiVersion: '1.0'
+      Id: ''
+      ContainerConfig: {}
+      Config: {}
+    dockerImageLayers: []
+    dockerImageMetadataVersion: '1.0'
+parameters:
+  - name: NAME

--- a/openshift_scalability/scripts/etcd/test_too_many_secrets/load_cluster_with_secrets.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_secrets/load_cluster_with_secrets.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#################################################
+# Author: skordas@redhat.com
+# Related Test Case: OCP-69213
+#
+# Description:
+# Script to create large number of secrets
+# per project.
+#################################################
+
+START=$(date)
+
+for i in {1..300}
+  do oc new-project project-$i
+  oc label ns project-$i purpose=test
+  for j in {1..400}
+    do sh load_secret.sh $j &
+  done
+  while [ $(oc get secrets -n project-$i | grep -c my-secret) -lt 400 ]
+    do oc get secrets -n project-$i | grep -c my-secret
+    sleep 5
+  done
+done
+
+END=$(date)
+echo "Start: $START"
+echo "End  : $END" 

--- a/openshift_scalability/scripts/etcd/test_too_many_secrets/load_secret.sh
+++ b/openshift_scalability/scripts/etcd/test_too_many_secrets/load_secret.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+i=$1
+oc create secret generic my-secret-$i --from-literal=key1=supersecret --from-literal=key2=topsecret


### PR DESCRIPTION
To test these: 
[OCP-69210](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-69210) 
[OCP-69213](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-69213) 
[OCP-69214](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-69214) 
 we need to load cluster with big number of objects. Using suggested in test cases way it can take a very long time (up to 10 hours).
 Running this is sub-processes is shortening wait time for that.