### PR TITLE
fix reporting by using correct var in log_result

### DIFF
--- a/reliability-v2/tasks/Tasks.py
+++ b/reliability-v2/tasks/Tasks.py
@@ -502,7 +502,7 @@ class Tasks:
         else:
             self.logger.error(f"Flowcollector status fetch error: result {result}, rc - {rc}")
             rc_return = 1
-        self.__log_result(rc)
+        self.__log_result(rc_return)
         return (result, rc_return)
 
     # check netobserv pods health
@@ -526,7 +526,7 @@ class Tasks:
             else:
                 self.logger.error(f"Pods status fetch error: result {result}, rc - {rc}")
                 rc_return = 1
-        self.__log_result(rc)
+        self.__log_result(rc_return)
         return (result, rc_return)
     
     # check netobserv pod restarts


### PR DESCRIPTION
This is a fix for the missreporting of the `check_netobserv_pods` and `check_flowcollector` functions.

This was the result before in the final report:
```
[Function]               |     Total|    Passed|    Failed|Failure Rate|
-----------------------------------------------------------------------
[check_netobserv_pods]   |      1500|         0|      1500|    100.0%|
[check_flowcollector]    |      1500|         0|      1500|    100.0%|
```
even though it was clear all of the runs were successful, after a short 10m runs I have verified that the fix works and reporting is now correct:

```
[Function]               |     Total|    Passed|    Failed|Failure Rate|
-----------------------------------------------------------------------
[apply_nonamespace]      |         5|         5|         0|      0.0%|
[check_netobserv_pods]   |         2|         2|         0|      0.0%|
[check_flowcollector]    |         2|         2|         0|      0.0%|
-----------------------------------------------------------------------
```