### PR TITLE
network policy scalability refine

### DIFF
--- a/perfscale_regression_ci/scripts/network/network_policy_scalability.sh
+++ b/perfscale_regression_ci/scripts/network/network_policy_scalability.sh
@@ -1,22 +1,21 @@
 #/!/bin/bash -x
 ################################################
 ## Auth=mifiedle@redhat.com qili@redhat.com lhorsley@redhat.com
-## Desription: Time how long it takes to scale up to 2000 pods with and without the networkpolicy 
+## Desription: Time how long it takes to scale up to from 500 to 2000 pods with and without the networkpolicy 
 ## Note: The scale up time with the networkpolicy in place will be more than without, but it should not be an order of magnitude difference.	
 ## Polarion test case: OCP-41535 - NetworkPolicy scalability - 2000 pods per namespace using customer network policy	
 ## https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-41535
-## Cluster config: Cluster needed in AWS EC2 (m5.2xlarge or equivalent) with 40 worker nodes
+## Cluster config: Cluster needed in AWS EC2 (m5.2xlarge or equivalent) with 12 worker nodes
 ## Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1950283
 ## kube-burner config: perfscale_regerssion_ci/kubeburner-object-templates/scaling-network-policy-deployment.yml
 ## 					   perfscale_regerssion_ci/kubeburner-object-templates/scaling-no-network-policy-deployment.yml
 ################################################ 
-
 source ../../utils/run_workload.sh
 source ../custom_workload_env.sh
 source ../common.sh
 source network_policy_scalability_env.sh
 
-pass_fail=0
+pass_case=0
 workload_template_list=("${DIR}/../../kubeburner-object-templates/scaling-network-policy-config.yaml" "${DIR}/../../kubeburner-object-templates/scaling-no-network-policy-config.yaml")
 pod_scale_max=2000
 kube_burner_job_list=("np-issue-test" "no-np-issue-test")
@@ -27,8 +26,8 @@ return_traffic_code=200
 
 
 echo "======Use kube-burner to load the cluster with test objects======"
-
-for ((i = 0; i < 2; i++));
+length=${#kube_burner_job_list[@]}
+for ((i = 0; i < $length; i++));
 do
     export WORKLOAD_TEMPLATE=${workload_template_list[$i]}
     export NAME=${kube_burner_job_list[$i]}
@@ -36,8 +35,9 @@ do
     deployment_name=${kube_burner_job_list[$i]}
     scale_up=0
 
-    echo "Starting scale-up test for ${kube_burner_job_list[$i]}..."
+    echo "Load objects for ${kube_burner_job_list[$i]}..."
     run_workload
+    echo "Starting scale-up test for ${kube_burner_job_list[$i]}..."
     oc scale --replicas $pod_scale_max deployment $deployment_name -n ${NAMESPACE}; start_time=`date +%s`
     echo "start time: $start_time"
     scale_up=$(oc get deployment $deployment_name --no-headers -n ${NAMESPACE} | awk -F ' {1,}' '{print $4}')
@@ -47,7 +47,11 @@ do
     final_time=$((end_time - start_time))
     echo "execution time for test ${kube_burner_job_list[$i]}: $final_time s."
     final_time_list+=($final_time)
-	sleep 1
+    # delete the test objects to release more resource for the next test
+    if (($(($i+1)) != $length)); then
+        delete_project_by_label kube-burner-job
+    fi
+    sleep 1
     echo "=========================================================================="
 done
 
@@ -63,7 +67,7 @@ deny_time_start=`date +%s`
 check_http_code $deny_traffic_code $pod_ip $apiserver_pod
 deny_time_end=`date +%s`
 deny_final_time=$((deny_time_end - deny_time_start))
-echo "Time taken for network policy to become inactive: $deny_final_time s"
+echo "Time taken for deny network policy to become active: $deny_final_time s"
 
 sleep 1
 
@@ -73,60 +77,46 @@ return_traffic_start=`date +%s`
 check_http_code $return_traffic_code $pod_ip $apiserver_pod
 return_traffic_end=`date +%s`
 return_traffic_final_time=$((return_traffic_end - return_traffic_start))
-echo "Time taken for network policy to become active: $return_traffic_final_time s"
+echo "Time taken for deny network policy to become inactive: $return_traffic_final_time s"
 
 echo "=========================================================================="
 
 
 final_time_np=${final_time_list[0]}
 final_time_no_np=${final_time_list[1]}
+policy_no_policy_difference=$(calculate_difference ${final_time_np} ${final_time_no_np})
 
-if [[ ( $final_time_np -le 120 ) &&  ( $final_time_no_np -le 120 )]]; then
-	echo "Expected: test time with network policy $final_time_np s <= 120 s (2 minutes)."
-	echo "Expected: test time without network policy $final_time_no_np s <= 120 s (2 minutes)."
-	((++pass_fail))
+if [[ ( $final_time_np -le 120 ) &&  ( $final_time_no_np -le 120 ) && ( $policy_no_policy_difference -le 10 ) ]]; then
+    echo "PASS: test time to scale from 500 to 2000 pods with network policy ${final_time_np}s <= 120 s (2 minutes)."
+    echo "PASS: test time to scale from 500 to 2000 pods without network policy ${final_time_no_np}s <= 120 s (2 minutes)."
+    echo "PASS: Difference in test times to scale from 500 to 2000 pods (between with and without network policy) ${policy_no_policy_difference}s <= 10 s."
+    ((++pass_case))
 else
-	echo "Test time with network policy: $final_time_np s"
-	echo "Test time without network policy $final_time_no_np s"
+    echo "FAIL: Test time to scale from 500 to 2000 pods with network policy: ${final_time_np}s should be <= 120 s (2 minutes)."
+    echo "FAIL: Test time to scale from 500 to 2000 pods without network policy ${final_time_no_np}s should be <= 120 s (2 minutes)."
+    echo "FAIL: Difference in test times to scale from 500 to 2000 pods (between with and without network policy): ${policy_no_policy_difference}s should be <= 10 s."
 fi
-
 
 if [[ ( $deny_final_time -le 10 ) && ( $return_traffic_final_time -le 10 ) ]]; then
-	echo "Expected: Time when network traffic blocked $deny_final_time s <= 10 s."
-	echo "Expected: Time when network traffic returns $return_traffic_final_time s <= 10 s."
-	((++pass_fail))
+    echo "PASS: Time taken for deny network policy to become active: ${deny_final_time}s <= 10 s."
+    echo "PASS: Time taken for deny network policy to become inactive: ${return_traffic_final_time}s <= 10 s."
+    ((++pass_case))
 else
-	echo "Time when traffic blocked: $deny_final_time s"
-	echo "Time when network traffic returns: $return_traffic_final_time s"
+    echo "FAIL: Time taken for deny network policy to become active: ${deny_final_time}s should be <= 10 s."
+    echo "FAIL: Time taken for deny network policy to become inactive: ${return_traffic_final_time} s should be <= 10 s."
 fi
-
-
-policy_no_policy_difference=$(calculate_difference ${final_time_np} ${final_time_no_np})
-deny_return_traffic_difference=$(calculate_difference ${deny_final_time} ${return_traffic_final_time})
-
-if [[ ( $policy_no_policy_difference -le 10 ) && ( $deny_return_traffic_difference -le 10 ) ]]; then
-	echo "Expected: Difference in test times (with and without network policy) $policy_no_policy_difference s <= 10 s."
-	echo "Expected: Difference in test times (traffic denied and traffic returned) $deny_return_traffic_difference s <= 10 s."
-	((++pass_fail))
-else
-	echo "Difference in test times (with and without network policy): $policy_no_policy_difference"
-	echo "Difference in test times (traffic denied and traffic returned): $deny_return_traffic_difference"
-fi
-
 
 echo ""
 echo "======Final test result======"
 
-if [[ $pass_fail -eq 3 ]]; then
-	echo -e "\nOverall NetworkPolicy scalability - using customer network policy Testcase result:  PASS"
-  	echo "======Clean up test environment======"
-	# # delete projects:
-  	# ######### Clean up: delete projects and wait until all projects and pods are gone
-  	echo "Deleting test objects"
-	delete_project_by_label kube-burner-job
-	exit 0
+if [[ $pass_case -eq 2 ]]; then
+    echo -e "\nOverall NetworkPolicy scalability - using customer network policy Testcase result: PASS"
+    echo "======Clean up test environment======"
+    echo "Deleting test objects"
+    delete_project_by_label kube-burner-job
+    exit 0
 else
-	echo -e "\nOverall NetworkPolicy scalability - using customer network policy Testcase result:  FAIL"
- 	 echo "Please debug. When debugging is complete, delete all projects using 'oc delete project -l kube-burner-job=${kube_burner_job_list[0]}' and 'oc delete project -l kube-burner-job=${kube_burner_job_list[1]}'"
-	exit 1
+    echo -e "\nOverall NetworkPolicy scalability - using customer network policy Testcase result: FAIL"
+    echo "Please debug. When debugging is complete, delete all projects using 'oc delete projects -l kube-burner-job'"
+    exit 1
 fi


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-25903
Test Job
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/regression-test/585/console
Result
```
09-23 15:37:23.175  PASS: test time to scale from 500 to 2000 pods with network policy 31s <= 120 s (2 minutes).
09-23 15:37:23.175  PASS: test time to scale from 500 to 2000 pods without network policy 31s <= 120 s (2 minutes).
09-23 15:37:23.175  PASS: Difference in test times to scale from 500 to 2000 pods (between with and without network policy) 0s <= 10 s.
09-23 15:37:23.175  PASS: Time taken for deny network policy to become active: 2s <= 10 s.
09-23 15:37:23.175  PASS: Time taken for deny network policy to become inactive: 1s <= 10 s.
09-23 15:37:23.175  
09-23 15:37:23.175  ======Final test result======
09-23 15:37:23.175  
09-23 15:37:23.175  Overall NetworkPolicy scalability - using customer network policy Testcase result: PASS
```