### PR TITLE
update pyyaml version

### DIFF
--- a/reliability-v2/README.md
+++ b/reliability-v2/README.md
@@ -32,7 +32,7 @@ For classic rosa and rosa hypershift cluster, additional pre-requisite:
  - [aws configuration](https://docs.google.com/document/d/1j7bhLXT_cIAjpMh_x2jeegtpE7495Mj5A-EcQsgZEDo)
 
 ## A quick start script: start.sh
-[start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh) is a quick start script that helps you to do nessessary preparations and generate a default configurations based on [example_reliability.yaml](https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml) and start a reliability test to run for a certain time. It can upgrade the cluster every 24 hours if there is new nightly build.
+[start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh) is a quick start script that helps you to do nessessary preparations and generate a default configurations based on [reliability.yaml](https://github.com/openshift/svt/blob/master/reliability-v2/config/reliability.yaml) and start a reliability test to run for a certain time. It can upgrade the cluster every 24 hours if there is new nightly build.
 
 e.g. Run reliability test for 7 days with the default configuration and upgrade the cluster every 24 hours if there is new nightly build
 ```
@@ -45,7 +45,7 @@ export SLACK_API_TOKEN, find it in https://vault.bitwarden.com 'Red Hat, Inc. va
 To make you tagged in the slack notification, export the following env variable.
 export SLACK_MEMBER=<get it by clicking 'Copy member ID' in your slack Profile>
 
-If you don't want to use the default configuration, you can update (https://github.com/openshift/svt/blob/master/reliability-v2/config/example_reliability.yaml) before you trigger [start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh)
+If you don't want to use the default configuration, you can update (https://github.com/openshift/svt/blob/master/reliability-v2/config/reliability.yaml) before you trigger [start.sh](https://github.com/openshift/svt/tree/master/reliability-v2/start.sh)
 
 For configuration details, check [Configuration](#Configuration)
 

--- a/reliability-v2/requirements.txt
+++ b/reliability-v2/requirements.txt
@@ -1,5 +1,5 @@
-pyyaml==5.4.1
-requests==2.25.1
-aiohttp>=3.7.4
-apscheduler==3.8.0
+pyyaml>=6.0.2
+requests>=2.31.0
+aiohttp>=3.8.1
+apscheduler>=3.8.0
 slack_sdk==3.21.3


### PR DESCRIPTION
This PR will address the following error:
```console
jiazha-mac:reliability-v2 jiazha$ ./start.sh -p kubeconfig/
start.sh logs will be saved to start_20250905_150353.log.
[20250905 15:03:53][INFO] Test folder test20250905150353 is created.
[20250905 15:03:53][INFO] ====Preparing venv====
Python 3.11.9
/Users/jiazha/goproject/svt/reliability-v2
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [67 lines of output]
      /private/var/folders/5n/w9ysf4w93jnfy7k19xxct31c0000gn/T/pip-build-env-x_lo8b7_/overlay/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      ...
````
It works after this PR.
```console
jiazha-mac:reliability-v2 jiazha$ ./start.sh -p /Users/jiazha/goproject/svt/reliability-v2/path_to_auth_files
start.sh logs will be saved to start_20250905_154720.log.
[20250905 15:47:20][INFO] Test folder test20250905154720 is created.
[20250905 15:47:20][INFO] ====Preparing venv====
Python 3.11.9
/Users/jiazha/goproject/svt/reliability-v2
[20250905 15:47:55][INFO] ====Generating reliability config file====
Generating reliabilty configuration file.
Reliability config file is generated to /Users/jiazha/goproject/svt/reliability-v2/test20250905154720/reliability.yaml.
export KUBECONFIG=/Users/jiazha/goproject/svt/reliability-v2/path_to_auth_files/kubeconfig
[20250905 15:47:55][INFO] ====Create key and cert for route external certification====
tls.crt tls.key
Total time to run is: 10m
Total seconds to run is: 600
Error from server (NotFound): configmaps "cluster-monitoring-config" not found
[20250905 15:47:59][INFO] ====Configure storage for monitoring====
configmap/cluster-monitoring-config created
Sleep 60s to wait for monitoring to take the new config map.
deployment "cluster-monitoring-operator" successfully rolled out
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 2 pods at revision prometheus-k8s-569d87cf77...
Sleep 30s to wait for prometheus status to become success.
Prometheus status is not success yet, retrying in 10s, retries left: 19.
[20250905 15:50:09][INFO] Prometheus is success now.
Error from server (NotFound): namespaces "dittybopper" not found
[20250905 15:50:10][INFO] ====Install dittybopper====
Cloning into 'performance-dashboards'...
remote: Enumerating objects: 105, done.
remote: Counting objects: 100% (105/105), done.
remote: Compressing objects: 100% (80/80), done.
remote: Total 105 (delta 48), reused 53 (delta 22), pack-reused 0 (from 0)
Receiving objects: 100% (105/105), 214.55 KiB | 232.00 KiB/s, done.
Resolving deltas: 100% (48/48), done.


    ____  _ __  __        __
   / __ \(_) /_/ /___  __/ /_  ____  ____  ____  ___  _____
  / / / / / __/ __/ / / / __ \/ __ \/ __ \/ __ \/ _ \/ ___/
 / /_/ / / /_/ /_/ /_/ / /_/ / /_/ / /_/ / /_/ /  __/ /
/_____/_/\__/\__/\__, /_.___/\____/ .___/ .___/\___/_/
                /____/           /_/   /_/


Using k8s command: oc
Using namespace: dittybopper
Using default grafana password: admin

Getting environment vars...
Prometheus URL is: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
Prometheus bearer token collected.

Creating namespace...
namespace/dittybopper created

Deploying Grafana...
service/dittybopper created
service/renderer created
deployment.apps/grafana-renderer created
route.route.openshift.io/dittybopper created
deployment.apps/dittybopper created
configmap/sc-ocp-prom created
configmap/sc-grafana-config created

Waiting for dittybopper deployment to be available...
deployment.apps/dittybopper condition met

You can access the Grafana instance at http://dittybopper-dittybopper.apps.jiwei-0905b.qe.gcp.devcluster.openshift.com
[20250905 15:50:57][INFO] dittybopper installed successfully.
[20250905 15:50:57][INFO] ====Clearing test ns with label purpose=reliability.====
No resources found
[20250905 15:50:58][INFO] ====Start Reliability test. Log is writting to test20250905154720/reliability.log.====
[20250905 15:50:59][INFO] Cluster information: Client Version: 4.18.0-0.nightly-2025-01-07-210831
Kustomize Version: v5.4.2
Server Version: 4.20.0-0.nightly-2025-09-01-101753
Kubernetes Version: v1.33.3
[20250905 15:50:59][INFO] default storage class: standard-csi
[20250905 15:51:03][INFO] haproxy: HAProxy version 2.8.10-f28885f 2024/06/14 - https://haproxy.org/
Status: long-term supported branch - will stop receiving fixes around Q2 2028.
Known bugs: http://www.haproxy.org/bugs/bugs-2.8.10.html
Running on: Linux 5.14.0-570.39.1.el9_6.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Aug 23 04:30:05 EDT 2025 x86_64
[20250905 15:51:05][INFO] node os image: Red Hat Enterprise Linux CoreOS 9.6.20250826-1 (Plow)
[20250905 15:51:06][INFO] node containerRuntimeVersion: cri-o://1.33.3-7.rhaos4.20.gitbb04ce8.el9
[20250905 15:51:06][INFO] Reliability config: reliability.yaml
[20250905 15:51:06][INFO] Reliability test will run 10m. Test will end on 2025-09-05 16:01:06. If you want to halt the test before that, open another terminal and 'touch halt' under reliability-v2 folder.
[20250905 15:51:06][WARNING] DO NOT CTRL+c or terminate this session.
[20250905 16:01:06][INFO] Reliability will run 10m , and end on 2025-09-05 16:01:06. Log is writting to test20250905154720/reliability.log.
[20250905 16:01:06][INFO] Reliability test is stopped after running 10m. Please check logs in test20250905154720/reliability.log.

The process reliability.py has been terminated.
Reliability test results missing, please check reliability.log
./start.sh: line 14: kill: (46742) - No such process
```