### PR TITLE
route external cert: add reencrypt and cacert

### DIFF
--- a/reliability-v2/config/reliability-route-external-certification.yaml
+++ b/reliability-v2/config/reliability-route-external-certification.yaml
@@ -95,9 +95,34 @@ reliability:
         - func delete_project -n 2 # delete project in 2 namespaces
         - func verify_project_deletion -n 2 # verfy project deletion in 2 namespaces
 
-    - name: dev-prod
+    - name: dev-prod-edge
       user_name: testuser-
       user_start: 31
+      user_end: 34
+      loops: forever
+      trigger: 600
+      jitter: 3600
+      interval: 600
+      pre_tasks:
+        - func delete_all_projects
+        - func verify_project_deletion -n 8
+        - func new_project -n 8
+        # If network policy is planed in the test, uncomment the following line
+        #- func apply -n 2 -p "<path_to_content>/network-policy/allow-same-namespace.yaml" # Apply network policy to 2 projects
+        - func apply -n 8 -p "<path_to_content>/nginx-deploy.yaml"
+        - func apply -n 8 -p "<path_to_content>/nginx-service.yaml"
+        - func enable_route_external_cert -n 8
+        - func apply -n 8 -p "<path_to_content>/route-edge.yaml"
+      tasks:
+        - func load_app -n 8 -p 50
+        - func scale_deployment -n 8 -p 2 # scale deployment in 2 namespaces to 2 replicas
+        - func scale_deployment -n 8 -p 1 # scale deployment in 2 namespaces to 1 replicas
+      post_tasks:
+        - func delete_project -n 8
+
+    - name: dev-prod-reencrypt
+      user_name: testuser-
+      user_start: 34
       user_end: 36
       loops: forever
       trigger: 600
@@ -111,10 +136,10 @@ reliability:
         #- func apply -n 2 -p "<path_to_content>/network-policy/allow-same-namespace.yaml" # Apply network policy to 2 projects
         - func apply -n 8 -p "<path_to_content>/nginx-deploy.yaml"
         - func apply -n 8 -p "<path_to_content>/nginx-service.yaml"
-        - func enable_route_external_cert -n 8 -p <path_to_content>
-        - func apply -n 8 -p "<path_to_content>/route-edge.yaml"
+        - func enable_route_external_cert -n 8
+        - func apply -n 8 -p "<path_to_content>/route-reencrypt.yaml"
       tasks:
-        - func load_app -n 8 -p 50
+        - func load_app -n 8 -p 50 
         - func scale_deployment -n 8 -p 2 # scale deployment in 2 namespaces to 2 replicas
         - func scale_deployment -n 8 -p 1 # scale deployment in 2 namespaces to 1 replicas
       post_tasks:

--- a/reliability-v2/content/route-edge.yaml
+++ b/reliability-v2/content/route-edge.yaml
@@ -7,7 +7,7 @@ spec:
     targetPort: http
   tls:
     externalCertificate:
-      name: edge-external-cert
+      name: external-cert
     termination: edge
   to:
     kind: Service

--- a/reliability-v2/content/route-reencrypt.yaml
+++ b/reliability-v2/content/route-reencrypt.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: nginx-reencrypt
+spec:
+  port:
+    targetPort: https
+  tls:
+    externalCertificate:
+      name: external-cert
+    termination: reencrypt
+    destinationCACertificate: "-----BEGIN CERTIFICATE-----\nMIIDbTCCAlWgAwIBAgIJAJR/jN0Oa+/rMA0GCSqGSIb3DQEBCwUAME0xCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMQswCQYDVQQHDAJOWTEcMBoGA1UE\nCgwTRGVmYXVsdCBDb21wYW55IEx0ZDAeFw0xNzAxMjQwODExMDJaFw0yNzAxMjIw\nODExMDJaME0xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMQswCQYD\nVQQHDAJOWTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBAMItGS9sSafyqBuOcQcQ5j7OQ0EwF9qOckhl\nfT8VzUbcOy8/L/w654MpLEa4O4Fiek3keE7SDWGVtGZWDvT9y1QUxPhkDWq1Y3rr\nyMelv1xRIyPVD7EEicga50flKe8CKd1U3D6iDQzq0uxZZ6I/VArXW/BZ4LfPauzN\n9EpCYyKq0fY7WRFIGouO9Wu800nxcHptzhLAgSpO97aaZ+V+jeM7n7fchRSNrpIR\nzPBl/lIBgCPJgkax0tcm4EIKIwlG+jXWc5mvV8sbT8rAv32HVuaP6NafyWXXP3H1\noBf2CQCcwuM0sM9ZeZ5JEDF/7x3eNtqSt1X9HjzVpQjiVBXY+E0CAwEAAaNQME4w\nHQYDVR0OBBYEFOXxMHAA1qaKWlP+gx8tKO2rQ81WMB8GA1UdIwQYMBaAFOXxMHAA\n1qaKWlP+gx8tKO2rQ81WMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB\nAJAri7Pd0eSY/rvIIvAvjhDPvKt6gI5hJEUp+M3nWTWA/IhQFYutb9kkZGhbBeLj\nqneJa6XYKaCcUx6/N6Vvr3AFqVsbbubbejRpdpXldJC33QkwaWtTumudejxSon24\nW/ANN/3ILNJVMouspLRGkFfOYp3lq0oKAlNZ5G3YKsG0znAfqhAVtqCTG9RU24Or\nxzkEaCw8IY5N4wbjCS9FPLm7zpzdg/M3A/f/vrIoGdns62hzjzcp0QVTiWku74M8\nv7/XlUYYvXOvPQCCHgVjnAZlnjcxMTBbwtdwfxjAmdNTmFFpASnf0s3b287zQwVd\nIeSydalVtLm7rBRZ59/2DYo=\n-----END CERTIFICATE-----"
+  to:
+    kind: Service
+    name: nginx
+    

--- a/reliability-v2/start.sh
+++ b/reliability-v2/start.sh
@@ -280,10 +280,7 @@ fi
 script_folder=$RELIABILITY_DIR/tasks/script
 content_folder=$RELIABILITY_DIR/content
 
-# Create key and cert for route external certification
-log "info" "====Create key and cert for route external certification and move to ${content_folder}===="
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=edge-ingress-perf.apps.mohit.perfscale.devcluster.openshift.com/O=MyOrganization" > /dev/null 2>&1
-mv tls.key tls.crt ${content_folder}
+cd $RELIABILITY_DIR
 
 # generate reliability config file
 if [[ ! -z $path_to_auth_files ]]; then
@@ -297,6 +294,14 @@ fi
 
 echo "export KUBECONFIG=$KUBECONFIG"
 export KUBECONFIG
+
+# Create key and cert for route external certification
+log "info" "====Create key and cert for route external certification===="
+base_domain=$(oc get dns cluster -o json | jq '.spec.baseDomain')
+base_domain=$(echo "$base_domain" | tr -d '"')
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=*.apps.${base_domain}" > /dev/null 2>&1
+#openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls1.key -out tls1.crt -subj "/CN=*.apps.${base_domain}" > /dev/null 2>&1
+ls *.key *.crt
 
 # Deploy NFS storage class for cluster without storageclass
 cd $RELIABILITY_DIR


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPQE-29059
One hour test with reencrypt and cacert passed https://redhat-internal.slack.com/archives/C0266JJ4XM5/p1744951753827959
```
[2025-04-18 06:30:26 UTC] [93c52c87-554e-482e-9708-ec7cd3d4bca8] 
[@Qiujie Li - qili](https://redhat-internal.slack.com/team/U01SBLKMZFZ)
,  Reliability test results:
[Function]               |     Total|    Passed|    Failed|Failure Rate|
-----------------------------------------------------------------------
[apply_nonamespace]      |         5|         5|         0|      0.0%|
[delete_all_projects]    |        82|        82|         0|      0.0%|
[verify_project_deletion]|       346|       346|         0|      0.0%|
[new_project]            |       193|       193|         0|      0.0%|
[check_all_projects]     |        76|        76|         0|      0.0%|
[check_operators]        |         6|         6|         0|      0.0%|
[oc_task]                |         6|         6|         0|      0.0%|
[apply]                  |       420|       420|         0|      0.0%|
[kubectl_task]           |         6|         6|         0|      0.0%|
[load_app]               |      2720|      2720|         0|      0.0%|
[check_pods]             |       152|       152|         0|      0.0%|
[new_app]                |        52|        52|         0|      0.0%|
[delete_project]         |       193|       193|         0|      0.0%|
[build]                  |        26|        26|         0|      0.0%|
[cronjob.sh -n 10]       |         1|         1|         0|      0.0%|
[cronjob.sh -c]          |         5|         5|         0|      0.0%|
[__create_secret]        |        40|        40|         0|      0.0%|
[__create_role]          |        40|        40|         0|      0.0%|
[__create_rolebinding]   |        40|        40|         0|      0.0%|
[enable_route_external_cert]|        40|        40|         0|      0.0%|
[scale_deployment]       |        48|        48|         0|      0.0%|
[cronjob.sh -d]          |         1|         1|         0|      0.0%|
-----------------------------------------------------------------------
```

7 days long run is ok too
https://redhat-internal.slack.com/archives/C0266JJ4XM5/p1744964261162469
```
[2025-04-25 09:06:51 UTC] [3cc9b30e-2bd6-4a22-aeb2-0798ee10642f] 
[@Qiujie Li - qili](https://redhat-internal.slack.com/team/U01SBLKMZFZ)
,  Reliability test results:
[Function]               |     Total|    Passed|    Failed|Failure Rate|
-----------------------------------------------------------------------
[apply_nonamespace]      |         5|         5|         0|      0.0%|
[delete_all_projects]    |     12715|     12715|         0|      0.0%|
[verify_project_deletion]|     50876|     50876|         0|      0.0%|
[check_operators]        |       923|       923|         0|      0.0%|
[oc_task]                |       923|       923|         0|      0.0%|
[new_project]            |     25459|     25459|         0|      0.0%|
[kubectl_task]           |       923|       923|         0|      0.0%|
[check_all_projects]     |     12709|     12709|         0|      0.0%|
[apply]                  |     50694|     50694|         0|      0.0%|
[load_app]               |    643360|    643360|         0|      0.0%|
[cronjob.sh -n 10]       |         1|         1|         0|      0.0%|
[check_pods]             |     25416|     25416|         0|      0.0%|
[cronjob.sh -c]          |       911|       911|         0|      0.0%|
[delete_project]         |     25457|     25457|         0|      0.0%|
[new_app]                |      8560|      8559|         1|      0.0%|
[build]                  |      4279|      4279|         0|      0.0%|
[__create_secret]        |        40|        40|         0|      0.0%|
[__create_role]          |        40|        40|         0|      0.0%|
[__create_rolebinding]   |        40|        40|         0|      0.0%|
[enable_route_external_cert]|        40|        40|         0|      0.0%|
[scale_deployment]       |     15568|     15568|         0|      0.0%|
[cronjob.sh -d]          |         1|         1|         0|      0.0%|
-----------------------------------------------------------------------
```