### PR TITLE
fix the dittybopper install issue

### DIFF
--- a/reliability-v2/start.sh
+++ b/reliability-v2/start.sh
@@ -405,10 +405,12 @@ if [[ $operators ]]; then
 fi
 
 # Install dittybopper if not exist
+set +e
 oc get ns dittybopper
 if [[ $? -ne 0 ]]; then
     install_dittybopper
 fi
+set -e
 
 # Cleanup test projects
 cd $RELIABILITY_DIR


### PR DESCRIPTION
The script exits when dittybopper ns is not found because of set -e