### PR TITLE
Add analyze option

### DIFF
--- a/openshift_performance/ose3_perf/scripts/build_test.py
+++ b/openshift_performance/ose3_perf/scripts/build_test.py
@@ -36,7 +36,8 @@ def analyze_builds(all_builds):
     for build in all_builds:
         namespace = build["namespace"]
         name = build["name"]
-        global_build_status[namespace + ":" + name] = STATUS_STARTED
+        # Using -1 to use stardad naming convention for Builds
+        global_build_status[namespace + ":" + name + "-1"] = STATUS_STARTED
 
     
     with ThreadPoolExecutor(max_workers=global_config["worker"]) \


### PR DESCRIPTION
This analyze option will allow a kube-burner run, to only gather the results from Builds that have already ran.

Adding a new option -y that will skip running the jobs and just analyze them.
Original functionality stays the same.